### PR TITLE
feat: 增加支持数据库引用外部笔记页面 #2442

### DIFF
--- a/blog.config.js
+++ b/blog.config.js
@@ -491,6 +491,7 @@ const BLOG = {
     password: process.env.NEXT_PUBLIC_NOTION_PROPERTY_PASSWORD || 'password',
     type: process.env.NEXT_PUBLIC_NOTION_PROPERTY_TYPE || 'type', // 文章类型，
     type_post: process.env.NEXT_PUBLIC_NOTION_PROPERTY_TYPE_POST || 'Post', // 当type文章类型与此值相同时，为博文。
+    type_post_url: process.env.NEXT_PUBLIC_NOTION_PROPERTY_TYPE_POST_URL || 'Post_url', // 当type文章类型与此值相同时，为外链博文。
     type_page: process.env.NEXT_PUBLIC_NOTION_PROPERTY_TYPE_PAGE || 'Page', // 当type文章类型与此值相同时，为单页。
     type_notice:
       process.env.NEXT_PUBLIC_NOTION_PROPERTY_TYPE_NOTICE || 'Notice', // 当type文章类型与此值相同时，为公告。

--- a/lib/db/getSiteData.js
+++ b/lib/db/getSiteData.js
@@ -508,9 +508,9 @@ async function getDataBaseInfoByNotionAPI({ pageId, from }) {
   const NOTION_CONFIG = (await getConfigMapFromConfigPage(collectionData)) || {}
 
   // 处理每一条数据的字段
-  collectionData.forEach(function (element) {
-    adjustPageProperties(element, NOTION_CONFIG)
-  })
+  for (const element of collectionData) {
+    await adjustPageProperties(element, NOTION_CONFIG);
+  }
 
   const siteInfo = getSiteInfo({ collection, block, pageId })
 

--- a/lib/notion/getNotionPost.js
+++ b/lib/notion/getNotionPost.js
@@ -33,6 +33,7 @@ export async function getPost(pageId) {
     ),
     fullWidth: postInfo?.fullWidth || false,
     page_cover: getPageCover(postInfo) || BLOG.HOME_BANNER_IMAGE,
+    pageIcon: postInfo?.format?.page_icon,
     date: {
       start_date: formatDate(
         new Date(postInfo?.last_edited_time).toString(),

--- a/lib/notion/getPageProperties.js
+++ b/lib/notion/getPageProperties.js
@@ -173,7 +173,7 @@ function mapProperties(properties) {
  * 过滤处理页面数据
  * 过滤处理过程会用到NOTION_CONFIG中的配置
  */
-export function adjustPageProperties(properties, NOTION_CONFIG) {
+export async function adjustPageProperties(properties, NOTION_CONFIG) {
   // 处理URL
   // 1.按照用户配置的URL_PREFIX 转换一下slug
   // 2.为文章添加一个href字段，存储最终调整的路径
@@ -193,8 +193,8 @@ export function adjustPageProperties(properties, NOTION_CONFIG) {
        * Post_url外链格式与Post对齐
        * pageCover和pageIcon优先使用数据库数据
        */
-      properties.pageCover = !properties.pageCover ?  originPage.page_cover : properties.pageCover
-      properties.pageCoverThumbnail = !properties.pageCoverThumbnail ?  originPage.page_cover : properties.pageCoverThumbnail
+      properties.pageCover = !properties.pageCover ? originPage.page_cover : properties.pageCover
+      properties.pageCoverThumbnail = !properties.pageCoverThumbnail ? originPage.page_cover : properties.pageCoverThumbnail
       properties.pageIcon = !properties.pageIcon ? originPage.pageIcon : properties.pageIcon
 
       properties.type = 'Post'

--- a/lib/notion/getPageProperties.js
+++ b/lib/notion/getPageProperties.js
@@ -11,6 +11,7 @@ import {
   sliceUrlFromHttp
 } from '../utils'
 import { mapImgUrl } from './mapImage'
+import { getPost } from '@/lib/notion/getNotionPost'
 
 /**
  * 获取页面元素成员属性
@@ -151,6 +152,9 @@ function mapProperties(properties) {
   if (properties?.type === BLOG.NOTION_PROPERTY_NAME.type_post) {
     properties.type = 'Post'
   }
+  if (properties?.type === BLOG.NOTION_PROPERTY_NAME.type_post_url) {
+    properties.type = 'Post_url'
+  }
   if (properties?.type === BLOG.NOTION_PROPERTY_NAME.type_page) {
     properties.type = 'Page'
   }
@@ -178,6 +182,31 @@ export function adjustPageProperties(properties, NOTION_CONFIG) {
       properties.slug = generateCustomizeSlug(properties, NOTION_CONFIG)
     }
     properties.href = properties.slug ?? properties.id
+  } else if (properties.type === 'Post_url') {
+    const regex = /[0-9a-f]{32}$/
+    const id = properties.url.match(regex)[0]
+    if (id) {
+      // 获取外链页面数据
+      const originPage = await getPost(id)
+
+      /**
+       * Post_url外链格式与Post对齐
+       * pageCover和pageIcon优先使用数据库数据
+       */
+      properties.pageCover = !properties.pageCover ?  originPage.page_cover : properties.pageCover
+      properties.pageCoverThumbnail = !properties.pageCoverThumbnail ?  originPage.page_cover : properties.pageCoverThumbnail
+      properties.pageIcon = !properties.pageIcon ? originPage.pageIcon : properties.pageIcon
+
+      properties.type = 'Post'
+      properties.id = id
+      properties.publishDay = originPage.createdTime
+      properties.lastEditedDay = originPage.lastEditedDay
+
+      if (siteConfig('POST_URL_PREFIX', '', NOTION_CONFIG)) {
+        properties.slug = generateCustomizeSlug(properties, NOTION_CONFIG)
+      }
+      properties.href = properties.slug ?? properties.id
+    }
   } else if (properties.type === 'Page') {
     properties.href = properties.slug ?? properties.id
   } else if (properties.type === 'Menu' || properties.type === 'SubMenu') {


### PR DESCRIPTION
1. 数据库Type创建**Post_url**选项作为读取数据库外部文章的标签
2. 数据库新增 **url** 属性，作为读取数据库外部文章的连接，可以填写完整url或者page id

![PixPin_2024-06-13_17-13-30](https://github.com/tangly1024/NotionNext/assets/57619369/6d4de64f-9b81-4ad0-a673-ec2cd71bfb91)

修改内容：如果标签是Post_url则手动将数据库对应页面id修改为指向的pageId，数据库的标题、icon和封面图优先读取数据库页面的数据