### PR TITLE
支持微软clarity

### DIFF
--- a/blog.config.js
+++ b/blog.config.js
@@ -352,6 +352,9 @@ const BLOG = {
   SEO_BAIDU_SITE_VERIFICATION:
         process.env.NEXT_PUBLIC_SEO_BAIDU_SITE_VERIFICATION || '', // Remove the value or replace it with your own google site verification code
 
+  // 微软 Clarity 站点分析
+  CLARITY_ID: process.env.NEXT_PUBLIC_CLARITY_ID || null , // 只需要复制Clarity脚本中的ID部分，ID是一个十位的英文数字组合
+
   // <---- 站点统计
 
   // START---->营收相关

--- a/components/Busuanzi.js
+++ b/components/Busuanzi.js
@@ -2,14 +2,14 @@ import busuanzi from '@/lib/busuanzi'
 import { useRouter } from 'next/router'
 import { useGlobal } from '@/lib/global'
 // import { useRouter } from 'next/router'
-import React from 'react'
+import { useEffect } from 'react'
 
 let path = ''
 
 export default function Busuanzi () {
   const { theme } = useGlobal()
-  const Router = useRouter()
-  Router.events.on('routeChangeComplete', (url, option) => {
+  const router = useRouter()
+  router.events.on('routeChangeComplete', (url, option) => {
     if (url !== path) {
       path = url
       busuanzi.fetch()
@@ -17,7 +17,7 @@ export default function Busuanzi () {
   })
 
   // 更换主题时更新
-  React.useEffect(() => {
+  useEffect(() => {
     if (theme) {
       busuanzi.fetch()
     }

--- a/components/ExternalPlugins.js
+++ b/components/ExternalPlugins.js
@@ -78,6 +78,7 @@ const ExternalPlugin = (props) => {
   const DIFY_CHATBOT_ENABLED = siteConfig('DIFY_CHATBOT_ENABLED')
   const TIANLI_KEY = siteConfig('TianliGPT_KEY')
   const GLOBAL_JS = siteConfig('GLOBAL_JS')
+  const CLARITY_ID = siteConfig('CLARITY_ID')
 
   // 自定义样式css和js引入
   if (isBrowser) {
@@ -165,6 +166,19 @@ const ExternalPlugin = (props) => {
                         }
                     `
             }} />
+        </>)}
+
+
+        {CLARITY_ID && (<>
+        <script async dangerouslySetInnerHTML={{
+            __html:`
+            (function(c,l,a,r,i,t,y){
+                c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+                t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+                y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+            })(window, document, "clarity", "script", "${CLARITY_ID}");
+            `
+        }}/>
         </>)}
 
         {COMMENT_DAO_VOICE_ID && (<>


### PR DESCRIPTION
已添加，在 blog.config.js 中配置CLARITY_ID即可，ID来自这里：
![image](https://github.com/tangly1024/NotionNext/assets/15920488/195dc8f1-298e-4278-aae2-ac9c5365233d)

![image](https://github.com/tangly1024/NotionNext/assets/15920488/bce855c5-3aeb-4063-9616-3db9eba4f8e6)

添加后，基本上马上就能在微软的后台看到实时动作视频：

![image](https://github.com/tangly1024/NotionNext/assets/15920488/2edaba0b-9134-4441-bced-06bfcfbcf874)

