### PR TITLE
fix: medium theme catalog miss

### DIFF
--- a/themes/medium/index.js
+++ b/themes/medium/index.js
@@ -46,12 +46,17 @@ export const useMediumGlobal = () => useContext(ThemeGlobalMedium)
  * @constructor
  */
 const LayoutBase = props => {
-  const { children, showInfoCard = true, slotRight, notice } = props
+  const { children, showInfoCard = true, post, notice } = props
   const { locale } = useGlobal()
   const router = useRouter()
   const [tocVisible, changeTocVisible] = useState(false)
   const { onLoading, fullWidth } = useGlobal()
 
+  const slotRight = post?.toc?.length > 0 && (
+    <div key={locale.COMMON.TABLE_OF_CONTENTS} >
+        <Catalog toc={post?.toc} />
+    </div>
+  )
   const slotTop = <BlogPostBar {...props} />
 
   return (


### PR DESCRIPTION
solve #2264
解决 medium 主题文章详情目录缺失的问题

修改前
<img width="278" alt="image" src="https://github.com/tangly1024/NotionNext/assets/23479787/64cc809f-b1b6-4965-b2b6-e1f8fe830dca">

修改后
<img width="292" alt="image" src="https://github.com/tangly1024/NotionNext/assets/23479787/3ef13c45-b1fa-470b-bda1-8423c07ac2b1">
