### PR TITLE
fix: fix build error for no title or description

### DIFF
--- a/lib/notion/getNotionData.js
+++ b/lib/notion/getNotionData.js
@@ -157,8 +157,8 @@ async function getBlogInfo ({ notionPageData, from }) {
     return null
   }
   const collection = notionPageData?.collection
-  const title = collection?.name[0][0] || BLOG.TITLE
-  const description = collection?.description[0][0] || BLOG.DESCRIPTION
+  const title = collection?.name?.[0][0] || BLOG.TITLE
+  const description = collection?.description?.[0][0] || BLOG.DESCRIPTION
   const pageCover = mapCoverUrl(collection?.cover, notionPageData.block)
   return { title, description, pageCover }
 }


### PR DESCRIPTION
对于未设置标题或者描述的 notion 文档会出现报错，本 pr 修复了此问题。
复现：
<img width="1023" alt="image" src="https://user-images.githubusercontent.com/56540811/161285782-174e26fd-c1b0-445f-95c3-1c90b4d37f27.png">
