### PR TITLE
Fix: 修复 Medium 主题首页文章列表无封面图片时动画异常

### DIFF
--- a/components/LazyImage.js
+++ b/components/LazyImage.js
@@ -60,6 +60,7 @@ export default function LazyImage({
     ref: imageRef,
     src: imageLoaded ? src : placeholderSrc,
     alt: alt,
+    style: src ? style : { height: '0px', ...style },
     onLoad: handleImageLoad
   }
 

--- a/components/LazyImage.js
+++ b/components/LazyImage.js
@@ -60,7 +60,6 @@ export default function LazyImage({
     ref: imageRef,
     src: imageLoaded ? src : placeholderSrc,
     alt: alt,
-    style: src ? style : { height: '0px', ...style },
     onLoad: handleImageLoad
   }
 

--- a/themes/medium/components/BlogPostCard.js
+++ b/themes/medium/components/BlogPostCard.js
@@ -31,7 +31,7 @@ const BlogPostCard = ({ post, showSummary }) => {
                     }>
                     <div>
                         {CONFIG.POST_LIST_COVER && <div className='w-full max-h-96 object-cover overflow-hidden mb-2'>
-                            <LazyImage src={post.pageCoverThumbnail} className='w-full max-h-96 object-cover hover:scale-125 duration-150' />
+                            <LazyImage src={post.pageCoverThumbnail} style={post.pageCoverThumbnail ? {} : { height: '0px' }} className='w-full max-h-96 object-cover hover:scale-125 duration-150' />
                         </div>}
                         {post.title}
                     </div>


### PR DESCRIPTION
修复  #1569  
由于没有图片链接时 AOS 用默认图片没有固定高度，导致 AOS 计算高度异常。增加没有图片时自动给 img 标签高度为 0 的逻辑
NOTION_PAGE_ID=bd38f1769ad54d4987a479ef4d81abb3
修复前 https://notion-next-66i0xgkic-femoon.vercel.app/
修复后 https://femoon.top/