### PR TITLE
目录会填满侧边栏

### DIFF
--- a/themes/fukasawa/components/AsideLeft.js
+++ b/themes/fukasawa/components/AsideLeft.js
@@ -133,13 +133,12 @@ function AsideLeft(props) {
                 <DarkModeButton />
             </section>
 
-            <section className='sticky top-0 pt-12'>
+            <section className='sticky top-0 pt-12  flex flex-col max-h-screen '>
                 <Catalog toc={post?.toc} />
                 <div className='flex justify-center'>
                     <div>{slot}</div>
                 </div>
             </section>
-
         </div>
     </div>
 }

--- a/themes/fukasawa/components/Catalog.js
+++ b/themes/fukasawa/components/Catalog.js
@@ -62,7 +62,6 @@ const Catalog = ({ toc }) => {
 
   return <div id='catalog'>
     <div className='w-full dark:text-gray-300 mb-2'><i className='mr-1 fas fa-stream' />{locale.COMMON.TABLE_OF_CONTENTS}</div>
-    <div >
       <nav ref={tRef} className='h-full overflow-y-auto overscroll-none scroll-hidden  text-black'>
         {toc.map((tocItem) => {
           const id = uuidToId(tocItem.id)
@@ -82,7 +81,6 @@ const Catalog = ({ toc }) => {
           )
         })}
       </nav>
-    </div>
   </div>
 }
 

--- a/themes/fukasawa/components/Catalog.js
+++ b/themes/fukasawa/components/Catalog.js
@@ -72,6 +72,7 @@ const Catalog = ({ toc }) => {
           >
             <span style={{ display: 'inline-block', marginLeft: tocItem.indentLevel * 16 }}
               className={`${activeSection === id && ' font-bold text-red-400 underline'}`}
+              title={tocItem.text}
             >
               {tocItem.text}
             </span>

--- a/themes/fukasawa/components/Catalog.js
+++ b/themes/fukasawa/components/Catalog.js
@@ -54,14 +54,13 @@ const Catalog = ({ toc }) => {
 
   // 目录自动滚动
   const tRef = useRef(null)
-
   // 无目录就直接返回空
   if (!toc || toc?.length < 1) {
     return <></>
   }
-
   return <div id='catalog'>
     <div className='w-full dark:text-gray-300 mb-2'><i className='mr-1 fas fa-stream' />{locale.COMMON.TABLE_OF_CONTENTS}</div>
+    <div className='max-h-[calc(100vh-8rem)]'>
       <nav ref={tRef} className='h-full overflow-y-auto overscroll-none scroll-hidden  text-black'>
         {toc.map((tocItem) => {
           const id = uuidToId(tocItem.id)
@@ -81,6 +80,7 @@ const Catalog = ({ toc }) => {
           )
         })}
       </nav>
+    </div>
   </div>
 }
 

--- a/themes/fukasawa/components/Catalog.js
+++ b/themes/fukasawa/components/Catalog.js
@@ -62,7 +62,7 @@ const Catalog = ({ toc }) => {
 
   return <div id='catalog'>
     <div className='w-full dark:text-gray-300 mb-2'><i className='mr-1 fas fa-stream' />{locale.COMMON.TABLE_OF_CONTENTS}</div>
-    <div className='h-96'>
+    <div >
       <nav ref={tRef} className='h-full overflow-y-auto overscroll-none scroll-hidden  text-black'>
         {toc.map((tocItem) => {
           const id = uuidToId(tocItem.id)

--- a/themes/fukasawa/components/Catalog.js
+++ b/themes/fukasawa/components/Catalog.js
@@ -58,29 +58,27 @@ const Catalog = ({ toc }) => {
   if (!toc || toc?.length < 1) {
     return <></>
   }
-  return <div id='catalog'>
+  return <div id='catalog' className='flex-1 flex-col flex overflow-hidden'>
     <div className='w-full dark:text-gray-300 mb-2'><i className='mr-1 fas fa-stream' />{locale.COMMON.TABLE_OF_CONTENTS}</div>
-    <div className='max-h-[calc(100vh-8rem)]'>
-      <nav ref={tRef} className='h-full overflow-y-auto overscroll-none scroll-hidden  text-black'>
-        {toc.map((tocItem) => {
-          const id = uuidToId(tocItem.id)
-          return (
-            <a
-              key={id}
-              href={`#${id}`}
-              className={`notion-table-of-contents-item duration-300 transform font-light dark:text-gray-300
+    <nav ref={tRef} className='flex-1 overflow-auto  overscroll-none scroll-hidden   text-black mb-6'>
+      {toc.map((tocItem) => {
+        const id = uuidToId(tocItem.id)
+        return (
+          <a
+            key={id}
+            href={`#${id}`}
+            className={`notion-table-of-contents-item duration-300 transform font-light dark:text-gray-300
               notion-table-of-contents-item-indent-level-${tocItem.indentLevel} `}
+          >
+            <span style={{ display: 'inline-block', marginLeft: tocItem.indentLevel * 16 }}
+              className={`${activeSection === id && ' font-bold text-red-400 underline'}`}
             >
-              <span style={{ display: 'inline-block', marginLeft: tocItem.indentLevel * 16 }}
-                className={`${activeSection === id && ' font-bold text-red-400 underline'}`}
-              >
-                {tocItem.text}
-              </span>
-            </a>
-          )
-        })}
-      </nav>
-    </div>
+              {tocItem.text}
+            </span>
+          </a>
+        )
+      })}
+    </nav>
   </div>
 }
 


### PR DESCRIPTION
之前样式是一个固定高度，不会填满侧边栏：
![image](https://github.com/tangly1024/NotionNext/assets/19898669/e123659e-abee-4605-b157-7150185e1a1c)
现在样式：
![image](https://github.com/tangly1024/NotionNext/assets/19898669/64d161c6-0b61-49af-9d7b-f9160100525f)
