### PR TITLE
修复nav主题下category和tag下文章链接不对的bug

### DIFF
--- a/themes/nav/components/BlogPostCard.js
+++ b/themes/nav/components/BlogPostCard.js
@@ -1,13 +1,14 @@
 import Link from 'next/link'
 import NotionIcon from './NotionIcon'
 import { useRouter } from 'next/router'
+import { siteConfig } from '@/lib/config'
 
 const BlogPostCard = ({ post, className }) => {
   const router = useRouter()
   const currentSelected = router.asPath.split('?')[0] === '/' + post.slug
   const pageIcon = post.pageIcon.indexOf('amazonaws.com') !== -1 ? post.pageIcon + '&width=88' : post.pageIcon
   return (
-    <Link href={`${removeHttp(post.slug)}`} target={(checkRemoveHttp(post.slug) ? '_blank' : '_self')} passHref>
+    <Link href={`${siteConfig('SUB_PATH', '')}/${removeHttp(post.slug)}`} target={(checkRemoveHttp(post.slug) ? '_blank' : '_self')} passHref>
         <div key={post.id} className={`${className} h-full rounded-2xl p-4 dark:bg-neutral-800 cursor-pointer bg-white hover:bg-white dark:hover:bg-gray-800 ${currentSelected ? 'bg-green-50 text-green-500' : ''}`}>
                 <div className="stack-entry w-full flex space-x-3 select-none dark:text-neutral-200">
                     <NotionIcon icon={pageIcon} size='10' className='text-6xl w-11 h-11 mx-1 my-0 flex-none' />


### PR DESCRIPTION
nav主题，category和tag路径下的文章链接多了 category/ 和 tag/ 目录，如  https://xxx.com/catetory 下的文章链接现在是 https://xxx.com/catetory/article/example-5，正确应为  https://xxx.com/article/example-5