### PR TITLE
fix: 修复当页面前缀为空时路由错误

### DIFF
--- a/lib/notion/getPageProperties.js
+++ b/lib/notion/getPageProperties.js
@@ -71,7 +71,7 @@ async function getPageProperties(id, block, schema, authToken, tagOptions, siteI
   properties.status = properties.status[0]
 
   if (properties.type === 'Post') {
-    properties.slug = BLOG.POST_URL_PREFIX + '/' + (properties.slug ?? properties.id)
+    properties.slug = `${BLOG.POST_URL_PREFIX ? BLOG.POST_URL_PREFIX + '/' : ''}` + (properties.slug ?? properties.id)
   } else {
     properties.slug = (properties.slug ?? properties.id)
   }


### PR DESCRIPTION
#412 当前如果填了空值会导致路由变成`//{slug}`，但双斜杠在Next.js中并不是可用路由