### PR TITLE
fix 仅文章状态为Published的，计算category与tags计数，Invisible的文章不参与计数

### DIFF
--- a/lib/notion/getAllCategories.js
+++ b/lib/notion/getAllCategories.js
@@ -14,7 +14,7 @@ import { isIterable } from '../utils'
  * @returns {Promise<{}|*[]>}
  */
 export function getAllCategories({ allPages, categoryOptions, sliceCount = 0 }) {
-  const allPosts = allPages.filter(page => page.type === 'Post')
+  const allPosts = allPages.filter(page => page.type === 'Post' && page.status === 'Published')
   if (!allPosts || !categoryOptions) {
     return []
   }

--- a/lib/notion/getAllTags.js
+++ b/lib/notion/getAllTags.js
@@ -8,7 +8,7 @@ import { isIterable } from '../utils'
  * @returns {Promise<{}|*[]>}
  */
 export function getAllTags({ allPages, sliceCount = 0, tagOptions }) {
-  const allPosts = allPages.filter(page => page.type === 'Post')
+  const allPosts = allPages.filter(page => page.type === 'Post' && page.status === 'Published')
 
   if (!allPosts || !tagOptions) {
     return []


### PR DESCRIPTION
一些分类或tags上显示有文章数量，但是点进去并没有，后来发现有文章是Invisible状态导致的，于是改了下，只计算Published状态的文章