### PR TITLE
为Safari添加拖拽框的简略修复

### DIFF
--- a/components/ExternalPlugins.js
+++ b/components/ExternalPlugins.js
@@ -5,7 +5,7 @@ import WebWhiz from './Webwhiz'
 import TianLiGPT from './TianliGPT'
 import { GlobalStyle } from './GlobalStyle'
 
-import { CUSTOM_EXTERNAL_CSS, CUSTOM_EXTERNAL_JS, IMG_SHADOW } from '@/blog.config'
+import { CUSTOM_EXTERNAL_CSS, CUSTOM_EXTERNAL_JS } from '@/blog.config'
 import { isBrowser, loadExternalResource } from '@/lib/utils'
 
 const TwikooCommentCounter = dynamic(() => import('@/components/TwikooCommentCounter'), { ssr: false })
@@ -79,6 +79,7 @@ const ExternalPlugin = (props) => {
   const TIANLI_KEY = siteConfig('TianliGPT_KEY')
   const GLOBAL_JS = siteConfig('GLOBAL_JS')
   const CLARITY_ID = siteConfig('CLARITY_ID')
+  const IMG_SHADOW = siteConfig('IMG_SHADOW')
 
   // 自定义样式css和js引入
   if (isBrowser) {

--- a/components/ThemeSwitch.js
+++ b/components/ThemeSwitch.js
@@ -20,6 +20,7 @@ const ThemeSwitch = () => {
   // 修改当前路径url中的 theme 参数
   // 例如 http://localhost?theme=hexo 跳转到 http://localhost?theme=newTheme
   const onThemeSelectChange = (e) => {
+    document.ontouchmove = document.ontouchend = document.onmousemove = document.onmouseup = null
     setIsLoading(true)
     const newTheme = e.target.value
     const query = router.query
@@ -32,6 +33,7 @@ const ThemeSwitch = () => {
   }
 
   const onLangSelectChange = (e) => {
+    document.ontouchmove = document.ontouchend = document.onmousemove = document.onmouseup = null
     const newLang = e.target.value
     changeLang(newLang)
   }

--- a/themes/starter/index.js
+++ b/themes/starter/index.js
@@ -30,7 +30,7 @@ import { Contact } from './components/Contact'
 import { Brand } from './components/Brand'
 import { Footer } from './components/Footer'
 import { BackToTopButton } from './components/BackToTopButton'
-import { MadeWithButton } from './components/MadeWithButton'
+// import { MadeWithButton } from './components/MadeWithButton'
 import { SVG404 } from './components/svg/SVG404'
 import { Banner } from './components/Banner'
 import { SignInForm } from './components/SignInForm'
@@ -64,7 +64,7 @@ const LayoutBase = (props) => {
 
             {/* 悬浮按钮 */}
             <BackToTopButton/>
-            <MadeWithButton/>
+            {/* <MadeWithButton/> */}
         </div>
 }
 


### PR DESCRIPTION
在macOS的Safari浏览器中鼠标事件的逻辑和Chromium浏览器的事件貌似有点不太一样。

效果体现上来说，Draggable在触发了内部的选项后，就粘贴到鼠标上不离开了。

在components/Draggable.js中，对鼠标按下和松开事件都进行了注册，也就是内部的语言切换和主题切换点击完毕后，鼠标松开事件可以正常触发，但是Safari有点不一样，它在触发了内部的事件后就不会再触发onmouseup这个事件。

在[Draggable.js](https://github.com/tangly1024/NotionNext/blob/main/components/Draggable.js)文件里面我思考了很久，发现我不怎么会判断它们，所以我在[ThemeSwitch.js](https://github.com/tangly1024/NotionNext/blob/main/components/ThemeSwitch.js)中进行了粗暴的事件清除。 