### PR TITLE
Bug/post base path

### DIFF
--- a/blog.config.js
+++ b/blog.config.js
@@ -31,8 +31,8 @@ const BLOG = {
   CUSTOM_FONT_SANS: ['LXGW WenKai Screen'], // 自定义无衬线字体
   CUSTOM_FONT_SERIF: ['LXGW WenKai Screen'], // 自定义衬线字体
 
-  // 图标字体
-  FONT_AWESOME_PATH: 'https://cdn.bootcdn.net/ajax/libs/font-awesome/5.15.4/css/all.min.css', // 图标库CDN ，国内推荐BootCDN，国外推荐 CloudFlare https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css
+  // 图标库CDN(可以直接改版本号）
+  FONT_AWESOME_PATH: 'https://cdn.bootcdn.net/ajax/libs/font-awesome/6.2.0/css/all.min.css',
 
   BACKGROUND_LIGHT: '#eeeeee', // use hex value, don't forget '#' e.g #fffefc
   BACKGROUND_DARK: '#000000', // use hex value, don't forget '#'

--- a/lib/notion/getPageProperties.js
+++ b/lib/notion/getPageProperties.js
@@ -71,7 +71,7 @@ async function getPageProperties(id, block, schema, authToken, tagOptions, siteI
   properties.status = properties.status?.[0]
 
   if (properties.type === 'Post') {
-    properties.slug = BLOG.POST_URL_PREFIX + '/' + (properties.slug ?? properties.id)
+    properties.slug = BLOG.POST_URL_PREFIX ? (BLOG.POST_URL_PREFIX + '/' + (properties.slug ?? properties.id)) : (properties.slug ?? properties.id)
   } else {
     properties.slug = (properties.slug ?? properties.id)
   }


### PR DESCRIPTION
bug1.修改[blog.config.js](https://github.com/lifeafter619/NotionNext/blob/393b53654c4d3e27edc3ff4f1f23837fedf5ea48/blog.config.js)中第41行的配置，设置为空，重新部署后文章打不开，显示404后返回主页面（不知道是不是我理解错了，前后试了好几遍都不行。

bug2.notion中page icon较新图标加载不出来，更新[blog.config.js](https://github.com/lifeafter619/NotionNext/blob/393b53654c4d3e27edc3ff4f1f23837fedf5ea48/blog.config.js)中图标库后解决（图标库链接改为6.2.0）