### PR TITLE
Delete Bitter from "FONT_SANS" of blog.config.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,9 @@
     <a href="https://github.com/kitety" style="display:inline-block;width:80px"><img src="https://avatars.githubusercontent.com/u/22906933" width="64px;"  alt="kitety"/><br/><sub><b>kitety</b></sub></a><br/><a href="https://github.com/tangly1024/NotionNext/commits?author=kitety" title="kitety" >🔧 🐛</a>
   </td>
 
+ <td align="center">
+    <a href="https://github.com/jxpeng98" style="display:inline-block;width:80px"><img src="https://avatars.githubusercontent.com/u/83734772" width="64px;"  alt=" Jiaxin Peng"/><br/><sub><b> Jiaxin Peng</b></sub></a><br/><a href="https://github.com/tangly1024/NotionNext/commits?author=jxpeng98" title="jxpeng98" >🔧 🐛</a>
+  </td>
 
 </tr>
 </table>

--- a/blog.config.js
+++ b/blog.config.js
@@ -42,7 +42,6 @@ const BLOG = {
   ],
   FONT_SANS: [
     // 无衬线字体 例如'LXGW WenKai'
-    'Bitter',
     '"PingFang SC"',
     '-apple-system',
     'BlinkMacSystemFont',


### PR DESCRIPTION
网页渲染的时候，英文内容无法使用无衬线：
<img width="538" alt="image" src="https://github.com/tangly1024/NotionNext/assets/83734772/cd5867ae-fbef-4627-a734-5fd495957beb">
<img width="296" alt="image" src="https://github.com/tangly1024/NotionNext/assets/83734772/e96efeed-5ef6-4ee1-880c-2713c028193b">


删掉Bitter之后，就可以正常渲染了：
<img width="536" alt="image" src="https://github.com/tangly1024/NotionNext/assets/83734772/fd6009b5-ceda-4e5b-b52a-8a8fb74024bc">
<img width="306" alt="image" src="https://github.com/tangly1024/NotionNext/assets/83734772/952cbed8-fe85-47ee-aedb-700f8946980a">

