### PR TITLE
fix: medium theme page refresh causing the catalog loss

### DIFF
--- a/themes/medium/components/BottomMenuBar.js
+++ b/themes/medium/components/BottomMenuBar.js
@@ -4,7 +4,7 @@ import JumpToTopButton from './JumpToTopButton'
 
 export default function BottomMenuBar ({ post, className }) {
   const { tocVisible, changeTocVisible } = useMediumGlobal()
-  const showTocBotton = post?.toc?.length > 0
+  const showTocButton = post?.toc?.length > 0
 
   const toggleToc = () => {
     changeTocVisible(!tocVisible)
@@ -18,13 +18,13 @@ export default function BottomMenuBar ({ post, className }) {
             <i className='fas fa-search'/>
           </div>
         </Link>
-        <div className='flex w-full items-center justify-center cursor-pointer'>
+        <div className='flex w-full items-center justify-center cursor-pointer z-20'>
           <JumpToTopButton/>
         </div>
-        {showTocBotton && <div onClick={toggleToc} className='flex w-full items-center justify-center cursor-pointer'>
+        {showTocButton && <div onClick={toggleToc} className='flex w-full items-center justify-center cursor-pointer z-30'>
           <i className='fas fa-list-ol ' />
         </div>}
-        { !showTocBotton && <Link href='/' passHref legacyBehavior>
+        { !showTocButton && <Link href='/' passHref legacyBehavior>
           <div className='flex w-full items-center justify-center cursor-pointer'>
             <i className='fas fa-home' />
           </div>

--- a/themes/medium/index.js
+++ b/themes/medium/index.js
@@ -51,12 +51,20 @@ const LayoutBase = props => {
   const router = useRouter()
   const [tocVisible, changeTocVisible] = useState(false)
   const { onLoading, fullWidth } = useGlobal()
+  const [slotRight, setSlotRight] = useState(null);
 
-  const slotRight = post?.toc?.length > 0 && (
-    <div key={locale.COMMON.TABLE_OF_CONTENTS} >
-        <Catalog toc={post?.toc} />
-    </div>
-  )
+  useEffect(()=> {
+    if (post?.toc?.length > 0) {
+      setSlotRight(
+        <div key={locale.COMMON.TABLE_OF_CONTENTS}>
+          <Catalog toc={post?.toc} />
+        </div>
+      );
+    } else {
+      setSlotRight(null);
+    }
+  },[post])
+
   const slotTop = <BlogPostBar {...props} />
 
   return (
@@ -178,7 +186,7 @@ const LayoutSlug = props => {
   }, [post])
 
   return (
-        <div showInfoCard={true} slotRight={slotRight} {...props} >
+        <div {...props} >
             {/* 文章锁 */}
             {lock && <ArticleLock validPassword={validPassword} />}
 


### PR DESCRIPTION
问题：
1. medium 主题文章页面 PC 端刷新页面会丢失目录标签
2. medium 主题文章页面 手机端「返回顶部按钮」不展示时存在 dom 覆盖了右下角的目录操作热区

解决：
1. 用 useEffect 监听 post 触发视图刷新，react 现学的帮忙看下
2. 用 z-index 增加目录按钮层级
<img width="417" alt="image" src="https://github.com/tangly1024/NotionNext/assets/23479787/b4aad4d3-0900-4184-8258-20b73bf0b6c2">
