### PR TITLE
fix: Sidebar width changes and catalog styles

### DIFF
--- a/themes/commerce/components/Catalog.js
+++ b/themes/commerce/components/Catalog.js
@@ -79,7 +79,7 @@ const Catalog = ({ toc }) => {
             notion-table-of-contents-item-indent-level-${tocItem.indentLevel} `}
             >
               <span style={{ display: 'inline-block', marginLeft: tocItem.indentLevel * 16 }}
-                className={`${activeSection === id && ' font-bold text-red-600'}`}
+                className={`truncate ${activeSection === id ? 'font-bold text-red-600': ''}`}
               >
                 {tocItem.text}
               </span>

--- a/themes/fukasawa/components/Catalog.js
+++ b/themes/fukasawa/components/Catalog.js
@@ -71,7 +71,7 @@ const Catalog = ({ toc }) => {
               notion-table-of-contents-item-indent-level-${tocItem.indentLevel} `}
           >
             <span style={{ display: 'inline-block', marginLeft: tocItem.indentLevel * 16 }}
-              className={`${activeSection === id && ' font-bold text-red-400 underline'}`}
+              className={`truncate ${activeSection === id ? 'font-bold text-red-400 underline' : ''}`}
               title={tocItem.text}
             >
               {tocItem.text}

--- a/themes/gitbook/components/Catalog.js
+++ b/themes/gitbook/components/Catalog.js
@@ -74,7 +74,7 @@ const Catalog = ({ post }) => {
               notion-table-of-contents-item-indent-level-${tocItem.indentLevel} `}
             >
               <span style={{ display: 'inline-block', marginLeft: tocItem.indentLevel * 16 }}
-                className={`${activeSection === id && ' font-bold text-gray-500 underline'}`}
+                className={`truncate ${activeSection === id ? 'font-bold text-gray-500 underline' : ''}`}
               >
                 {tocItem.text}
               </span>

--- a/themes/gitbook/index.js
+++ b/themes/gitbook/index.js
@@ -166,7 +166,7 @@ const LayoutBase = (props) => {
                     {/*  右侧侧推拉抽屉 */}
                     {fullWidth
                       ? null
-                      : <div style={{ width: '32rem' }} className={'hidden xl:block dark:border-transparent relative z-10 '}>
+                      : <div style={{ width: '20rem' }} className={'hidden xl:block dark:border-transparent flex-shrink-0 relative z-10 '}>
                       <div className='py-14 px-6 sticky top-0'>
                           <ArticleInfo post={props?.post ? props?.post : props.notice} />
 

--- a/themes/heo/components/Catalog.js
+++ b/themes/heo/components/Catalog.js
@@ -74,7 +74,7 @@ const Catalog = ({ toc }) => {
             notion-table-of-contents-item-indent-level-${tocItem.indentLevel} `}
             >
               <span style={{ display: 'inline-block', marginLeft: tocItem.indentLevel * 16 }}
-                className={`${activeSection === id && ' font-bold text-indigo-600'}`}
+                className={`truncate ${activeSection === id ? 'font-bold text-indigo-600' : ''}`}
               >
                 {tocItem.text}
               </span>

--- a/themes/hexo/components/Catalog.js
+++ b/themes/hexo/components/Catalog.js
@@ -79,7 +79,7 @@ const Catalog = ({ toc }) => {
             notion-table-of-contents-item-indent-level-${tocItem.indentLevel} `}
             >
               <span style={{ display: 'inline-block', marginLeft: tocItem.indentLevel * 16 }}
-                className={`${activeSection === id && ' font-bold text-indigo-600'}`}
+                className={`truncate ${activeSection === id ? 'font-bold text-indigo-600' : ''}`}
               >
                 {tocItem.text}
               </span>

--- a/themes/matery/components/Catalog.js
+++ b/themes/matery/components/Catalog.js
@@ -78,7 +78,7 @@ const Catalog = ({ toc }) => {
             notion-table-of-contents-item-indent-level-${tocItem.indentLevel} `}
             >
               <span style={{ display: 'inline-block', marginLeft: tocItem.indentLevel * 16 }}
-                className={`${activeSection === id && ' font-bold text-green-500 underline overflow-ellipsis truncate'}`}
+                className={`truncate ${activeSection === id ? 'font-bold text-green-500 underline' : ''}`}
               >
                 {tocItem.text}
               </span>

--- a/themes/medium/components/Catalog.js
+++ b/themes/medium/components/Catalog.js
@@ -76,7 +76,7 @@ const Catalog = ({ toc }) => {
               notion-table-of-contents-item-indent-level-${tocItem.indentLevel} `}
             >
               <span style={{ display: 'inline-block', marginLeft: tocItem.indentLevel * 16 }}
-                className={`${activeSection === id && ' font-bold text-green-500 underline'}`}
+                className={`truncate ${activeSection === id ? 'font-bold text-green-500 underline' : ''}`}
               >
                 {tocItem.text}
               </span>

--- a/themes/medium/index.js
+++ b/themes/medium/index.js
@@ -102,7 +102,7 @@ const LayoutBase = props => {
                     {/* 桌面端右侧 */}
                     {fullWidth
                       ? null
-                      : <div className={`hidden xl:block border-l dark:border-transparent w-96 relative z-10 ${siteConfig('MEDIUM_RIGHT_PANEL_DARK', null, CONFIG) ? 'bg-hexo-black-gray dark' : ''}`}>
+                      : <div className={`hidden xl:block border-l dark:border-transparent w-80 flex-shrink-0 relative z-10 ${siteConfig('MEDIUM_RIGHT_PANEL_DARK', null, CONFIG) ? 'bg-hexo-black-gray dark' : ''}`}>
                             <div className='py-14 px-6 sticky top-0'>
                                 <Tabs>
                                     {slotRight}

--- a/themes/nav/components/Catalog.js
+++ b/themes/nav/components/Catalog.js
@@ -74,7 +74,7 @@ const Catalog = ({ post }) => {
               notion-table-of-contents-item-indent-level-${tocItem.indentLevel} `}
             >
               <span style={{ display: 'inline-block', marginLeft: tocItem.indentLevel * 16 }}
-                className={`${activeSection === id && ' font-bold text-gray-500 underline'}`}
+                className={`truncate ${activeSection === id ? 'font-bold text-gray-500 underline' : ''}`}
               >
                 {tocItem.text}
               </span>

--- a/themes/next/components/Toc.js
+++ b/themes/next/components/Toc.js
@@ -74,7 +74,7 @@ const Toc = ({ toc }) => {
               className={`notion-table-of-contents-item duration-300 transform font-light
               notion-table-of-contents-item-indent-level-${tocItem.indentLevel} `}
             >
-              <span style={{ display: 'inline-block', marginLeft: tocItem.indentLevel * 16 }} className={`${activeSection === id && ' font-bold text-red-400 underline'}`}>
+              <span style={{ display: 'inline-block', marginLeft: tocItem.indentLevel * 16 }} className={`truncate ${activeSection === id ? ' font-bold text-red-400 underline' : ''}`}>
                 {tocItem.text}
               </span>
             </a>

--- a/themes/simple/components/Catalog.js
+++ b/themes/simple/components/Catalog.js
@@ -73,7 +73,7 @@ const Catalog = ({ post }) => {
             notion-table-of-contents-item-indent-level-${tocItem.indentLevel} `}
                         >
                             <span style={{ display: 'inline-block', marginLeft: tocItem.indentLevel * 16 }}
-                                className={`${activeSection === id && ' font-bold text-red-600 underline overflow-ellipsis truncate'}`}
+                                className={`truncate ${activeSection === id ? ' font-bold text-red-600 underline' : ''}`}
                             >
                                 {tocItem.text}
                             </span>


### PR DESCRIPTION
问题：Medium 主题中的「目录」标签在内部有标题超长的情况下会将侧边栏撑到最大宽度，「关于」标签因为内容少被左侧内容挤压，导致两个 Tab 切换时侧边栏宽度不一致。

解决：减少了侧边栏的宽度，禁止侧边栏被 shrink 挤压宽度，切换 Tab 时侧边栏宽度不变。
Gitbook 主题同上，固定了宽度

同时优化了目录未激活时，增加文字超出宽度显示省略号
<img width="442" alt="image" src="https://github.com/tangly1024/NotionNext/assets/23479787/a7e67289-bf93-4e85-bd79-f506077d4b4b">
<img width="382" alt="image" src="https://github.com/tangly1024/NotionNext/assets/23479787/a64f8cac-5f3f-41d6-93c5-c230061b0751">