### PR TITLE
Waline会自动适配白天/黑夜模式无需再写CSS

### DIFF
--- a/components/WalineComponent.js
+++ b/components/WalineComponent.js
@@ -29,6 +29,7 @@ const WalineComponent = (props) => {
         serverURL: BLOG.COMMENT_WALINE_SERVER_URL,
         lang: BLOG.lang,
         reaction: true,
+        dark: 'html.dark',
         emoji: [
           '//npm.elemecdn.com/@waline/emojis@1.1.0/tieba',
           '//npm.elemecdn.com/@waline/emojis@1.1.0/weibo',

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -181,20 +181,6 @@ nav {
   margin: -0.125em 0.25em;
 }
 
-
-/* waline评论插件夜间适配 */
-.wl-panel{
-  @apply dark:bg-black dark:border-gray-800
-}
-
-.wl-input,.wl-editor{
-  @apply dark:focus-within:bg-gray-900 dark:text-gray-200
-}
-
-.wl-meta > span {
-  @apply dark:bg-gray-800 !important
-}
-
 /* 固定两行 */
 .text-line-2 {
     overflow : hidden;


### PR DESCRIPTION
参考：[Waline暗黑模式支持](https://waline.js.org/guide/features/style.html#%E6%9A%97%E9%BB%91%E6%A8%A1%E5%BC%8F%E6%94%AF%E6%8C%81)