### PR TITLE
fix medium 移动端目录溢出

### DIFF
--- a/themes/medium/components/Catalog.js
+++ b/themes/medium/components/Catalog.js
@@ -63,7 +63,7 @@ const Catalog = ({ toc }) => {
     <div className='w-full mt-2 mb-4'>
       <Progress />
     </div>
-    <div className='overflow-y-auto max-h-96 overscroll-none scroll-hidden' ref={tRef}>
+    <div className='overflow-y-auto max-h-44 overscroll-none scroll-hidden' ref={tRef}>
       <nav className='h-full  text-black'>
         {toc.map((tocItem) => {
           const id = uuidToId(tocItem.id)


### PR DESCRIPTION
修复 由于Catalog 组件高度超过了父组件Toc的高度，导致目录显示不完全和无法滚动的情况