### PR TITLE
多级slug-bug

### DIFF
--- a/lib/notion/getPageProperties.js
+++ b/lib/notion/getPageProperties.js
@@ -135,6 +135,8 @@ function mapProperties(properties) {
 
 /**
  * 获取自定义URL
+ * 可以根据变量生成URL
+ * 支持：%year%/%month%/%day%/%slug%
  * @param {*} postProperties
  * @returns
  */

--- a/pages/[prefix]/[slug]/[...suffix].js
+++ b/pages/[prefix]/[slug]/[...suffix].js
@@ -1,0 +1,113 @@
+import BLOG from '@/blog.config'
+import { getPostBlocks } from '@/lib/notion'
+import { getGlobalData } from '@/lib/notion/getNotionData'
+import { idToUuid } from 'notion-utils'
+import { getNotion } from '@/lib/notion/getNotion'
+import Slug, { getRecommendPost } from '..'
+import { uploadDataToAlgolia } from '@/lib/algolia'
+
+/**
+ * 根据notion的slug访问页面
+ * 解析三级以上目录 /article/2023/10/29/test
+ * @param {*} props
+ * @returns
+ */
+const PrefixSlug = props => {
+  return <Slug {...props}/>
+}
+
+/**
+ * 编译渲染页面路径
+ * @returns
+ */
+export async function getStaticPaths() {
+  if (!BLOG.isProd) {
+    return {
+      paths: [],
+      fallback: true
+    }
+  }
+
+  const from = 'slug-paths'
+  const { allPages } = await getGlobalData({ from })
+  return {
+    paths: allPages?.filter(row => hasMultipleSlashes(row.slug) && row.type.indexOf('Menu') < 0).map(row => ({ params: { prefix: row.slug.split('/')[0], slug: row.slug.split('/')[1], suffix: row.slug.split('/').slice(1) } })),
+    fallback: true
+  }
+}
+
+/**
+ * 抓取页面数据
+ * @param {*} param0
+ * @returns
+ */
+export async function getStaticProps({ params: { prefix, slug, suffix } }) {
+  let fullSlug = prefix + '/' + slug + '/' + suffix.join('/')
+  if (JSON.parse(BLOG.PSEUDO_STATIC)) {
+    if (!fullSlug.endsWith('.html')) {
+      fullSlug += '.html'
+    }
+  }
+  const from = `slug-props-${fullSlug}`
+  const props = await getGlobalData({ from })
+  // 在列表内查找文章
+  props.post = props?.allPages?.find((p) => {
+    return p.slug === fullSlug || p.id === idToUuid(fullSlug)
+  })
+
+  // 处理非列表内文章的内信息
+  if (!props?.post) {
+    const pageId = fullSlug.slice(-1)[0]
+    if (pageId.length >= 32) {
+      const post = await getNotion(pageId)
+      props.post = post
+    }
+  }
+
+  // 无法获取文章
+  if (!props?.post) {
+    props.post = null
+    return { props, revalidate: parseInt(BLOG.NEXT_REVALIDATE_SECOND) }
+  }
+
+  // 文章内容加载
+  if (!props?.posts?.blockMap) {
+    props.post.blockMap = await getPostBlocks(props.post.id, from)
+  }
+  // 生成全文索引 && JSON.parse(BLOG.ALGOLIA_RECREATE_DATA)
+  if (BLOG.ALGOLIA_APP_ID) {
+    uploadDataToAlgolia(props?.post)
+  }
+
+  // 推荐关联文章处理
+  const allPosts = props.allPages?.filter(page => page.type === 'Post' && page.status === 'Published')
+  if (allPosts && allPosts.length > 0) {
+    const index = allPosts.indexOf(props.post)
+    props.prev = allPosts.slice(index - 1, index)[0] ?? allPosts.slice(-1)[0]
+    props.next = allPosts.slice(index + 1, index + 2)[0] ?? allPosts[0]
+    props.recommendPosts = getRecommendPost(props.post, allPosts, BLOG.POST_RECOMMEND_COUNT)
+  } else {
+    props.prev = null
+    props.next = null
+    props.recommendPosts = []
+  }
+
+  delete props.allPages
+  return {
+    props,
+    revalidate: parseInt(BLOG.NEXT_REVALIDATE_SECOND)
+  }
+}
+
+/**
+ * 判断是否包含两个以上的 /
+ * @param {*} str
+ * @returns
+ */
+function hasMultipleSlashes(str) {
+  const regex = /\/+/g; // 创建正则表达式，匹配所有的斜杠符号
+  const matches = str.match(regex); // 在字符串中找到所有匹配的斜杠符号
+  return matches && matches.length >= 2; // 判断匹配的斜杠符号数量是否大于等于2
+}
+
+export default PrefixSlug

--- a/pages/[prefix]/[slug]/index.js
+++ b/pages/[prefix]/[slug]/index.js
@@ -3,11 +3,12 @@ import { getPostBlocks } from '@/lib/notion'
 import { getGlobalData } from '@/lib/notion/getNotionData'
 import { idToUuid } from 'notion-utils'
 import { getNotion } from '@/lib/notion/getNotion'
-import Slug, { getRecommendPost } from '.'
+import Slug, { getRecommendPost } from '..'
 import { uploadDataToAlgolia } from '@/lib/algolia'
 
 /**
  * 根据notion的slug访问页面
+ * 解析二级目录 /article/about
  * @param {*} props
  * @returns
  */

--- a/pages/[prefix]/index.js
+++ b/pages/[prefix]/index.js
@@ -13,6 +13,7 @@ import { uploadDataToAlgolia } from '@/lib/algolia'
 
 /**
  * 根据notion的slug访问页面
+ * 只解析一级目录例如 /about
  * @param {*} props
  * @returns
  */


### PR DESCRIPTION
在4.0中改动了多级目录的解析方式，导致类似`年/月/日/slug`这样的多级目录无法访问