### PR TITLE
fix only display toc of current page

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,11 @@
   <td align="center">
     <a href="https://github.com/hongzzz" style="display:inline-block;width:80px"><img src="https://avatars.githubusercontent.com/u/25585061" width="64px;"  alt="Hongzzz"/><br/><sub><b>Hongzzz</b></sub></a><br/><a href="https://github.com/tangly1024/NotionNext/commits?author=hongzzz" title="hongzzz" >🔧 🐛</a>
   </td>
+
+  <td align="center">
+    <a href="https://github.com/RedhairHambagu" style="display:inline-block;width:80px"><img src="https://avatars.githubusercontent.com/u/129669334" width="64px;"  alt="RedhairHambagu"/><br/><sub><b>RedhairHambagu</b></sub></a><br/><a href="https://github.com/tangly1024/NotionNext/commits?author=RedhairHambagu" title="RedhairHambagu" >🔧 🐛</a>
+  </td>
+
 </tr>
 </table>
 

--- a/pages/[...slug].js
+++ b/pages/[...slug].js
@@ -31,7 +31,7 @@ const Slug = props => {
       setLock(true)
     } else {
       if (!lock && post?.blockMap?.block) {
-        post.content = Object.keys(post.blockMap.block)
+        post.content = Object.keys(post.blockMap.block).filter(key => post.blockMap.block[key]?.value.parent_id === post.id)
         post.toc = getPageTableOfContents(post, post.blockMap)
       }
 


### PR DESCRIPTION
问题：当前页面如果有database， 且database 内页面也有toc， 则右侧会把所有toc都展示出来.
处理：判断过滤block的parent_id为当前页的page id才会获取toc。

看了下post.blockMap内实际上是把所有的block都获取上了。前端不太熟，所以不确定别的地方是否也需要过滤处理

wrong toc: 
![wrong_toc](https://user-images.githubusercontent.com/129669334/234013099-115abe1b-9228-4b48-bfc2-d8ca6d32d0ff.jpg)


database内页面的toc展示
![subpage_toc_example](https://user-images.githubusercontent.com/129669334/234013738-4722e9b1-b94e-4db8-b0a7-29205620879e.jpg)

过滤后的toc正常
![fix_toc](https://user-images.githubusercontent.com/129669334/234013828-8369e071-6029-4e76-aa31-d163f58e3df1.jpg)


