### PR TITLE
Update CommonHead.js

### DIFF
--- a/components/CommonHead.js
+++ b/components/CommonHead.js
@@ -48,7 +48,11 @@ const CommonHead = ({ meta, children }) => {
                 <link rel="stylesheet" href={BLOG.FONT_AWESOME} crossOrigin="anonymous" referrerpolicy="no-referrer" />
             </>}
             {BLOG.FONT_URL?.map((fontUrl, index) => {
-              return <link key={index} rel='preload' href={fontUrl} as='font' type='font/woff2' />
+              if (fontUrl.endsWith('.css')) {
+                return <link key={index} rel="stylesheet" href={fontUrl} />
+              } else {
+                return <link key={index} rel="preload" href={fontUrl} as="font" type="font/woff2" />
+              }
             })}
 
             {BLOG.COMMENT_WEBMENTION.ENABLE && (


### PR DESCRIPTION
修复外挂字体无法导入的问题，通过if来讲css的字体以stylesheet导入。