### PR TITLE
fix: 修复github代码合并时检查编译错误

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG NOTION_PAGE_ID
 # Install dependencies only when needed
-FROM node:14-alpine AS deps
+FROM node:18-alpine AS deps
 # Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
 RUN apk add --no-cache libc6-compat
 WORKDIR /app


### PR DESCRIPTION
该项目Dockerfile使用的基础镜像为node14，但依赖包要求node16以上，现在修改到node18，可以正常编译通过