### PR TITLE
fix: wrapper style paddingTop

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,10 @@
     <a href="https://github.com/emengweb" style="display:inline-block;width:80px"><img src="https://avatars.githubusercontent.com/u/31469739" width="64px;"  alt="emengweb"/><br/><sub><b>emengweb</b></sub></a><br/><a href="https://github.com/tangly1024/NotionNext/commits?author=emengweb" title="emengweb" >🔧 🐛</a>
   </td>
 
+  <td align="center">
+    <a href="https://github.com/kitety" style="display:inline-block;width:80px"><img src="https://avatars.githubusercontent.com/u/22906933" width="64px;"  alt="kitety"/><br/><sub><b>kitety</b></sub></a><br/><a href="https://github.com/tangly1024/NotionNext/commits?author=kitety" title="kitety" >🔧 🐛</a>
+  </td>
+
 
 </tr>
 </table>

--- a/themes/hexo/LayoutBase.js
+++ b/themes/hexo/LayoutBase.js
@@ -12,6 +12,7 @@ import { useGlobal } from '@/lib/global'
 import BLOG from '@/blog.config'
 import dynamic from 'next/dynamic'
 import { isBrowser, loadExternalResource } from '@/lib/utils'
+import CONFIG_HEXO from './config_hexo'
 
 const FacebookPage = dynamic(
   () => {
@@ -65,6 +66,8 @@ const LayoutBase = props => {
   if (isBrowser()) {
     loadExternalResource('/css/theme-hexo.css', 'css')
   }
+
+  const fixStyleObject = !CONFIG_HEXO.HOME_BANNER_ENABLE ? { paddingTop: '4rem' }:{}
   return (
     <div id='theme-hexo'>
       <CommonHead meta={meta} siteInfo={siteInfo}/>
@@ -73,7 +76,7 @@ const LayoutBase = props => {
 
       {headerSlot}
 
-      <main id="wrapper" className="bg-hexo-background-gray dark:bg-black w-full py-8 md:px-8 lg:px-24 min-h-screen relative">
+      <main id="wrapper" className="bg-hexo-background-gray dark:bg-black w-full py-8 md:px-8 lg:px-24 min-h-screen relative" style={fixStyleObject}>
         <div id="container-inner" className={(BLOG.LAYOUT_SIDEBAR_REVERSE ? 'flex-row-reverse' : '') + ' w-full mx-auto lg:flex lg:space-x-4 justify-center relative z-10'} >
           <div className={'w-full max-w-4xl h-full ' + props.className}>
             {onLoading ? <LoadingCover /> : children}

--- a/themes/hexo/LayoutBase.js
+++ b/themes/hexo/LayoutBase.js
@@ -67,7 +67,6 @@ const LayoutBase = props => {
     loadExternalResource('/css/theme-hexo.css', 'css')
   }
 
-  const fixStyleObject = !CONFIG_HEXO.HOME_BANNER_ENABLE ? { paddingTop: '4rem' }:{}
   return (
     <div id='theme-hexo'>
       <CommonHead meta={meta} siteInfo={siteInfo}/>
@@ -76,7 +75,7 @@ const LayoutBase = props => {
 
       {headerSlot}
 
-      <main id="wrapper" className="bg-hexo-background-gray dark:bg-black w-full py-8 md:px-8 lg:px-24 min-h-screen relative" style={fixStyleObject}>
+      <main id="wrapper" className={`${CONFIG_HEXO.HOME_BANNER_ENABLE ? '' : 'pt-16'} bg-hexo-background-gray dark:bg-black w-full py-8 md:px-8 lg:px-24 min-h-screen relative`}>
         <div id="container-inner" className={(BLOG.LAYOUT_SIDEBAR_REVERSE ? 'flex-row-reverse' : '') + ' w-full mx-auto lg:flex lg:space-x-4 justify-center relative z-10'} >
           <div className={'w-full max-w-4xl h-full ' + props.className}>
             {onLoading ? <LoadingCover /> : children}

--- a/themes/matery/LayoutBase.js
+++ b/themes/matery/LayoutBase.js
@@ -42,7 +42,6 @@ const LayoutBase = props => {
   if (isBrowser()) {
     loadExternalResource('/css/theme-matery.css', 'css')
   }
-  const fixStyleObject = !CONFIG_MATERY.HOME_BANNER_ENABLE ? { paddingTop: '4rem' } : {}
 
   return (
         <div id='theme-matery' className="min-h-screen flex flex-col justify-between bg-hexo-background-gray dark:bg-black w-full">
@@ -53,7 +52,7 @@ const LayoutBase = props => {
 
             {headerSlot}
 
-            <main id="wrapper" className="flex-1 w-full py-8 md:px-8 lg:px-24 relative" style={fixStyleObject}>
+            <main id="wrapper" className={`${CONFIG_MATERY.HOME_BANNER_ENABLE ? '' : 'pt-16'} flex-1 w-full py-8 md:px-8 lg:px-24 relative`}>
                 {/* 嵌入区域 */}
                                <div id="container-slot" className={`w-full max-w-6xl ${props?.post && ' lg:max-w-3xl 2xl:max-w-4xl '} mt-6 px-3 mx-auto lg:flex lg:space-x-4 justify-center relative z-10`}>
                    {props.containerSlot}

--- a/themes/matery/LayoutBase.js
+++ b/themes/matery/LayoutBase.js
@@ -12,6 +12,7 @@ import FloatDarkModeButton from './components/FloatDarkModeButton'
 import throttle from 'lodash.throttle'
 import { isBrowser, loadExternalResource } from '@/lib/utils'
 import SocialButton from './components/SocialButton'
+import CONFIG_MATERY from './config_matery'
 
 /**
  * 基础布局 采用左右两侧布局，移动端使用顶部导航栏
@@ -41,6 +42,7 @@ const LayoutBase = props => {
   if (isBrowser()) {
     loadExternalResource('/css/theme-matery.css', 'css')
   }
+  const fixStyleObject = !CONFIG_MATERY.HOME_BANNER_ENABLE ? { paddingTop: '4rem' } : {}
 
   return (
         <div id='theme-matery' className="min-h-screen flex flex-col justify-between bg-hexo-background-gray dark:bg-black w-full">
@@ -51,7 +53,7 @@ const LayoutBase = props => {
 
             {headerSlot}
 
-            <main id="wrapper" className="flex-1 w-full py-8 md:px-8 lg:px-24 relative">
+            <main id="wrapper" className="flex-1 w-full py-8 md:px-8 lg:px-24 relative" style={fixStyleObject}>
                 {/* 嵌入区域 */}
                                <div id="container-slot" className={`w-full max-w-6xl ${props?.post && ' lg:max-w-3xl 2xl:max-w-4xl '} mt-6 px-3 mx-auto lg:flex lg:space-x-4 justify-center relative z-10`}>
                    {props.containerSlot}


### PR DESCRIPTION
Add additional padding-top when the theme sets no top home banner.
For Example :
hexo:
original:
![image](https://github.com/tangly1024/NotionNext/assets/22906933/a669baed-eed9-4285-917d-b82c6c6792f9)
fixed:
![image](https://github.com/tangly1024/NotionNext/assets/22906933/7ea6553d-6744-41f7-a4b3-69aa9fecdcc0)
 
matery:
original:
![image](https://github.com/tangly1024/NotionNext/assets/22906933/2e2dafcf-077d-4af0-9901-4b07fd855359)
fixed:
![image](https://github.com/tangly1024/NotionNext/assets/22906933/6a65e047-6dfe-417e-998e-164e5aa48cc2)




