### PR TITLE
fix 修复heo主题从NotionConfig读取失败Bug

### DIFF
--- a/themes/heo/components/NoticeBar.js
+++ b/themes/heo/components/NoticeBar.js
@@ -8,8 +8,10 @@ import { siteConfig } from '@/lib/config'
  * 通知横幅
  */
 export function NoticeBar() {
-  const notices = siteConfig('HEO_NOTICE_BAR', null, CONFIG)
-
+  let notices = siteConfig('HEO_NOTICE_BAR', null, CONFIG)
+  if (typeof notices === 'string') {
+    notices = JSON.parse(notices)
+  }
   if (!notices || notices?.length === 0) {
     return <></>
   }


### PR DESCRIPTION
默认从NotionConfig读取为字符串，此时会导致notices获取失败