### PR TITLE
gitbook 侧边栏支持自动分组自动排序

### DIFF
--- a/themes/gitbook/components/NavPostList.js
+++ b/themes/gitbook/components/NavPostList.js
@@ -1,6 +1,7 @@
 import NavPostListEmpty from './NavPostListEmpty'
 import { useRouter } from 'next/router'
 import NavPostItem from './NavPostItem'
+import CONFIG from '../config'
 
 /**
  * 博客列表滚动分页
@@ -15,10 +16,20 @@ const NavPostList = (props) => {
   let selectedSth = false
   const groupedArray = filteredNavPages?.reduce((groups, item) => {
     const categoryName = item?.category ? item?.category : '' // 将category转换为字符串
-    const lastGroup = groups[groups.length - 1] // 获取最后一个分组
 
-    if (!lastGroup || lastGroup?.category !== categoryName) { // 如果当前元素的category与上一个元素不同，则创建新分组
-      groups.push({ category: categoryName, items: [] })
+    // 开启自动分组排序
+    if (JSON.parse(CONFIG.AUTO_SORT)) {
+      const existingGroup = groups.find(group => group.category === categoryName)
+      if (existingGroup) {
+        existingGroup.items.push(item)
+      } else {
+        groups.push({ category: categoryName, items: [item] })
+      }
+    } else {
+      const lastGroup = groups[groups.length - 1] // 获取最后一个分组
+      if (!lastGroup || lastGroup?.category !== categoryName) { // 如果当前元素的category与上一个元素不同，则创建新分组
+        groups.push({ category: categoryName, items: [] })
+      }
     }
 
     groups[groups.length - 1].items.push(item) // 将元素加入对应的分组

--- a/themes/gitbook/config.js
+++ b/themes/gitbook/config.js
@@ -2,6 +2,8 @@ const CONFIG = {
 
   INDEX_PAGE: 'about', // 文档首页显示的文章，请确此路径包含在您的notion数据库中
 
+  AUTO_SORT: process.env.NEXT_PUBLIC_GITBOOK_AUTO_SORT || true, // 是否自动按分类名 归组排序文章；自动归组可能会打乱您Notion中的文章顺序
+
   // 菜单
   MENU_CATEGORY: true, // 显示分类
   MENU_TAG: true, // 显示标签


### PR DESCRIPTION
切换gitbook主题时，将默认按照文章分类进行归组排序。
从而解决在gitbook主题下，不同分类文章没有排在一起时，分类名会重复的问题。
在/themes/gitbook/config.js 中可以关闭自动分组排序
