### PR TITLE
fix: 編譯時的引入外部字體方式提示

### DIFF
--- a/components/CommonHead.js
+++ b/components/CommonHead.js
@@ -41,8 +41,6 @@ const CommonHead = ({ meta, children }) => {
         <meta property='article:author' content={BLOG.AUTHOR} />
       </>
     )}
-    {/* 谷歌字体镜像 */}
-    <link href="https://fonts.loli.net/css2?family=Noto+Serif+SC&display=swap" rel="stylesheet"/>
     {children}
   </Head>
 }

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -15,6 +15,8 @@ class MyDocument extends Document {
         <Head>
           <link rel='icon' href='/favicon.ico' />
           <link rel='icon' href='/favicon.svg' type='image/svg+xml' />
+          {/* 谷歌字体镜像 */}
+          <link href="https://fonts.loli.net/css2?family=Noto+Serif+SC&display=swap" rel="stylesheet"/>
           <CommonScript />
         </Head>
 


### PR DESCRIPTION
依據編譯時提示修正 [Next Hint](https://nextjs.org/docs/messages/no-stylesheets-in-head-component)