### PR TITLE
feat: support blog favicon configurable,  use lcoal favicon.ico as default ,  also can use online resource

### DIFF
--- a/blog.config.js
+++ b/blog.config.js
@@ -34,6 +34,7 @@ const BLOG = {
 
   NOTION_HOST: process.env.NEXT_PUBLIC_NOTION_HOST || 'https://www.notion.so', // Notion域名，您可以选择用自己的域名进行反向代理，如果不懂得什么是反向代理，请勿修改此项
 
+  BLOG_FAVICON: process.env.NEXT_PUBLIC_FAVICON || '/favicon.ico', // blog favicon 配置, 默认使用 /public/favicon.ico，支持在线图片，如 https://img.imesong.com/favicon.png
   // 网站字体
   FONT_STYLE: process.env.NEXT_PUBLIC_FONT_STYLE || 'font-sans', // ['font-serif','font-sans'] 两种可选，分别是衬线和无衬线: 参考 https://www.jianshu.com/p/55e410bd2115
   FONT_URL: [

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -13,7 +13,7 @@ class MyDocument extends Document {
     return (
             <Html lang={BLOG.LANG}>
                 <Head>
-                    <link rel='icon' href='/favicon.ico' />
+                    <link rel='icon' href= {`${BLOG.BLOG_FAVICON}`} />
                     <CommonScript />
                 </Head>
 


### PR DESCRIPTION
## 一句话描述改动
新增feature，支持配置 blog 的 favicon，支持在线图标

## 为什么改动
1. 现在如果要修改 favicon，需要修改 public 目录下的 favicon.ico ，修改之后，每次手动更新源码，会产生不必要冲突。
2. 代码中固定了获取 favicon 的path，扩展性较低，不够灵活。

## 改动后的效果对比

<img width="333" alt="image" src="https://github.com/tangly1024/NotionNext/assets/3849293/356caa26-cdfe-49f0-9c8b-3599dd0778b8">

<img width="588" alt="image" src="https://github.com/tangly1024/NotionNext/assets/3849293/7453119f-134f-4bb7-a960-0e19bc6d1958">


可以通过 [11it.com](https://11it.com) 预览
