### PR TITLE
fix: solve linked img crash

### DIFF
--- a/lib/notion/getPageProperties.js
+++ b/lib/notion/getPageProperties.js
@@ -79,8 +79,8 @@ export default async function getPageProperties(id, block, schema, authToken, ta
   properties.createdTime = formatDate(new Date(value.created_time).toString(), BLOG.LANG)
   properties.lastEditedTime = formatDate(new Date(value?.last_edited_time).toString(), BLOG.LANG)
   properties.fullWidth = value.format?.page_full_width ?? false
-  properties.pageIcon = getPageIcon(id, block) ?? ''
-  properties.page_cover = getPostCover(id, block) ?? siteInfo?.pageCover
+  properties.pageIcon = getImageUrl(block[id].value?.format?.page_icon, block[id].value) ?? ''
+  properties.page_cover = getImageUrl(block[id].value?.format?.page_cover, block[id].value) ?? siteInfo?.pageCover
   properties.content = value.content ?? []
   properties.tagItems = properties?.tags?.map(tag => {
     return { name: tag, color: tagOptions?.find(t => t.value === tag)?.color || 'gray' }
@@ -89,20 +89,23 @@ export default async function getPageProperties(id, block, schema, authToken, ta
   return properties
 
   // 从Block获取封面图;优先取PageCover，否则取内容图片
-  function getPostCover(id, block) {
-    const pageCover = block[id].value?.format?.page_cover
-    if (pageCover) {
-      if (pageCover.startsWith('/')) return 'https://www.notion.so' + pageCover
-      if (pageCover.startsWith('http')) return defaultMapImageUrl(pageCover, block[id].value)
+  function getImageUrl(imgObj, blockVal) {
+    if (!imgObj) {
+      return null
     }
-  }
-}
+    if (imgObj.startsWith('/')) {
+      return 'https://www.notion.so' + imgObj // notion内部图片转相对路径为绝对路径
+    }
 
-function getPageIcon(id, block) {
-  const pageIcon = block[id].value?.format?.page_icon
-  if (pageIcon) {
-    if (pageIcon.startsWith('/')) return 'https://www.notion.so' + pageIcon
-    if (pageIcon.startsWith('http')) return defaultMapImageUrl(pageIcon, block[id].value)
-    return pageIcon
+    if (imgObj.startsWith('http')) {
+      // 判断如果是notion上传的图片要拼接访问token
+      const u = new URL(imgObj)
+      if (u.pathname.startsWith('/secure.notion-static.com') && u.hostname.endsWith('.amazonaws.com')) {
+        return defaultMapImageUrl(imgObj, blockVal) // notion上传的图片需要转换请求地址
+      }
+    }
+
+    // 其他图片链接 或 emoji
+    return imgObj
   }
 }

--- a/themes/hexo/components/BlogPostCard.js
+++ b/themes/hexo/components/BlogPostCard.js
@@ -7,6 +7,11 @@ import NotionPage from '@/components/NotionPage'
 
 const BlogPostCard = ({ post, showSummary }) => {
   const showPreview = CONFIG_HEXO.POST_LIST_PREVIEW && post.blockMap
+  const linkedCoverPrefix = 'https://www.notion.so/image/'
+  if (post?.page_cover && post?.page_cover?.startsWith(linkedCoverPrefix)) {
+    const linkedCoverPrefixLength = linkedCoverPrefix.length
+    post.page_cover = decodeURIComponent(post.page_cover.slice(linkedCoverPrefixLength))
+  }
   return (
     <div className="w-full shadow-sm hover:shadow border dark:border-black rounded-xl bg-white dark:bg-hexo-black-gray duration-300">
       <div

--- a/themes/hexo/components/BlogPostCard.js
+++ b/themes/hexo/components/BlogPostCard.js
@@ -7,11 +7,6 @@ import NotionPage from '@/components/NotionPage'
 
 const BlogPostCard = ({ post, showSummary }) => {
   const showPreview = CONFIG_HEXO.POST_LIST_PREVIEW && post.blockMap
-  const linkedCoverPrefix = 'https://www.notion.so/image/'
-  if (post?.page_cover && post?.page_cover?.startsWith(linkedCoverPrefix)) {
-    const linkedCoverPrefixLength = linkedCoverPrefix.length
-    post.page_cover = decodeURIComponent(post.page_cover.slice(linkedCoverPrefixLength))
-  }
   return (
     <div className="w-full shadow-sm hover:shadow border dark:border-black rounded-xl bg-white dark:bg-hexo-black-gray duration-300">
       <div


### PR DESCRIPTION
 解决了issue  #322 ，
bug出现原因：
由于封面拿到的链接地址被notion添加了前缀<https://www.notion.so/image/>，导致封面无法正常显示
解决方案：
通过对链接地址去除前缀并decode，可以获得正确链接