### PR TITLE
修复分页组件bug

### DIFF
--- a/themes/fukasawa/components/PaginationSimple.js
+++ b/themes/fukasawa/components/PaginationSimple.js
@@ -47,7 +47,7 @@ const PaginationSimple = ({ page, showNext }) => {
         {locale.PAGINATION.NEXT}→
       </Link>
     </div>
-  );
+  )
 }
 
 export default PaginationSimple

--- a/themes/hexo/components/PaginationNumber.js
+++ b/themes/hexo/components/PaginationNumber.js
@@ -47,7 +47,7 @@ const PaginationNumber = ({ page, totalPage }) => {
 
         </Link>
     </div>
-  );
+  )
 }
 
 function getPageElement(page, currentPage, pagePrefix) {
@@ -66,7 +66,7 @@ function getPageElement(page, currentPage, pagePrefix) {
       {page}
 
     </Link>)
-  );
+  )
 }
 
 function generatePages(pagePrefix, page, currentPage, totalPage) {

--- a/themes/matery/components/PaginationSimple.js
+++ b/themes/matery/components/PaginationSimple.js
@@ -1,4 +1,3 @@
-import BLOG from '@/blog.config'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
 
@@ -13,6 +12,7 @@ const PaginationSimple = ({ page, totalPage }) => {
   const router = useRouter()
   const currentPage = +page
   const showNext = currentPage < totalPage
+  const pagePrefix = router.asPath.replace(/\/page\/[1-9]\d*/, '').replace(/\/$/, '')
 
   return (
     <div className="my-10 mx-6 flex justify-between font-medium text-black dark:text-gray-100 space-x-2">
@@ -20,8 +20,8 @@ const PaginationSimple = ({ page, totalPage }) => {
         href={{
           pathname:
             currentPage - 1 === 1
-              ? `${BLOG.SUB_PATH || '/'}`
-              : `/page/${currentPage - 1}`,
+              ? `${pagePrefix}/`
+              : `${pagePrefix}/page/${currentPage - 1}`,
           query: router.query.s ? { s: router.query.s } : {}
         }}
         passHref
@@ -36,7 +36,7 @@ const PaginationSimple = ({ page, totalPage }) => {
       </Link>
       <Link
         href={{
-          pathname: `/page/${currentPage + 1}`,
+          pathname: `${pagePrefix}/page/${currentPage + 1}`,
           query: router.query.s ? { s: router.query.s } : {}
         }}
         passHref

--- a/themes/medium/components/PaginationSimple.js
+++ b/themes/medium/components/PaginationSimple.js
@@ -48,7 +48,7 @@ const PaginationSimple = ({ page, totalPage }) => {
         {locale.PAGINATION.NEXT}→
       </Link>
     </div>
-  );
+  )
 }
 
 export default PaginationSimple

--- a/themes/next/components/PaginationSimple.js
+++ b/themes/next/components/PaginationSimple.js
@@ -1,4 +1,3 @@
-import BLOG from '@/blog.config'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
 import { useGlobal } from '@/lib/global'
@@ -14,6 +13,8 @@ const PaginationSimple = ({ page, showNext }) => {
   const { locale } = useGlobal()
   const router = useRouter()
   const currentPage = +page
+  const pagePrefix = router.asPath.replace(/\/page\/[1-9]\d*/, '').replace(/\/$/, '')
+
   return (
     <div
         data-aos="fade-down"
@@ -25,8 +26,8 @@ const PaginationSimple = ({ page, showNext }) => {
         href={{
           pathname:
             currentPage - 1 === 1
-              ? `${BLOG.SUB_PATH || '/'}`
-              : `/page/${currentPage - 1}`,
+              ? `${pagePrefix}/`
+              : `${pagePrefix}/page/${currentPage - 1}`,
           query: router.query.s ? { s: router.query.s } : {}
         }}
         passHref


### PR DESCRIPTION
此bug的发现来源于邮件留言，再次感谢 Jimmy Huang!

> tangly您好，最近我使用您的NotionNext项目搭建了自己的静态博客，在使用过程中发现了一个Bug。
当使用主题为Matery时，在tag、catagory的具体分类下点击下一页时，页面跳转并没有带上应该有的前缀，我描述的可能不太清晰，我举一个例子。
当前页面为https://tangly1024.com/category/知识分享
点击屏幕右下角的下一页，页面应当跳转到https://tangly1024.com/category/知识分享/page/2
但是实际上页面跳转到了https://tangly1024.com/page/2
我测试多次，多个分类，似乎都存在着这个问题。这个现象似乎并不是特例，我猜想应当是编码过程存在Bug，所以发邮件告知您一声，如果在您闲暇之余可以修复这个Bug就更完美了。
您的NotionNext项目做的很棒，为您点赞。