### PR TITLE
Move vercel analytics from head to body

### DIFF
--- a/components/CommonScript.js
+++ b/components/CommonScript.js
@@ -1,5 +1,4 @@
 import BLOG from '@/blog.config'
-import { Analytics } from '@vercel/analytics/react'
 
 /**
  * 第三方代码 统计脚本
@@ -8,8 +7,6 @@ import { Analytics } from '@vercel/analytics/react'
  */
 const CommonScript = () => {
   return (<>
-    {BLOG.ANALYTICS_VERCEL && <Analytics />}
-
     {BLOG.COMMENT_DAO_VOICE_ID && (<>
       {/* DaoVoice 反馈 */}
       <script async dangerouslySetInnerHTML={{

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -22,6 +22,7 @@ import { StarrySky } from '@/components/StarrySky'
 import MusicPlayer from '@/components/MusicPlayer'
 import ExternalScript from '@/components/ExternalScript'
 import smoothscroll from 'smoothscroll-polyfill'
+import { Analytics } from '@vercel/analytics/react'
 
 import AOS from 'aos'
 import 'aos/dist/aos.css' // You can also use <link> for styles
@@ -45,6 +46,7 @@ const MyApp = ({ Component, pageProps }) => {
         {JSON.parse(BLOG.DEBUG) && <DebugPanel />}
         {BLOG.ANALYTICS_ACKEE_TRACKER && <Ackee />}
         {BLOG.ANALYTICS_GOOGLE_ID && <Gtag />}
+        {BLOG.ANALYTICS_VERCEL && <Analytics />}
         {JSON.parse(BLOG.ANALYTICS_BUSUANZI_ENABLE) && <Busuanzi />}
         {BLOG.ADSENSE_GOOGLE_ID && <GoogleAdsense />}
         {BLOG.FACEBOOK_APP_ID && BLOG.FACEBOOK_PAGE_ID && <Messenger />}


### PR DESCRIPTION
## Detail

The previous change for Vercel Analytics didn't work. According to the [Vercel doc](https://vercel.com/docs/concepts/analytics/quickstart), the Analytics component should be put inside the body instead of head.

## Testing

Deployed the change on my personal website and verified it is working.