### PR TITLE
Fix 通过修改主题引入方式以及调整全局布局位置，修复页面闪烁的问题

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -14,11 +14,33 @@ import 'aos/dist/aos.css' // You can also use <link> for styles
 import dynamic from 'next/dynamic'
 import { isBrowser, loadExternalResource } from '@/lib/utils'
 import BLOG from '@/blog.config'
-
+import { getGlobalLayoutByTheme } from '@/themes/theme'
+import { useRouter } from 'next/router'
+import { useCallback, useMemo } from 'react'
+import { getQueryParam } from '../lib/utils'
 // 各种扩展插件 动画等
 const ExternalPlugins = dynamic(() => import('@/components/ExternalPlugins'))
 
 const MyApp = ({ Component, pageProps }) => {
+  /**
+   * 首页布局
+   * @param {*} props
+   * @returns
+   */
+  const route = useRouter()
+  const queryParam = useMemo(() => {
+    return getQueryParam(route.asPath, 'theme') || BLOG.THEME
+  }, [route])
+
+  const GLayout = useCallback(
+    props => {
+      // 根据页面路径加载不同Layout文件
+      const Layout = getGlobalLayoutByTheme(queryParam)
+      return <Layout {...props} />
+    },
+    [queryParam.asPath]
+  )
+
   // 自定义样式css和js引入
   if (isBrowser) {
     // 初始化AOS动画
@@ -48,10 +70,12 @@ const MyApp = ({ Component, pageProps }) => {
   }
 
   return (
-        <GlobalContextProvider {...pageProps}>
-            <Component {...pageProps} />
-            <ExternalPlugins {...pageProps} />
-        </GlobalContextProvider>
+    <GlobalContextProvider {...pageProps}>
+      <GLayout {...pageProps}>
+        <Component {...pageProps} />
+      </GLayout>
+      <ExternalPlugins {...pageProps} />
+    </GlobalContextProvider>
   )
 }
 

--- a/themes/example/index.js
+++ b/themes/example/index.js
@@ -133,9 +133,9 @@ const LayoutPostList = props => {
     slotTop = props.slotTop
   }
   return (
-        <LayoutBase {...props} slotTop={slotTop}>
+        <div {...props} slotTop={slotTop}>
             {BLOG.POST_LIST_STYLE === 'page' ? <BlogListPage {...props} /> : <BlogListScroll {...props} />}
-        </LayoutBase>
+        </div>
   )
 }
 
@@ -147,7 +147,7 @@ const LayoutPostList = props => {
 const LayoutSlug = props => {
   const { post, lock, validPassword } = props
   return (
-        <LayoutBase {...props}>
+        <div {...props}>
             {lock
               ? <ArticleLock validPassword={validPassword} />
               : <div id="article-wrapper" className="px-2">
@@ -156,7 +156,7 @@ const LayoutSlug = props => {
                     <ShareBar post={post} />
                     <Comment frontMatter={post} />
                 </div>}
-        </LayoutBase>
+        </div>
   )
 }
 
@@ -166,7 +166,7 @@ const LayoutSlug = props => {
  * @returns
  */
 const Layout404 = (props) => {
-  return <LayoutBase {...props}>404 Not found.</LayoutBase>
+  return <div {...props}>404 Not found.</div>
 }
 
 /**
@@ -207,13 +207,13 @@ const LayoutSearch = props => {
 const LayoutArchive = props => {
   const { archivePosts } = props
   return (
-        <LayoutBase {...props}>
+        <div {...props}>
             <div className="mb-10 pb-20 md:py-12 p-3  min-h-screen w-full">
                 {Object.keys(archivePosts).map(archiveTitle => (
                     <BlogListGroupByDate key={archiveTitle} archiveTitle={archiveTitle} archivePosts={archivePosts} />
                 ))}
             </div>
-        </LayoutBase>
+        </div>
   )
 }
 
@@ -225,11 +225,11 @@ const LayoutArchive = props => {
 const LayoutCategoryIndex = props => {
   const { categoryOptions } = props
   return (
-        <LayoutBase {...props}>
+        <div {...props}>
             <div id='category-list' className='duration-200 flex flex-wrap'>
                 {categoryOptions?.map(category => <CategoryItem key={category.name} category={category} />)}
             </div>
-        </LayoutBase>
+        </div>
   )
 }
 
@@ -241,16 +241,17 @@ const LayoutCategoryIndex = props => {
 const LayoutTagIndex = (props) => {
   const { tagOptions } = props
   return (
-        <LayoutBase {...props}>
+        <div {...props}>
             <div id='tags-list' className='duration-200 flex flex-wrap'>
                 {tagOptions.map(tag => <TagItem key={tag.name} tag={tag} />)}
             </div>
-        </LayoutBase>
+        </div>
   )
 }
 
 export {
   CONFIG as THEME_CONFIG,
+  LayoutBase,
   LayoutIndex,
   LayoutPostList,
   LayoutSearch,

--- a/themes/fukasawa/index.js
+++ b/themes/fukasawa/index.js
@@ -123,9 +123,9 @@ const LayoutIndex = (props) => {
  * @param {*} props
             */
 const LayoutPostList = (props) => {
-  return <LayoutBase {...props}>
+  return <div {...props}>
         {BLOG.POST_LIST_STYLE === 'page' ? <BlogListPage {...props} /> : <BlogListScroll {...props} />}
-    </LayoutBase>
+    </div>
 }
 
 /**
@@ -136,9 +136,9 @@ const LayoutPostList = (props) => {
 const LayoutSlug = (props) => {
   const { lock, validPassword } = props
   return (
-        <LayoutBase {...props} >
+        <div {...props} >
             {lock ? <ArticleLock validPassword={validPassword} /> : <ArticleDetail {...props} />}
-        </LayoutBase>
+        </div>
   )
 }
 
@@ -168,7 +168,7 @@ const LayoutSearch = props => {
  */
 const LayoutArchive = (props) => {
   const { archivePosts } = props
-  return <LayoutBase {...props}>
+  return <div {...props}>
         <div className="mb-10 pb-20 bg-white md:p-12 p-3 dark:bg-gray-800 shadow-md min-h-full">
             {Object.keys(archivePosts).map(archiveTitle => (
                 <BlogArchiveItem
@@ -178,7 +178,7 @@ const LayoutArchive = (props) => {
                 />
             ))}
         </div>
-    </LayoutBase>
+    </div>
 }
 
 /**
@@ -187,7 +187,7 @@ const LayoutArchive = (props) => {
             * @returns
             */
 const Layout404 = props => {
-  return <LayoutBase {...props}>404</LayoutBase>
+  return <div {...props}>404</div>
 }
 
 /**
@@ -199,7 +199,7 @@ const LayoutCategoryIndex = (props) => {
   const { locale } = useGlobal()
   const { categoryOptions } = props
   return (
-        <LayoutBase {...props}>
+        <div {...props}>
             <div className='bg-white dark:bg-gray-700 px-10 py-10 shadow'>
                 <div className='dark:text-gray-200 mb-5'>
                     <i className='mr-4 fas fa-th' />{locale.COMMON.CATEGORY}:
@@ -221,7 +221,7 @@ const LayoutCategoryIndex = (props) => {
                     })}
                 </div>
             </div>
-        </LayoutBase>
+        </div>
   )
 }
 
@@ -233,7 +233,7 @@ const LayoutCategoryIndex = (props) => {
 const LayoutTagIndex = (props) => {
   const { locale } = useGlobal()
   const { tagOptions } = props
-  return <LayoutBase {...props} >
+  return <div {...props} >
         <div className='bg-white dark:bg-gray-700 px-10 py-10 shadow'>
             <div className='dark:text-gray-200 mb-5'><i className='mr-4 fas fa-tag' />{locale.COMMON.TAGS}:</div>
             <div id="tags-list" className="duration-200 flex flex-wrap ml-8">
@@ -246,11 +246,12 @@ const LayoutTagIndex = (props) => {
                 })}
             </div>
         </div>
-    </LayoutBase>
+    </div>
 }
 
 export {
   CONFIG as THEME_CONFIG,
+  LayoutBase,
   LayoutIndex,
   LayoutSearch,
   LayoutArchive,

--- a/themes/gitbook/index.js
+++ b/themes/gitbook/index.js
@@ -189,7 +189,7 @@ const LayoutIndex = (props) => {
     })
   }, [])
 
-  return <LayoutBase {...props} />
+  return <div {...props} />
 }
 
 /**
@@ -199,9 +199,9 @@ const LayoutIndex = (props) => {
  * @returns
  */
 const LayoutPostList = (props) => {
-  return <LayoutBase {...props} >
+  return <div {...props} >
             <div className='mt-10'><BlogPostListPage {...props} /></div>
-    </LayoutBase>
+    </div>
 }
 
 /**
@@ -213,7 +213,7 @@ const LayoutSlug = (props) => {
   const { post, prev, next, lock, validPassword } = props
 
   return (
-        <LayoutBase {...props} >
+        <div {...props} >
             {/* 文章锁 */}
             {lock && <ArticleLock validPassword={validPassword} />}
 
@@ -246,7 +246,7 @@ const LayoutSlug = (props) => {
 
                 <TocDrawer {...props} />
             </div>}
-        </LayoutBase>
+        </div>
   )
 }
 
@@ -257,7 +257,7 @@ const LayoutSlug = (props) => {
  * @returns
  */
 const LayoutSearch = (props) => {
-  return <LayoutBase {...props}></LayoutBase>
+  return <div {...props}></div>
 }
 
 /**
@@ -269,20 +269,20 @@ const LayoutSearch = (props) => {
 const LayoutArchive = (props) => {
   const { archivePosts } = props
 
-  return <LayoutBase {...props}>
+  return <div {...props}>
         <div className="mb-10 pb-20 md:py-12 py-3  min-h-full">
             {Object.keys(archivePosts)?.map(archiveTitle => <BlogArchiveItem key={archiveTitle} archiveTitle={archiveTitle} archivePosts={archivePosts} />)}
         </div>
-  </LayoutBase>
+  </div>
 }
 
 /**
  * 404
  */
 const Layout404 = props => {
-  return <LayoutBase {...props}>
+  return <div {...props}>
         <div className='w-full h-96 py-80 flex justify-center items-center'>404 Not found.</div>
-    </LayoutBase>
+    </div>
 }
 
 /**
@@ -291,7 +291,7 @@ const Layout404 = props => {
 const LayoutCategoryIndex = (props) => {
   const { categoryOptions } = props
   const { locale } = useGlobal()
-  return <LayoutBase {...props}>
+  return <div {...props}>
      <div className='bg-white dark:bg-gray-700 py-10'>
                 <div className='dark:text-gray-200 mb-5'>
                     <i className='mr-4 fas fa-th' />{locale.COMMON.CATEGORY}:
@@ -313,7 +313,7 @@ const LayoutCategoryIndex = (props) => {
                     })}
                 </div>
             </div>
-  </LayoutBase>
+  </div>
 }
 
 /**
@@ -323,7 +323,7 @@ const LayoutTagIndex = (props) => {
   const { tagOptions } = props
   const { locale } = useGlobal()
 
-  return <LayoutBase {...props}>
+  return <div {...props}>
      <div className="bg-white dark:bg-gray-700 py-10">
                 <div className="dark:text-gray-200 mb-5">
                     <i className="mr-4 fas fa-tag" />
@@ -339,11 +339,12 @@ const LayoutTagIndex = (props) => {
                     })}
                 </div>
             </div>
-  </LayoutBase>
+  </div>
 }
 
 export {
   CONFIG as THEME_CONFIG,
+  LayoutBase,
   LayoutIndex,
   LayoutSearch,
   LayoutArchive,

--- a/themes/heo/index.js
+++ b/themes/heo/index.js
@@ -126,7 +126,7 @@ const LayoutIndex = props => {
   const slotRight = <SideRight {...props} />
 
   return (
-    <LayoutBase {...props} slotRight={slotRight} headerSlot={headerSlot}>
+    <div {...props} slotRight={slotRight} headerSlot={headerSlot}>
       <div id="post-outer-wrapper" className="px-5 md:px-0">
         {/* 文章分类条 */}
         <CategoryBar {...props} />
@@ -138,7 +138,7 @@ const LayoutIndex = props => {
           <BlogPostListScroll {...props} />
             )}
       </div>
-    </LayoutBase>
+    </div>
   )
 }
 
@@ -160,7 +160,7 @@ const LayoutPostList = props => {
   )
 
   return (
-    <LayoutBase {...props} slotRight={slotRight} headerSlot={headerSlot}>
+    <div {...props} slotRight={slotRight} headerSlot={headerSlot}>
       <div id="post-outer-wrapper" className="px-5  md:px-0">
         {/* 文章分类条 */}
         <CategoryBar {...props} />
@@ -172,7 +172,7 @@ const LayoutPostList = props => {
           <BlogPostListScroll {...props} />
             )}
       </div>
-    </LayoutBase>
+    </div>
   )
 }
 
@@ -211,7 +211,7 @@ const LayoutSearch = props => {
     }
   }, [])
   return (
-    <LayoutBase
+    <div
       {...props}
       currentSearch={currentSearch}
       headerSlot={headerSlot}
@@ -233,7 +233,7 @@ const LayoutSearch = props => {
           </div>
             )}
       </div>
-    </LayoutBase>
+    </div>
   )
 }
 
@@ -259,7 +259,7 @@ const LayoutArchive = props => {
   // 归档页顶部显示条，如果是默认归档则不显示。分类详情页显示分类列表，标签详情页显示当前标签
 
   return (
-    <LayoutBase {...props} slotRight={slotRight} headerSlot={headerSlot}>
+    <div {...props} slotRight={slotRight} headerSlot={headerSlot}>
       <div className="p-5 rounded-xl border dark:border-gray-600 max-w-6xl w-full bg-white dark:bg-[#1e1e1e]">
         {/* 文章分类条 */}
         <CategoryBar {...props} border={false} />
@@ -274,7 +274,7 @@ const LayoutArchive = props => {
           ))}
         </div>
       </div>
-    </LayoutBase>
+    </div>
   )
 }
 
@@ -313,7 +313,7 @@ const LayoutSlug = props => {
   )
 
   return (
-    <LayoutBase
+    <div
       {...props}
       headerSlot={headerSlot}
       showCategory={false}
@@ -377,7 +377,7 @@ const LayoutSlug = props => {
         )}
       </div>
       <FloatTocButton {...props} />
-    </LayoutBase>
+    </div>
   )
 }
 
@@ -474,7 +474,7 @@ const LayoutCategoryIndex = props => {
   )
 
   return (
-    <LayoutBase {...props} className="mt-8" headerSlot={headerSlot}>
+    <div {...props} className="mt-8" headerSlot={headerSlot}>
       <div id="category-outer-wrapper" className="px-5 md:px-0">
         <div className="text-4xl font-extrabold dark:text-gray-200 mb-5">
           {locale.COMMON.CATEGORY}
@@ -507,7 +507,7 @@ const LayoutCategoryIndex = props => {
           })}
         </div>
       </div>
-    </LayoutBase>
+    </div>
   )
 }
 
@@ -528,7 +528,7 @@ const LayoutTagIndex = props => {
     </header>
   )
   return (
-    <LayoutBase {...props} className="mt-8" headerSlot={headerSlot}>
+    <div {...props} className="mt-8" headerSlot={headerSlot}>
       <div id="tag-outer-wrapper" className="px-5  md:px-0">
         <div className="text-4xl font-extrabold dark:text-gray-200 mb-5">
           {locale.COMMON.TAGS}
@@ -561,12 +561,13 @@ const LayoutTagIndex = props => {
           })}
         </div>
       </div>
-    </LayoutBase>
+    </div>
   )
 }
 
 export {
   CONFIG as THEME_CONFIG,
+  LayoutBase,
   LayoutIndex,
   LayoutSearch,
   LayoutArchive,

--- a/themes/hexo/index.js
+++ b/themes/hexo/index.js
@@ -122,10 +122,10 @@ const LayoutIndex = (props) => {
  * @returns
  */
 const LayoutPostList = (props) => {
-  return <LayoutBase {...props} className='pt-8'>
+  return <div {...props} className='pt-8'>
         <SlotBar {...props} />
         {BLOG.POST_LIST_STYLE === 'page' ? <BlogPostListPage {...props} /> : <BlogPostListScroll {...props} />}
-    </LayoutBase>
+    </div>
 }
 
 /**
@@ -152,11 +152,11 @@ const LayoutSearch = props => {
   })
 
   return (
-        <LayoutBase {...props} currentSearch={currentSearch} className='pt-8'>
+        <div {...props} currentSearch={currentSearch} className='pt-8'>
             {!currentSearch
               ? <SearchNav {...props} />
               : <div id="posts-wrapper"> {BLOG.POST_LIST_STYLE === 'page' ? <BlogPostListPage {...props} /> : <BlogPostListScroll {...props} />}  </div>}
-        </LayoutBase>
+        </div>
   )
 }
 
@@ -167,7 +167,7 @@ const LayoutSearch = props => {
  */
 const LayoutArchive = (props) => {
   const { archivePosts } = props
-  return <LayoutBase {...props} className='pt-8'>
+  return <div {...props} className='pt-8'>
         <Card className='w-full'>
             <div className="mb-10 pb-20 bg-white md:p-12 p-3 min-h-full dark:bg-hexo-black-gray">
                 {Object.keys(archivePosts).map(archiveTitle => (
@@ -179,7 +179,7 @@ const LayoutArchive = (props) => {
                 ))}
             </div>
         </Card>
-    </LayoutBase>
+    </div>
 }
 
 /**
@@ -205,7 +205,7 @@ const LayoutSlug = props => {
     </>
 
   return (
-        <LayoutBase {...props} headerSlot={<PostHeader {...props} />} showCategory={false} showTag={false} floatSlot={floatSlot} >
+        <div {...props} headerSlot={<PostHeader {...props} />} showCategory={false} showTag={false} floatSlot={floatSlot} >
             <div className="w-full lg:hover:shadow lg:border rounded-t-xl lg:rounded-xl lg:px-2 lg:py-4 bg-white dark:bg-hexo-black-gray dark:border-black article">
                 {lock && <ArticleLock validPassword={validPassword} />}
 
@@ -240,7 +240,7 @@ const LayoutSlug = props => {
                 <TocDrawer post={post} cRef={drawerRight} targetRef={targetRef} />
             </div>
 
-        </LayoutBase>
+        </div>
   )
 }
 
@@ -265,7 +265,7 @@ const Layout404 = props => {
     }, 3000)
   })
   return (
-        <LayoutBase {...props}>
+        <div {...props}>
             <div className="text-black w-full h-screen text-center justify-center content-center items-center flex flex-col">
                 <div className="dark:text-gray-200">
                     <h2 className="inline-block border-r-2 border-gray-600 mr-2 px-3 py-2 align-top">
@@ -276,7 +276,7 @@ const Layout404 = props => {
                     </div>
                 </div>
             </div>
-        </LayoutBase>
+        </div>
   )
 }
 
@@ -289,7 +289,7 @@ const LayoutCategoryIndex = props => {
   const { categoryOptions } = props
   const { locale } = useGlobal()
   return (
-        <LayoutBase {...props} className='mt-8'>
+        <div {...props} className='mt-8'>
             <Card className="w-full min-h-screen">
                 <div className="dark:text-gray-200 mb-5 mx-3">
                     <i className="mr-4 fas fa-th" />  {locale.COMMON.CATEGORY}:
@@ -306,7 +306,7 @@ const LayoutCategoryIndex = props => {
                     })}
                 </div>
             </Card>
-        </LayoutBase>
+        </div>
   )
 }
 
@@ -319,7 +319,7 @@ const LayoutTagIndex = props => {
   const { tagOptions } = props
   const { locale } = useGlobal()
   return (
-        <LayoutBase {...props} className='mt-8'>
+        <div {...props} className='mt-8'>
             <Card className='w-full'>
                 <div className="dark:text-gray-200 mb-5 ml-4">
                     <i className="mr-4 fas fa-tag" /> {locale.COMMON.TAGS}:
@@ -330,12 +330,13 @@ const LayoutTagIndex = props => {
                     </div>)}
                 </div>
             </Card>
-        </LayoutBase>
+        </div>
   )
 }
 
 export {
   CONFIG as THEME_CONFIG,
+  LayoutBase,
   LayoutIndex,
   LayoutSearch,
   LayoutArchive,

--- a/themes/index.js
+++ b/themes/index.js
@@ -1,0 +1,15 @@
+import * as EXAMPLE from './example'
+import * as FUKASAWA from './fukasawa'
+import * as GITBOOK from './gitbook'
+import * as HEXO from './hexo'
+import * as HEO from './heo'
+import * as LANDING from './landing'
+import * as MATERY from './matery'
+import * as MEDIUM from './medium'
+import * as NAV from './nav'
+import * as NEXT from './next'
+import * as NOBELIUM from './nobelium'
+import * as PLOG from './plog'
+import * as SIMPLE from './simple'
+
+export {EXAMPLE, FUKASAWA, GITBOOK, HEO, HEXO, LANDING, MATERY, MEDIUM, NAV, NOBELIUM, PLOG, SIMPLE, NEXT}

--- a/themes/landing/index.js
+++ b/themes/landing/index.js
@@ -63,13 +63,13 @@ const LayoutBase = (props) => {
  */
 const LayoutIndex = (props) => {
     return (
-        <LayoutBase {...props}>
+        <div {...props}>
             <Hero />
             <Features />
             <FeaturesBlocks />
             <Testimonials />
             <Newsletter />
-        </LayoutBase>
+        </div>
     )
 }
 
@@ -87,23 +87,23 @@ const LayoutSlug = (props) => {
         return  <div id='theme-landing'><Loading /></div>
     }
 
-    return <LayoutBase {...props}>
+    return <div {...props}>
 
         <div id='container-inner' className='mx-auto max-w-screen-lg p-12'>
             <NotionPage {...props} />
         </div>
-    </LayoutBase>
+    </div>
 
 
 }
 
 // 其他布局暂时留空
-const LayoutSearch = (props) => <LayoutBase {...props}><Hero /></LayoutBase>
-const LayoutArchive = (props) => <LayoutBase {...props}><Hero /></LayoutBase>
-const Layout404 = (props) => <LayoutBase {...props}><Hero /></LayoutBase>
-const LayoutCategoryIndex = (props) => <LayoutBase {...props}><Hero /></LayoutBase>
-const LayoutPostList = (props) => <LayoutBase {...props}><Hero /></LayoutBase>
-const LayoutTagIndex = (props) => <LayoutBase {...props}><Hero /></LayoutBase>
+const LayoutSearch = (props) => <div {...props}><Hero /></div>
+const LayoutArchive = (props) => <div {...props}><Hero /></div>
+const Layout404 = (props) => <div {...props}><Hero /></div>
+const LayoutCategoryIndex = (props) => <div {...props}><Hero /></div>
+const LayoutPostList = (props) => <div {...props}><Hero /></div>
+const LayoutTagIndex = (props) => <div {...props}><Hero /></div>
 
 export {
     THEME_CONFIG,

--- a/themes/matery/index.js
+++ b/themes/matery/index.js
@@ -123,9 +123,9 @@ const LayoutIndex = (props) => {
  */
 const LayoutPostList = (props) => {
   return (
-        <LayoutBase {...props} containerSlot={<BlogListBar {...props} />}>
+        <div {...props} containerSlot={<BlogListBar {...props} />}>
             {BLOG.POST_LIST_STYLE === 'page' ? <BlogPostListPage {...props} /> : <BlogPostListScroll {...props} />}
-        </LayoutBase>
+        </div>
   )
 }
 
@@ -152,13 +152,13 @@ const LayoutSearch = props => {
     }
   })
   return (
-        <LayoutBase {...props} currentSearch={currentSearch}>
+        <div {...props} currentSearch={currentSearch}>
             {!currentSearch
               ? <SearchNave {...props} />
               : <div id="posts-wrapper">
                     {BLOG.POST_LIST_STYLE === 'page' ? <BlogPostListPage {...props} /> : <BlogPostListScroll {...props} />}
                 </div>}
-        </LayoutBase>
+        </div>
   )
 }
 
@@ -169,7 +169,7 @@ const LayoutSearch = props => {
  */
 const LayoutArchive = (props) => {
   const { archivePosts } = props
-  return <LayoutBase {...props} headerSlot={<PostHeader {...props} />} >
+  return <div {...props} headerSlot={<PostHeader {...props} />} >
         <Card className='w-full -mt-32'>
             <div className="mb-10 pb-20 bg-white md:p-12 p-3 min-h-full dark:bg-hexo-black-gray">
                 {Object.keys(archivePosts).map(archiveTitle => (
@@ -181,7 +181,7 @@ const LayoutArchive = (props) => {
                 ))}
             </div>
         </Card>
-    </LayoutBase>
+    </div>
 }
 
 /**
@@ -192,7 +192,7 @@ const LayoutArchive = (props) => {
 const LayoutSlug = props => {
   const { post, lock, validPassword } = props
 
-  return (<LayoutBase {...props} headerSlot={<PostHeader {...props} />} showCategory={false} showTag={false} floatRightBottom={<JumpToCommentButton />}>
+  return (<div {...props} headerSlot={<PostHeader {...props} />} showCategory={false} showTag={false} floatRightBottom={<JumpToCommentButton />}>
 
         <div id='inner-wrapper' className={'w-full lg:max-w-3xl 2xl:max-w-4xl'} >
 
@@ -255,7 +255,7 @@ const LayoutSlug = props => {
 
         </div>
 
-    </LayoutBase>
+    </div>
   )
 }
 
@@ -278,7 +278,7 @@ const Layout404 = props => {
     }, 3000)
   })
   return (
-        <LayoutBase {...props}>
+        <div {...props}>
             <div className="text-black w-full h-screen text-center justify-center content-center items-center flex flex-col">
                 <div className="dark:text-gray-200">
                     <h2 className="inline-block border-r-2 border-gray-600 mr-2 px-3 py-2 align-top">
@@ -289,7 +289,7 @@ const Layout404 = props => {
                     </div>
                 </div>
             </div>
-        </LayoutBase>
+        </div>
   )
 }
 
@@ -302,7 +302,7 @@ const LayoutCategoryIndex = props => {
   const { categoryOptions } = props
 
   return (
-        <LayoutBase {...props} headerSlot={<PostHeader {...props} />} >
+        <div {...props} headerSlot={<PostHeader {...props} />} >
 
             <div id='inner-wrapper' className='w-full'>
                 <div className="drop-shadow-xl -mt-32 rounded-md mx-3 px-5 lg:border lg:rounded-xl lg:px-2 lg:py-4 bg-white dark:bg-hexo-black-gray  dark:border-black dark:text-gray-300">
@@ -319,7 +319,7 @@ const LayoutCategoryIndex = props => {
                     </div>
                 </div>
             </div>
-        </LayoutBase>
+        </div>
   )
 }
 
@@ -332,7 +332,7 @@ const LayoutTagIndex = props => {
   const { tagOptions } = props
   const { locale } = useGlobal()
   return (
-        <LayoutBase {...props} headerSlot={<PostHeader {...props} />} >
+        <div {...props} headerSlot={<PostHeader {...props} />} >
             <div id='inner-wrapper' className='w-full drop-shadow-xl'>
 
                 <div className="-mt-32 rounded-md mx-3 px-5 lg:border lg:rounded-xl lg:px-2 lg:py-4 bg-white dark:bg-hexo-black-gray  dark:border-black">
@@ -352,12 +352,13 @@ const LayoutTagIndex = props => {
                     </div>
                 </div>
             </div>
-        </LayoutBase>
+        </div>
   )
 }
 
 export {
   CONFIG as THEME_CONFIG,
+  LayoutBase,
   LayoutIndex,
   LayoutPostList,
   LayoutSearch,

--- a/themes/medium/index.js
+++ b/themes/medium/index.js
@@ -136,9 +136,9 @@ const LayoutIndex = (props) => {
  */
 const LayoutPostList = (props) => {
   const slotTop = <BlogPostBar {...props} />
-  return <LayoutBase {...props} slotTop={slotTop}>
+  return <div {...props} slotTop={slotTop}>
         {BLOG.POST_LIST_STYLE === 'page' ? <BlogPostListPage {...props} /> : <BlogPostListScroll {...props} />}
-    </LayoutBase>
+    </div>
 }
 
 /**
@@ -156,7 +156,7 @@ const LayoutSlug = props => {
   )
 
   return (
-        <LayoutBase showInfoCard={true} slotRight={slotRight} {...props} >
+        <div showInfoCard={true} slotRight={slotRight} {...props} >
             {/* 文章锁 */}
             {lock && <ArticleLock validPassword={validPassword} />}
 
@@ -190,7 +190,7 @@ const LayoutSlug = props => {
                 {/* 移动端目录 */}
                 <TocDrawer {...props} />
             </div>}
-        </LayoutBase>
+        </div>
   )
 }
 
@@ -218,7 +218,7 @@ const LayoutSearch = (props) => {
     }
   }, [])
 
-  return <LayoutBase {...props}>
+  return <div {...props}>
 
         {/* 搜索导航栏 */}
         <div className='py-12'>
@@ -234,7 +234,7 @@ const LayoutSearch = (props) => {
         {currentSearch && <div>
             {BLOG.POST_LIST_STYLE === 'page' ? <BlogPostListPage {...props} /> : <BlogPostListScroll {...props} />}
         </div>}
-    </LayoutBase>
+    </div>
 }
 
 /**
@@ -245,12 +245,12 @@ const LayoutSearch = (props) => {
 const LayoutArchive = props => {
   const { archivePosts } = props
   return (
-        <LayoutBase {...props}>
+        <div {...props}>
             <div className="mb-10 pb-20 md:py-12 py-3  min-h-full">
                 {Object.keys(archivePosts)?.map(archiveTitle => <BlogArchiveItem key={archiveTitle} archiveTitle={archiveTitle} archivePosts={archivePosts} />
                 )}
             </div>
-        </LayoutBase>
+        </div>
   )
 }
 
@@ -260,9 +260,9 @@ const LayoutArchive = props => {
  * @returns
  */
 const Layout404 = props => {
-  return <LayoutBase {...props}>
+  return <div {...props}>
         <div className='w-full h-96 py-80 flex justify-center items-center'>404 Not found.</div>
-    </LayoutBase>
+    </div>
 }
 
 /**
@@ -274,7 +274,7 @@ const LayoutCategoryIndex = (props) => {
   const { categoryOptions } = props
   const { locale } = useGlobal()
   return (
-        <LayoutBase {...props}>
+        <div {...props}>
             <div className='bg-white dark:bg-gray-700 py-10'>
                 <div className='dark:text-gray-200 mb-5'>
                     <i className='mr-4 fas fa-th' />{locale.COMMON.CATEGORY}:
@@ -296,7 +296,7 @@ const LayoutCategoryIndex = (props) => {
                     })}
                 </div>
             </div>
-        </LayoutBase>
+        </div>
   )
 }
 
@@ -309,7 +309,7 @@ const LayoutTagIndex = props => {
   const { tagOptions } = props
   const { locale } = useGlobal()
   return (
-        <LayoutBase {...props}>
+        <div {...props}>
             <div className="bg-white dark:bg-gray-700 py-10">
                 <div className="dark:text-gray-200 mb-5">
                     <i className="mr-4 fas fa-tag" />
@@ -325,12 +325,13 @@ const LayoutTagIndex = props => {
                     })}
                 </div>
             </div>
-        </LayoutBase>
+        </div>
   )
 }
 
 export {
   CONFIG as THEME_CONFIG,
+  LayoutBase,
   LayoutIndex,
   LayoutPostList,
   LayoutSearch,

--- a/themes/nav/index.js
+++ b/themes/nav/index.js
@@ -172,10 +172,10 @@ const LayoutPostListIndex = props => {
   // const { customMenu, children, post, allNavPages, categoryOptions, slotLeft, slotRight, slotTop, meta } = props
   // const [filteredNavPages, setFilteredNavPages] = useState(allNavPages)
   return (
-    <LayoutBase {...props} >
+    <div {...props} >
         <Announcement {...props} />
         <BlogPostListAll { ...props } />
-    </LayoutBase>
+    </div>
   )
 }
 
@@ -189,7 +189,7 @@ const LayoutPostList = props => {
   // 顶部如果是按照分类或标签查看文章列表，列表顶部嵌入一个横幅
   // 如果是搜索，则列表顶部嵌入 搜索框
   return (
-    <LayoutBase {...props} >
+    <div {...props} >
         <div className='w-full max-w-7xl mx-auto justify-center mt-8'>
             <div id='posts-wrapper' class='card-list grid gap-4 sm:grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5'>
                 {posts?.map(post => (
@@ -197,7 +197,7 @@ const LayoutPostList = props => {
                 ))}
             </div>
         </div>
-    </LayoutBase>
+    </div>
   )
 }
 
@@ -210,7 +210,7 @@ const LayoutSlug = (props) => {
   const { post, lock, validPassword } = props
 
   return (
-        <LayoutBase {...props} >
+        <div {...props} >
             {/* 文章锁 */}
             {lock && <ArticleLock validPassword={validPassword} />}
 
@@ -244,7 +244,7 @@ const LayoutSlug = (props) => {
 
                 <TocDrawer {...props} />
             </div>}
-        </LayoutBase>
+        </div>
   )
 }
 
@@ -255,7 +255,7 @@ const LayoutSlug = (props) => {
  * @returns
  */
 const LayoutSearch = (props) => {
-  return <LayoutBase {...props}></LayoutBase>
+  return <div {...props}></div>
 }
 
 /**
@@ -267,20 +267,20 @@ const LayoutSearch = (props) => {
 const LayoutArchive = (props) => {
   const { archivePosts } = props
 
-  return <LayoutBase {...props}>
+  return <div {...props}>
         <div className="mb-10 pb-20 md:py-12 py-3  min-h-full">
             {Object.keys(archivePosts)?.map(archiveTitle => <BlogArchiveItem key={archiveTitle} archiveTitle={archiveTitle} archivePosts={archivePosts} />)}
         </div>
-  </LayoutBase>
+  </div>
 }
 
 /**
  * 404
  */
 const Layout404 = props => {
-  return <LayoutBase {...props}>
+  return <div {...props}>
         <div className='w-full h-96 py-80 flex justify-center items-center'>404 Not found.</div>
-    </LayoutBase>
+    </div>
 }
 
 /**
@@ -289,7 +289,7 @@ const Layout404 = props => {
 const LayoutCategoryIndex = (props) => {
   const { categoryOptions } = props
   const { locale } = useGlobal()
-  return <LayoutBase {...props}>
+  return <div {...props}>
      <div className='bg-white dark:bg-gray-700 py-10'>
                 <div className='dark:text-gray-200 mb-5'>
                     <i className='mr-4 fas fa-th' />{locale.COMMON.CATEGORY}:
@@ -311,7 +311,7 @@ const LayoutCategoryIndex = (props) => {
                     })}
                 </div>
             </div>
-  </LayoutBase>
+  </div>
 }
 
 /**
@@ -321,7 +321,7 @@ const LayoutTagIndex = (props) => {
   const { tagOptions } = props
   const { locale } = useGlobal()
 
-  return <LayoutBase {...props}>
+  return <div {...props}>
      <div className="bg-white dark:bg-gray-700 py-10">
                 <div className="dark:text-gray-200 mb-5">
                     <i className="mr-4 fas fa-tag" />
@@ -337,11 +337,12 @@ const LayoutTagIndex = (props) => {
                     })}
                 </div>
             </div>
-  </LayoutBase>
+  </div>
 }
 
 export {
   CONFIG as THEME_CONFIG,
+  LayoutBase,
   LayoutIndex,
   LayoutSearch,
   LayoutArchive,

--- a/themes/next/index.js
+++ b/themes/next/index.js
@@ -140,7 +140,7 @@ const LayoutIndex = (props) => {
  * @returns
  */
 const LayoutPostList = (props) => {
-  return <LayoutBase {...props} >
+  return <div {...props} >
 
         <BlogListBar {...props} />
 
@@ -148,7 +148,7 @@ const LayoutPostList = (props) => {
           ? <BlogPostListScroll {...props} showSummary={true} />
           : <BlogPostListPage {...props} />
         }
-    </LayoutBase>
+    </div>
 }
 
 /**
@@ -174,7 +174,7 @@ const LayoutSearch = (props) => {
   }, [])
 
   return (
-        <LayoutBase {...props} >
+        <div {...props} >
             <StickyBar>
                 <div className="p-4 dark:text-gray-200">
                     <i className="mr-1 fas fa-search" />{' '}
@@ -187,7 +187,7 @@ const LayoutSearch = (props) => {
                   : <BlogPostListPage {...props} />
                 }
             </div>
-        </LayoutBase>
+        </div>
   )
 }
 
@@ -210,7 +210,7 @@ const Layout404 = props => {
     }, 3000)
   }, [])
 
-  return <LayoutBase {...props}>
+  return <div {...props}>
         <div className='md:-mt-20 text-black w-full h-screen text-center justify-center content-center items-center flex flex-col'>
             <div className='dark:text-gray-200'>
                 <h2 className='inline-block border-r-2 border-gray-600 mr-2 px-3 py-2 align-top'><i className='mr-2 fas fa-spinner animate-spin' />404</h2>
@@ -219,7 +219,7 @@ const Layout404 = props => {
                 </div>
             </div>
         </div>
-    </LayoutBase>
+    </div>
 }
 
 /**
@@ -231,7 +231,7 @@ const LayoutArchive = (props) => {
   const { archivePosts } = props
 
   return (
-        <LayoutBase {...props}>
+        <div {...props}>
             <div className="mb-10 pb-20 bg-white md:p-12 p-3 dark:bg-hexo-black-gray shadow-md min-h-full">
                 {Object.keys(archivePosts).map(archiveTitle => (
                     <BlogPostArchive
@@ -241,7 +241,7 @@ const LayoutArchive = (props) => {
                     />
                 ))}
             </div>
-        </LayoutBase>
+        </div>
   )
 }
 
@@ -261,7 +261,7 @@ const LayoutSlug = (props) => {
     </div>
 
   return (
-        <LayoutBase {...props} floatSlot={floatSlot}>
+        <div {...props} floatSlot={floatSlot}>
 
             {post && !lock && <ArticleDetail {...props} />}
 
@@ -272,7 +272,7 @@ const LayoutSlug = (props) => {
                 <TocDrawer post={post} cRef={drawerRight} targetRef={targetRef} />
             </div>}
 
-        </LayoutBase>
+        </div>
   )
 }
 
@@ -285,7 +285,7 @@ const LayoutCategoryIndex = (props) => {
   const { allPosts, categoryOptions } = props
   const { locale } = useGlobal()
   return (
-        <LayoutBase totalPosts={allPosts} {...props}>
+        <div totalPosts={allPosts} {...props}>
             <div className='bg-white dark:bg-hexo-black-gray px-10 py-10 shadow h-full'>
                 <div className='dark:text-gray-200 mb-5'>
                     <i className='mr-4 fas faTh' />{locale.COMMON.CATEGORY}:
@@ -307,7 +307,7 @@ const LayoutCategoryIndex = (props) => {
                     })}
                 </div>
             </div>
-        </LayoutBase>
+        </div>
   )
 }
 
@@ -319,7 +319,7 @@ const LayoutCategoryIndex = (props) => {
 const LayoutTagIndex = (props) => {
   const { tagOptions } = props
   const { locale } = useGlobal()
-  return <LayoutBase {...props}>
+  return <div {...props}>
         <div className='bg-white dark:bg-hexo-black-gray px-10 py-10 shadow h-full'>
             <div className='dark:text-gray-200 mb-5'><i className='fas fa-tags mr-4' />{locale.COMMON.TAGS}:</div>
             <div id='tags-list' className='duration-200 flex flex-wrap'>
@@ -328,11 +328,12 @@ const LayoutTagIndex = (props) => {
                 })}
             </div>
         </div>
-    </LayoutBase>
+    </div>
 }
 
 export {
   CONFIG as THEME_CONFIG,
+  LayoutBase,
   LayoutIndex,
   LayoutSearch,
   LayoutArchive,

--- a/themes/nobelium/index.js
+++ b/themes/nobelium/index.js
@@ -130,10 +130,10 @@ const LayoutPostList = props => {
   }
 
   return (
-        <LayoutBase {...props} topSlot={<BlogListBar {...props} setFilterKey={setFilterKey} />}>
+        <div {...props} topSlot={<BlogListBar {...props} setFilterKey={setFilterKey} />}>
             {topSlot}
             {BLOG.POST_LIST_STYLE === 'page' ? <BlogListPage {...props} posts={filteredBlogPosts} /> : <BlogListScroll {...props} posts={filteredBlogPosts} />}
-        </LayoutBase>
+        </div>
   )
 }
 
@@ -172,10 +172,10 @@ const LayoutSearch = props => {
   }
   console.log('posts', props, posts, filteredBlogPosts)
 
-  return <LayoutBase {...props} topSlot={<BlogListBar {...props} setFilterKey={setFilterKey} />}>
+  return <div {...props} topSlot={<BlogListBar {...props} setFilterKey={setFilterKey} />}>
     <SearchNavBar {...props} />
     {BLOG.POST_LIST_STYLE === 'page' ? <BlogListPage {...props} posts={filteredBlogPosts} /> : <BlogListScroll {...props} posts={filteredBlogPosts} />}
-  </LayoutBase>
+  </div>
 }
 
 /**
@@ -186,11 +186,11 @@ const LayoutSearch = props => {
 const LayoutArchive = props => {
   const { archivePosts } = props
   return (
-        <LayoutBase {...props}>
+        <div {...props}>
             <div className="mb-10 pb-20 md:py-12 p-3  min-h-screen w-full">
                 {Object.keys(archivePosts).map(archiveTitle => <BlogArchiveItem key={archiveTitle} archiveTitle={archiveTitle} archivePosts={archivePosts} />)}
             </div>
-        </LayoutBase>
+        </div>
   )
 }
 
@@ -203,7 +203,7 @@ const LayoutSlug = props => {
   const { post, lock, validPassword } = props
 
   return (
-        <LayoutBase {...props}>
+        <div {...props}>
 
             {lock && <ArticleLock validPassword={validPassword} />}
 
@@ -217,7 +217,7 @@ const LayoutSlug = props => {
                 </>
             </div>}
 
-        </LayoutBase>
+        </div>
   )
 }
 
@@ -227,9 +227,9 @@ const LayoutSlug = props => {
  * @returns
  */
 const Layout404 = (props) => {
-  return <LayoutBase {...props}>
+  return <div {...props}>
         404 Not found.
-    </LayoutBase>
+    </div>
 }
 
 /**
@@ -241,7 +241,7 @@ const LayoutCategoryIndex = (props) => {
   const { categoryOptions } = props
 
   return (
-        <LayoutBase {...props}>
+        <div {...props}>
             <div id='category-list' className='duration-200 flex flex-wrap'>
                 {categoryOptions?.map(category => {
                   return (
@@ -258,7 +258,7 @@ const LayoutCategoryIndex = (props) => {
                   )
                 })}
             </div>
-        </LayoutBase>
+        </div>
   )
 }
 
@@ -270,7 +270,7 @@ const LayoutCategoryIndex = (props) => {
 const LayoutTagIndex = (props) => {
   const { tagOptions } = props
   return (
-        <LayoutBase {...props}>
+        <div {...props}>
             <div>
                 <div id='tags-list' className='duration-200 flex flex-wrap'>
                     {tagOptions.map(tag => {
@@ -285,12 +285,13 @@ const LayoutTagIndex = (props) => {
                     })}
                 </div>
             </div>
-        </LayoutBase>
+        </div>
   )
 }
 
 export {
   CONFIG as THEME_CONFIG,
+  LayoutBase,
   LayoutIndex,
   LayoutSearch,
   LayoutArchive,

--- a/themes/plog/index.js
+++ b/themes/plog/index.js
@@ -99,9 +99,9 @@ const LayoutIndex = props => {
  */
 const LayoutPostList = props => {
   return (
-        <LayoutBase {...props}>
+        <div {...props}>
             {BLOG.POST_LIST_STYLE === 'page' ? <BlogListPage {...props} /> : <BlogListScroll {...props} />}
-        </LayoutBase>
+        </div>
   )
 }
 
@@ -138,11 +138,11 @@ const LayoutSearch = props => {
 const LayoutArchive = props => {
   const { archivePosts } = props
   return (
-        <LayoutBase {...props}>
+        <div {...props}>
             <div className="mb-10 pb-20 md:py-12 p-3  min-h-screen w-full">
                 {Object.keys(archivePosts).map(archiveTitle => <BlogArchiveItem key={archiveTitle} archiveTitle={archiveTitle} archivePosts={archivePosts} />)}
             </div>
-        </LayoutBase>
+        </div>
   )
 }
 
@@ -155,7 +155,7 @@ const LayoutSlug = props => {
   const { post, lock, validPassword } = props
 
   return (
-        <LayoutBase {...props}>
+        <div {...props}>
 
             {lock && <ArticleLock validPassword={validPassword} />}
 
@@ -169,7 +169,7 @@ const LayoutSlug = props => {
                 </>
             </div>}
 
-        </LayoutBase>
+        </div>
   )
 }
 
@@ -179,9 +179,9 @@ const LayoutSlug = props => {
  * @returns
  */
 const Layout404 = (props) => {
-  return <LayoutBase {...props}>
+  return <div {...props}>
         404 Not found.
-    </LayoutBase>
+    </div>
 }
 
 /**
@@ -193,7 +193,7 @@ const LayoutCategoryIndex = (props) => {
   const { categoryOptions } = props
 
   return (
-        <LayoutBase {...props}>
+        <div {...props}>
             <div id='category-list' className='duration-200 flex flex-wrap'>
                 {categoryOptions?.map(category => {
                   return (
@@ -210,7 +210,7 @@ const LayoutCategoryIndex = (props) => {
                   )
                 })}
             </div>
-        </LayoutBase>
+        </div>
   )
 }
 
@@ -222,7 +222,7 @@ const LayoutCategoryIndex = (props) => {
 const LayoutTagIndex = (props) => {
   const { tagOptions } = props
   return (
-        <LayoutBase {...props}>
+        <div {...props}>
             <div>
                 <div id='tags-list' className='duration-200 flex flex-wrap'>
                     {tagOptions.map(tag => {
@@ -237,12 +237,13 @@ const LayoutTagIndex = (props) => {
                     })}
                 </div>
             </div>
-        </LayoutBase>
+        </div>
   )
 }
 
 export {
   CONFIG as THEME_CONFIG,
+  LayoutBase,
   LayoutIndex,
   LayoutSearch,
   LayoutArchive,

--- a/themes/simple/index.js
+++ b/themes/simple/index.js
@@ -106,9 +106,9 @@ const LayoutIndex = props => {
  */
 const LayoutPostList = props => {
   return (
-        <LayoutBase {...props}>
+        <div {...props}>
             {BLOG.POST_LIST_STYLE === 'page' ? <BlogListPage {...props} /> : <BlogListScroll {...props} />}
-        </LayoutBase>
+        </div>
   )
 }
 
@@ -145,11 +145,11 @@ const LayoutSearch = props => {
 const LayoutArchive = props => {
   const { archivePosts } = props
   return (
-        <LayoutBase {...props}>
+        <div {...props}>
             <div className="mb-10 pb-20 md:py-12 p-3  min-h-screen w-full">
                 {Object.keys(archivePosts).map(archiveTitle => <BlogArchiveItem key={archiveTitle} archiveTitle={archiveTitle} archivePosts={archivePosts} />)}
             </div>
-        </LayoutBase>
+        </div>
   )
 }
 
@@ -162,7 +162,7 @@ const LayoutSlug = props => {
   const { post, lock, validPassword, prev, next } = props
 
   return (
-        <LayoutBase {...props}>
+        <div {...props}>
 
             {lock && <ArticleLock validPassword={validPassword} />}
 
@@ -190,7 +190,7 @@ const LayoutSlug = props => {
 
             </div>
 
-        </LayoutBase>
+        </div>
   )
 }
 
@@ -200,9 +200,9 @@ const LayoutSlug = props => {
  * @returns
  */
 const Layout404 = (props) => {
-  return <LayoutBase {...props}>
+  return <div {...props}>
         404 Not found.
-    </LayoutBase>
+    </div>
 }
 
 /**
@@ -213,7 +213,7 @@ const Layout404 = (props) => {
 const LayoutCategoryIndex = props => {
   const { categoryOptions } = props
   return (
-        <LayoutBase {...props}>
+        <div {...props}>
             <div id='category-list' className='duration-200 flex flex-wrap'>
                 {categoryOptions?.map(category => {
                   return (
@@ -230,7 +230,7 @@ const LayoutCategoryIndex = props => {
                   )
                 })}
             </div>
-        </LayoutBase>
+        </div>
   )
 }
 
@@ -242,7 +242,7 @@ const LayoutCategoryIndex = props => {
 const LayoutTagIndex = (props) => {
   const { tagOptions } = props
   return (
-        <LayoutBase {...props}>
+        <div {...props}>
             <div id='tags-list' className='duration-200 flex flex-wrap'>
                 {tagOptions.map(tag => {
                   return (
@@ -258,12 +258,13 @@ const LayoutTagIndex = (props) => {
                   )
                 })}
             </div>
-        </LayoutBase>
+        </div>
   )
 }
 
 export {
   CONFIG as THEME_CONFIG,
+  LayoutBase,
   LayoutIndex,
   LayoutSearch,
   LayoutArchive,

--- a/themes/theme.js
+++ b/themes/theme.js
@@ -3,7 +3,7 @@ import BLOG from '@/blog.config'
 import { getQueryParam, getQueryVariable } from '../lib/utils'
 import dynamic from 'next/dynamic'
 import getConfig from 'next/config'
-import * as ThemeComponents from '@theme-components'
+import * as ThemeComponents from './index'
 // 所有主题在next.config.js中扫描
 export const { THEMES = [] } = getConfig().publicRuntimeConfig
 
@@ -15,11 +15,7 @@ export const { THEMES = [] } = getConfig().publicRuntimeConfig
  */
 export const getGlobalLayoutByTheme = (themeQuery) => {
     const layout = getLayoutNameByPath(-1)
-    if (themeQuery !== BLOG.THEME) {
-      return dynamic(() => import(`@/themes/${themeQuery}`).then(m => m[layout]), { ssr: true })
-    } else {
-      return ThemeComponents[layout]
-    }
+    return ThemeComponents[themeQuery.toUpperCase()][layout]
   }
 
 /**
@@ -31,11 +27,7 @@ export const getGlobalLayoutByTheme = (themeQuery) => {
 export const getLayoutByTheme = (router) => {
   const themeQuery = getQueryParam(router.asPath, 'theme') || BLOG.THEME
   const layout = getLayoutNameByPath(router.pathname)
-  if (themeQuery !== BLOG.THEME) {
-    return dynamic(() => import(`@/themes/${themeQuery}`).then(m => m[layout]), { ssr: true })
-  } else {
-    return ThemeComponents[layout]
-  }
+  return ThemeComponents[themeQuery.toUpperCase()][layout]
 }
 
 /**

--- a/themes/theme.js
+++ b/themes/theme.js
@@ -6,6 +6,22 @@ import getConfig from 'next/config'
 import * as ThemeComponents from '@theme-components'
 // 所有主题在next.config.js中扫描
 export const { THEMES = [] } = getConfig().publicRuntimeConfig
+
+/**
+ * 加载全局布局
+ * 如果是
+ * @param {*} themeQuery
+ * @returns
+ */
+export const getGlobalLayoutByTheme = (themeQuery) => {
+    const layout = getLayoutNameByPath(-1)
+    if (themeQuery !== BLOG.THEME) {
+      return dynamic(() => import(`@/themes/${themeQuery}`).then(m => m[layout]), { ssr: true })
+    } else {
+      return ThemeComponents[layout]
+    }
+  }
+
 /**
  * 加载主题文件
  * 如果是
@@ -29,6 +45,8 @@ export const getLayoutByTheme = (router) => {
  */
 export const getLayoutNameByPath = (path) => {
   switch (path) {
+    case -1:
+        return 'LayoutBase'
     case '/':
       return 'LayoutIndex'
     case '/archive':


### PR DESCRIPTION
现在主题在路由改变的时候会刷新全局布局，不仅动画会重新触发，通过url参数更换主题后还会发生闪烁的问题，具体可以看下面的网站，刚从主分支拉过来的

https://notion-next-git-base-velor2012.vercel.app/archive?theme=simple

选择**往期整理**，**历史归档**（其他的也可以），会发现顶部logo和右侧live2d会闪烁

选择默认主题（next），再进行上述步骤，动画会全部重新触发（代码内无法自主控制）

修改后效果如下

https://notion-next-git-feat-velor2012.vercel.app/archive?theme=simple
