### PR TITLE
change the icon of about in nav bar

### DIFF
--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -3,3 +3,6 @@
 #theme-fukasawa .sideLeft hr{
     opacity: .04;
 }
+.fa-info:before {
+    content: "\f05a";
+}


### PR DESCRIPTION
把关于页的icon从i更改为圆形，让导航栏更对称。 
之前
<img width="409" alt="image" src="https://github.com/tangly1024/NotionNext/assets/83734772/4a7412fa-1506-4f1d-9251-c474d540606c">

修改为[图标](https://fontawesome.com/icons/circle-info?f=classic&s=solid)
修改后： 
<img width="401" alt="image" src="https://github.com/tangly1024/NotionNext/assets/83734772/1382e64b-6932-4712-ab6b-b63be9cc9e41">
