### PR TITLE
minimize bundle size through dynamic import pdf and equation

### DIFF
--- a/components/NotionPage.js
+++ b/components/NotionPage.js
@@ -7,8 +7,8 @@ import { isBrowser } from '@/lib/utils'
 import Image from 'next/image'
 import Link from 'next/link'
 import { Code } from 'react-notion-x/build/third-party/code'
-import { Pdf } from 'react-notion-x/build/third-party/pdf'
-import { Equation } from 'react-notion-x/build/third-party/equation'
+// import { Pdf } from 'react-notion-x/build/third-party/pdf'
+// import { Equation } from 'react-notion-x/build/third-party/equation'
 
 import 'prismjs/components/prism-bash.js'
 import 'prismjs/components/prism-markup-templating.js'
@@ -43,8 +43,19 @@ import 'prismjs/components/prism-wasm.js'
 import 'prismjs/components/prism-yaml.js'
 import 'prismjs/components/prism-r.js'
 
-// 化学方程式
-import '@/lib/mhchem'
+const Equation = dynamic(() =>
+  import('react-notion-x/build/third-party/equation').then(async (m) => {
+    // 化学方程式
+    await import('@/lib/mhchem')
+    return m.Equation
+  })
+)
+const Pdf = dynamic(
+  () => import('react-notion-x/build/third-party/pdf').then((m) => m.Pdf),
+  {
+    ssr: false
+  }
+)
 
 // https://github.com/txs
 // import PrismMac from '@/components/PrismMac'


### PR DESCRIPTION
通过动态引入pdf和equation减小首包体积，经过测试，修改后代码在pdf渲染和方程式渲染上没有问题，下面是优化前后的包体积对比，包体积减少了40%。
**优化前**
***包大小***
<img width="1088" alt="截屏2022-12-06 14 17 25" src="https://user-images.githubusercontent.com/71168966/205839090-548fa0c1-5d87-4e6c-9e0b-05b33cebb8f0.png">
***体积分析***
<img width="1440" alt="截屏2022-12-06 14 21 24" src="https://user-images.githubusercontent.com/71168966/205839616-87804540-d742-4372-b00b-f6fc61e3d9b7.png">

**优化后**
***包大小***
<img width="1036" alt="截屏2022-12-06 14 23 20" src="https://user-images.githubusercontent.com/71168966/205839222-cb64fa19-6da7-49b6-ab86-d531801c8deb.png">
***体积分析***
<img width="1440" alt="截屏2022-12-06 14 22 53" src="https://user-images.githubusercontent.com/71168966/205839745-8db13c03-d45c-4ef1-bd28-2fb0a2dbf760.png">
