### PR TITLE
[fix] 修复未配置Action Secrets每日定时推送报错

### DIFF
--- a/.github/workflows/pushUrl.yml
+++ b/.github/workflows/pushUrl.yml
@@ -36,7 +36,7 @@ jobs:
         run: pip install requests
 
       - name: baiduPush
-        run: python pushUrl.py ${{ secrets.URL }} --baidu_token ${{ secrets.BAIDU_TOKEN }}
+        run: python pushUrl.py --url ${{ secrets.URL }} --baidu_token ${{ secrets.BAIDU_TOKEN }}
 
       - name: bingPush
-        run: python pushUrl.py ${{ secrets.URL }} --bing_api_key ${{ secrets.BING_API_KEY }}
+        run: python pushUrl.py --url ${{ secrets.URL }} --bing_api_key ${{ secrets.BING_API_KEY }}

--- a/.github/workflows/pushUrl.yml
+++ b/.github/workflows/pushUrl.yml
@@ -32,11 +32,8 @@ jobs:
         with:
           python-version: 3.8
 
-      - name: install requests
+      - name: Install requests
         run: pip install requests
 
-      - name: baiduPush
-        run: python pushUrl.py --url ${{ secrets.URL }} --baidu_token ${{ secrets.BAIDU_TOKEN }}
-
-      - name: bingPush
-        run: python pushUrl.py --url ${{ secrets.URL }} --bing_api_key ${{ secrets.BING_API_KEY }}
+      - name: Push
+        run: python pushUrl.py --url ${{ secrets.URL }} --baidu_token ${{ secrets.BAIDU_TOKEN }} --bing_api_key ${{ secrets.BING_API_KEY }}

--- a/pushUrl.py
+++ b/pushUrl.py
@@ -9,11 +9,18 @@ ssl._create_default_https_context = ssl._create_unverified_context
 def parse_stiemap(site):
     site = f'{site}/sitemap.xml'
     print('解析站点地图中，请稍后……')
-    result = requests.get(site)
-    big = re.findall('<loc>(.*?)</loc>', result.content.decode('utf-8'), re.S)
-    print('当前已有url:')
-    print(list(big))
-    return list(big)
+    try:
+        result = requests.get(site)
+        big = re.findall('<loc>(.*?)</loc>', result.content.decode('utf-8'), re.S)
+        print('当前已有url:')
+        print(list(big))
+        return list(big)
+    except:
+        print('请检查你的url是否有误。')
+        print('正确的应是完整的域名，包含https://，且不包含‘sitemap.xml’, 如下所示：')
+        print('正确的示例: https://ghlcode.cn')
+        print('详情参见: https://ghlcode.cn/fe032806-5362-4d82-b746-a0b26ce8b9d9')
+
 
 
 def push_to_bing(site, urls, api_key):
@@ -62,16 +69,17 @@ if __name__ == '__main__':
     args = parser.parse_args()
     if args.url:
         urls = parse_stiemap(args.url)
-        if args.bing_api_key:
-            push_to_bing(args.url, urls, args.bing_api_key)
-        else:
-            print('未配置 Bing API Key')
-            print('详情参见: https://ghlcode.cn/fe032806-5362-4d82-b746-a0b26ce8b9d9')
-        if args.baidu_token:
-            push_to_baidu(args.url, urls, args.baidu_token)
-        else:
-            print('未配置 Baidu Token')
-            print('详情参见: https://ghlcode.cn/fe032806-5362-4d82-b746-a0b26ce8b9d9')
+        if urls is not None:
+            if args.bing_api_key:
+                push_to_bing(args.url, urls, args.bing_api_key)
+            else:
+                print('未配置 Bing API Key')
+                print('详情参见: https://ghlcode.cn/fe032806-5362-4d82-b746-a0b26ce8b9d9')
+            if args.baidu_token:
+                push_to_baidu(args.url, urls, args.baidu_token)
+            else:
+                print('未配置 Baidu Token')
+                print('详情参见: https://ghlcode.cn/fe032806-5362-4d82-b746-a0b26ce8b9d9')
     else:
         print('请前往 Github Action Secrets 配置 URL')
         print('详情参见: https://ghlcode.cn/fe032806-5362-4d82-b746-a0b26ce8b9d9')

--- a/pushUrl.py
+++ b/pushUrl.py
@@ -8,8 +8,11 @@ ssl._create_default_https_context = ssl._create_unverified_context
 
 def parse_stiemap(site):
     site = f'{site}/sitemap.xml'
+    print('解析站点地图中，请稍后……')
     result = requests.get(site)
     big = re.findall('<loc>(.*?)</loc>', result.content.decode('utf-8'), re.S)
+    print('当前已有url:')
+    print(list(big))
     return list(big)
 
 
@@ -25,9 +28,9 @@ def push_to_bing(site, urls, api_key):
         response = requests.post(endpoint, json=payload)
         result = response.json()
         if response.status_code == 200:
-            print("successfully submitted to Bing.")
+            print("成功推送到Bing.")
         elif "ErrorCode" in result:
-            print("Error pushing URLs to Bing:", result["Message"])
+            print("推送到Bing出现错误，错误信息为：", result["Message"])
     except Exception as e:
         print("An error occurred:", e)
 
@@ -42,9 +45,9 @@ def push_to_baidu(site, urls, token):
         response = requests.post(api_url, data=payload, headers=headers)
         result = response.json()
         if "success" in result and result["success"]:
-            print("URLs successfully pushed to Baidu.")
+            print("成功推送到百度.")
         elif "error" in result:
-            print("Error pushing URLs to Baidu:", result["message"])
+            print("推送到百度出现错误，错误信息为：", result["message"])
         else:
             print("Unknown response from Baidu:", result)
     except Exception as e:
@@ -53,12 +56,22 @@ def push_to_baidu(site, urls, token):
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='parse sitemap')
-    parser.add_argument('url', type=str, help='The url of your website')
+    parser.add_argument('--url', type=str, help='The url of your website')
     parser.add_argument('--bing_api_key', type=str, default=None, help='your bing api key')
     parser.add_argument('--baidu_token', type=str, default=None, help='Your baidu push token')
     args = parser.parse_args()
-    urls = parse_stiemap(args.url)
-    if args.bing_api_key:
-        push_to_bing(args.url, urls, args.bing_api_key)
-    if args.baidu_token:
-        push_to_baidu(args.url, urls, args.baidu_token)
+    if args.url:
+        urls = parse_stiemap(args.url)
+        if args.bing_api_key:
+            push_to_bing(args.url, urls, args.bing_api_key)
+        else:
+            print('未配置 Bing API Key')
+            print('详情参见: https://ghlcode.cn/fe032806-5362-4d82-b746-a0b26ce8b9d9')
+        if args.baidu_token:
+            push_to_baidu(args.url, urls, args.baidu_token)
+        else:
+            print('未配置 Baidu Token')
+            print('详情参见: https://ghlcode.cn/fe032806-5362-4d82-b746-a0b26ce8b9d9')
+    else:
+        print('请前往 Github Action Secrets 配置 URL')
+        print('详情参见: https://ghlcode.cn/fe032806-5362-4d82-b746-a0b26ce8b9d9')


### PR DESCRIPTION
当用户未配置Action Secrets中的URL时每日定时推送会报错，github会发送一条邮件，可能会带来一些不便。
修复后，未配置Action Secrets则相关代码就不会执行。
具体如下：
未配置URL：则啥也不干
未配置Bing API KEY：则不推送至Bing
未配置Baidu Token：则不推送至百度

配置方法见: [https://ghlcode.cn/fe032806-5362-4d82-b746-a0b26ce8b9d9](https://ghlcode.cn/fe032806-5362-4d82-b746-a0b26ce8b9d9)