### PR TITLE
fix 尝试修复 #742 medium 主题无法正常显示目录：为Tabs.js fade-up 动画失效导致，删除后恢复正常；

### DIFF
--- a/components/Tabs.js
+++ b/components/Tabs.js
@@ -50,7 +50,6 @@ const Tabs = ({ className, children }) => {
         <div>
             {children.map((item, index) => {
               return <section key={index}
-                    data-aos="fade-up"
                     data-aos-duration="600"
                     data-aos-easing="ease-in-out"
                     data-aos-once="false"

--- a/themes/medium/components/Catalog.js
+++ b/themes/medium/components/Catalog.js
@@ -10,10 +10,6 @@ import JumpToTopButton from './JumpToTopButton'
  * @constructor
  */
 const Catalog = ({ toc }) => {
-  // 无目录就直接返回空
-  if (!toc || toc.length < 1) {
-    return <></>
-  }
   // 监听滚动事件
   React.useEffect(() => {
     window.addEventListener('scroll', actionSectionScrollSpy)
@@ -56,6 +52,11 @@ const Catalog = ({ toc }) => {
     const index = tocIds.indexOf(currentSectionId) || 0
     tRef?.current?.scrollTo({ top: 28 * index, behavior: 'smooth' })
   }, throttleMs))
+
+  // 无目录就直接返回空
+  if (!toc || toc.length < 1) {
+    return <></>
+  }
 
   return <div className='px-3'>
     <div className='w-full mt-2 mb-4'>


### PR DESCRIPTION
但是失去动画效果，修复不算完美；
另：直接访问文章页url（不是从首页或其他页面点进去），有大概率识别不到有目录，未能修复