### PR TITLE
🐛 fix: 修复表格和 Notion 显示不一致的问题

### DIFF
--- a/hooks/useAdjustStyle.js
+++ b/hooks/useAdjustStyle.js
@@ -33,7 +33,7 @@ const useAdjustStyle = () => {
     useEffect(() => {
         for (let i = 0; i < document.styleSheets.length; i++) {
             const styleSheet = document.styleSheets[i];
-            if (styleSheet.href && styleSheet.href.includes('fonts.googleapis.com')) {
+            if (styleSheet.href && styleSheet.href.includes('http')) {
                 continue; // 忽略指定样式表，避免访问报错
             }
             try {

--- a/hooks/useAdjustStyle.js
+++ b/hooks/useAdjustStyle.js
@@ -1,36 +1,58 @@
-import { isBrowser } from '@/lib/utils';
 import { useEffect } from 'react';
 
 /**
  * 样式调整的补丁
  */
 const useAdjustStyle = () => {
-  /**
-     * 避免 callout 含有图片时溢出撑开父容器
-     */
-  const adjustCalloutImg = () => {
-    const callOuts = document.querySelectorAll('.notion-callout-text');
-    callOuts.forEach((callout) => {
-      const images = callout.querySelectorAll('figure.notion-asset-wrapper.notion-asset-wrapper-image > div');
-      const calloutWidth = callout.offsetWidth;
-      images.forEach((container) => {
-        const imageWidth = container.offsetWidth;
-        if (imageWidth + 50 > calloutWidth) {
-          container.style.setProperty('width', '100%');
-        }
-      });
-    });
-  };
 
-  useEffect(() => {
-    if (isBrowser) {
-      adjustCalloutImg();
-      window.addEventListener('resize', adjustCalloutImg);
-      return () => {
-        window.removeEventListener('resize', adjustCalloutImg);
-      };
-    }
-  }, []);
+    // 避免 callout 含有图片时溢出撑开父容器
+    useEffect(() => {
+        const adjustCalloutImg = () => {
+            const callOuts = document.querySelectorAll('.notion-callout-text');
+            callOuts.forEach((callout) => {
+                const images = callout.querySelectorAll('figure.notion-asset-wrapper.notion-asset-wrapper-image > div');
+                const calloutWidth = callout.offsetWidth;
+                images.forEach((container) => {
+                    const imageWidth = container.offsetWidth;
+                    if (imageWidth + 50 > calloutWidth) {
+                        container.style.setProperty('width', '100%');
+                    }
+                });
+            });
+        };
+
+        adjustCalloutImg();
+
+        window.addEventListener('resize', adjustCalloutImg);
+        return () => {
+            window.removeEventListener('resize', adjustCalloutImg);
+        };
+    }, []);
+
+    // 强行移除 react-notion-x 表格表头第一行样式
+    useEffect(() => {
+        for (let i = 0; i < document.styleSheets.length; i++) {
+            const styleSheet = document.styleSheets[i];
+            if (styleSheet.href && styleSheet.href.includes('fonts.googleapis.com')) {
+                continue; // 忽略指定样式表，避免访问报错
+            }
+            try {
+                const rules = styleSheet.cssRules;
+                for (let j = 0; j < rules.length; j++) {
+                    const rule = rules[j];
+                    if (rule.selectorText === '.notion-simple-table tr:first-child td') {
+                        styleSheet.deleteRule(j);
+                        break;
+                    }
+                }
+            } catch (error) {
+                console.error('Error accessing stylesheets:', error);
+            }
+        }
+        return () => {
+        };
+    }, []);
+    
 };
 
 export default useAdjustStyle;

--- a/styles/notion.css
+++ b/styles/notion.css
@@ -2053,14 +2053,12 @@ code.language-mermaid {
 .notion-simple-table-row {
 }
 
-/* 表格头 */
+/* @Deprecated 表格头（在这写了也不会生效）*/
 .notion-simple-table tr:first-child td {
-  background-color: #f5f6f8;
-  @apply text-center font-bold dark:bg-gray-800 !important;
 }
 
 .notion-simple-table td {
-  border: 1px solid var(#eee) !important;
+  border: 1px solid lightgray !important;
 }
 
 /* 竖屏视频高度bug */


### PR DESCRIPTION
### notion 的原始表格
<img src="https://github.com/tangly1024/NotionNext/assets/116578480/d860d643-aa87-4f5d-8764-4d46ff14132b"  width="500"/>

### 未修复前的网页表格
- 第一行总是被默认设置为表头且文字居中加粗
<img src="https://github.com/tangly1024/NotionNext/assets/116578480/4d5f49ed-4e1e-46d4-80b0-992ab0040770"  width="500"/>

### 修复后
> [!warning]  
> **缺点：手动开启 header 不生效，要主动给指定行/列设置（灰色）背景颜色**  
> （但感觉是最优解了.... 没找到 notion 有相关 api 可以判断是否有开启表头）

<img src="https://github.com/tangly1024/NotionNext/assets/116578480/4fdff5c0-55dc-4e68-ada7-4ab2485e59ba"  width="500"/>

### 涉及 issue
- https://github.com/tangly1024/NotionNext/issues/2202
- https://github.com/tangly1024/NotionNext/issues/1477
- https://github.com/tangly1024/NotionNext/issues/1397