### PR TITLE
feat: 增加支持数据库引用外部笔记页面 #2442

### DIFF
--- a/blog.config.js
+++ b/blog.config.js
@@ -491,6 +491,7 @@ const BLOG = {
     password: process.env.NEXT_PUBLIC_NOTION_PROPERTY_PASSWORD || 'password',
     type: process.env.NEXT_PUBLIC_NOTION_PROPERTY_TYPE || 'type', // 文章类型，
     type_post: process.env.NEXT_PUBLIC_NOTION_PROPERTY_TYPE_POST || 'Post', // 当type文章类型与此值相同时，为博文。
+    type_post_url: process.env.NEXT_PUBLIC_NOTION_PROPERTY_TYPE_POST_URL || 'Post_url', // 当type文章类型与此值相同时，为外链博文。
     type_page: process.env.NEXT_PUBLIC_NOTION_PROPERTY_TYPE_PAGE || 'Page', // 当type文章类型与此值相同时，为单页。
     type_notice:
       process.env.NEXT_PUBLIC_NOTION_PROPERTY_TYPE_NOTICE || 'Notice', // 当type文章类型与此值相同时，为公告。

--- a/blog.config.js
+++ b/blog.config.js
@@ -17,6 +17,8 @@ const BLOG = {
   IS_TAG_COLOR_DISTINGUISHED:
     process.env.NEXT_PUBLIC_IS_TAG_COLOR_DISTINGUISHED === 'true' || true, // 对于名称相同的tag是否区分tag的颜色
 
+  TOGGLE_EXPAND: process.env.NEXT_PUBLIC_TOGGLE_EXPAND || false, // notion折叠块(普通或者标题)是否在加载时展开
+
   // 3.14.1版本后，欢迎语在此配置，英文逗号隔开 ,  即可支持多个欢迎语打字效果。
   GREETING_WORDS:
     process.env.NEXT_PUBLIC_GREETING_WORDS ||

--- a/components/NotionPage.js
+++ b/components/NotionPage.js
@@ -166,7 +166,7 @@ const autoScrollToHash = () => {
 }
 
 const allToggleExpand = (NOTION_CONFIG) => {
-  if (JSON.parse(siteConfig('TOGGLE_EXPAND', true))) {
+  if (JSON.parse(siteConfig('TOGGLE_EXPAND', null, NOTION_CONFIG))) {
     const wrapperElement = document.getElementById('wrapper')
     if (wrapperElement) {
       const detailsElements = wrapperElement.getElementsByClassName('notion-toggle')

--- a/components/NotionPage.js
+++ b/components/NotionPage.js
@@ -6,6 +6,7 @@ import 'katex/dist/katex.min.css'
 import dynamic from 'next/dynamic'
 import { useEffect, useRef } from 'react'
 import { NotionRenderer } from 'react-notion-x'
+import { useGlobal } from '@/lib/global'
 
 /**
  * 整个站点的核心组件
@@ -14,6 +15,8 @@ import { NotionRenderer } from 'react-notion-x'
  * @returns
  */
 const NotionPage = ({ post, className }) => {
+  const { NOTION_CONFIG } = useGlobal()
+
   // 是否关闭数据库和画册的点击跳转
   const POST_DISABLE_GALLERY_CLICK = siteConfig('POST_DISABLE_GALLERY_CLICK')
   const POST_DISABLE_DATABASE_CLICK = siteConfig('POST_DISABLE_DATABASE_CLICK')
@@ -32,6 +35,9 @@ const NotionPage = ({ post, className }) => {
   useEffect(() => {
     // 检测当前的url并自动滚动到对应目标
     autoScrollToHash()
+
+    // toggle块全部展开
+    allToggleExpand(NOTION_CONFIG)
   }, [])
 
   // 页面文章发生变化时会执行的勾子
@@ -157,6 +163,20 @@ const autoScrollToHash = () => {
       }
     }
   }, 180)
+}
+
+const allToggleExpand = (NOTION_CONFIG) => {
+  if (JSON.parse(siteConfig('TOGGLE_EXPAND', true))) {
+    const wrapperElement = document.getElementById('wrapper')
+    if (wrapperElement) {
+      const detailsElements = wrapperElement.getElementsByClassName('notion-toggle')
+      if (detailsElements.length > 0) {
+        for (const element of detailsElements) {
+          element.setAttribute('open', 'true')
+        }
+      }
+    }
+  }
 }
 
 /**

--- a/components/NotionPage.js
+++ b/components/NotionPage.js
@@ -166,7 +166,6 @@ const autoScrollToHash = () => {
 }
 
 const allToggleExpand = (NOTION_CONFIG) => {
-  console.log(NOTION_CONFIG)
   const TOGGLE_EXPAND = JSON.parse(siteConfig('TOGGLE_EXPAND', false, NOTION_CONFIG))
   if (TOGGLE_EXPAND) {
     const wrapperElement = document.getElementById('wrapper')

--- a/components/NotionPage.js
+++ b/components/NotionPage.js
@@ -166,9 +166,9 @@ const autoScrollToHash = () => {
 }
 
 const allToggleExpand = (NOTION_CONFIG) => {
-  const toggleExpand = JSON.parse(siteConfig('', null, NOTION_CONFIG))
-  console.log("Config->TOGGLE_EXPAND: ", toggleExpand)
-  if (toggleExpand) {
+  console.log(NOTION_CONFIG)
+  const TOGGLE_EXPAND = JSON.parse(siteConfig('TOGGLE_EXPAND', false, NOTION_CONFIG))
+  if (TOGGLE_EXPAND) {
     const wrapperElement = document.getElementById('wrapper')
     if (wrapperElement) {
       const detailsElements = wrapperElement.getElementsByClassName('notion-toggle')

--- a/components/NotionPage.js
+++ b/components/NotionPage.js
@@ -166,7 +166,9 @@ const autoScrollToHash = () => {
 }
 
 const allToggleExpand = (NOTION_CONFIG) => {
-  if (JSON.parse(siteConfig('TOGGLE_EXPAND', null, NOTION_CONFIG))) {
+  const toggleExpand = JSON.parse(siteConfig('', null, NOTION_CONFIG))
+  console.log("Config->TOGGLE_EXPAND: ", toggleExpand)
+  if (toggleExpand) {
     const wrapperElement = document.getElementById('wrapper')
     if (wrapperElement) {
       const detailsElements = wrapperElement.getElementsByClassName('notion-toggle')

--- a/lib/db/getSiteData.js
+++ b/lib/db/getSiteData.js
@@ -508,9 +508,9 @@ async function getDataBaseInfoByNotionAPI({ pageId, from }) {
   const NOTION_CONFIG = (await getConfigMapFromConfigPage(collectionData)) || {}
 
   // 处理每一条数据的字段
-  collectionData.forEach(function (element) {
-    adjustPageProperties(element, NOTION_CONFIG)
-  })
+  for (const element of collectionData) {
+    await adjustPageProperties(element, NOTION_CONFIG);
+  }
 
   const siteInfo = getSiteInfo({ collection, block, pageId })
 

--- a/lib/notion/getNotionPost.js
+++ b/lib/notion/getNotionPost.js
@@ -33,6 +33,7 @@ export async function getPost(pageId) {
     ),
     fullWidth: postInfo?.fullWidth || false,
     page_cover: getPageCover(postInfo) || BLOG.HOME_BANNER_IMAGE,
+    pageIcon: postInfo?.format?.page_icon,
     date: {
       start_date: formatDate(
         new Date(postInfo?.last_edited_time).toString(),

--- a/lib/notion/getPageProperties.js
+++ b/lib/notion/getPageProperties.js
@@ -173,7 +173,7 @@ function mapProperties(properties) {
  * 过滤处理页面数据
  * 过滤处理过程会用到NOTION_CONFIG中的配置
  */
-export function adjustPageProperties(properties, NOTION_CONFIG) {
+export async function adjustPageProperties(properties, NOTION_CONFIG) {
   // 处理URL
   // 1.按照用户配置的URL_PREFIX 转换一下slug
   // 2.为文章添加一个href字段，存储最终调整的路径
@@ -193,8 +193,8 @@ export function adjustPageProperties(properties, NOTION_CONFIG) {
        * Post_url外链格式与Post对齐
        * pageCover和pageIcon优先使用数据库数据
        */
-      properties.pageCover = !properties.pageCover ?  originPage.page_cover : properties.pageCover
-      properties.pageCoverThumbnail = !properties.pageCoverThumbnail ?  originPage.page_cover : properties.pageCoverThumbnail
+      properties.pageCover = !properties.pageCover ? originPage.page_cover : properties.pageCover
+      properties.pageCoverThumbnail = !properties.pageCoverThumbnail ? originPage.page_cover : properties.pageCoverThumbnail
       properties.pageIcon = !properties.pageIcon ? originPage.pageIcon : properties.pageIcon
 
       properties.type = 'Post'

--- a/lib/notion/getPageProperties.js
+++ b/lib/notion/getPageProperties.js
@@ -11,6 +11,7 @@ import {
   sliceUrlFromHttp
 } from '../utils'
 import { mapImgUrl } from './mapImage'
+import { getPost } from '@/lib/notion/getNotionPost'
 
 /**
  * 获取页面元素成员属性
@@ -151,6 +152,9 @@ function mapProperties(properties) {
   if (properties?.type === BLOG.NOTION_PROPERTY_NAME.type_post) {
     properties.type = 'Post'
   }
+  if (properties?.type === BLOG.NOTION_PROPERTY_NAME.type_post_url) {
+    properties.type = 'Post_url'
+  }
   if (properties?.type === BLOG.NOTION_PROPERTY_NAME.type_page) {
     properties.type = 'Page'
   }
@@ -178,6 +182,31 @@ export function adjustPageProperties(properties, NOTION_CONFIG) {
       properties.slug = generateCustomizeSlug(properties, NOTION_CONFIG)
     }
     properties.href = properties.slug ?? properties.id
+  } else if (properties.type === 'Post_url') {
+    const regex = /[0-9a-f]{32}$/
+    const id = properties.url.match(regex)[0]
+    if (id) {
+      // 获取外链页面数据
+      const originPage = await getPost(id)
+
+      /**
+       * Post_url外链格式与Post对齐
+       * pageCover和pageIcon优先使用数据库数据
+       */
+      properties.pageCover = !properties.pageCover ?  originPage.page_cover : properties.pageCover
+      properties.pageCoverThumbnail = !properties.pageCoverThumbnail ?  originPage.page_cover : properties.pageCoverThumbnail
+      properties.pageIcon = !properties.pageIcon ? originPage.pageIcon : properties.pageIcon
+
+      properties.type = 'Post'
+      properties.id = id
+      properties.publishDay = originPage.createdTime
+      properties.lastEditedDay = originPage.lastEditedDay
+
+      if (siteConfig('POST_URL_PREFIX', '', NOTION_CONFIG)) {
+        properties.slug = generateCustomizeSlug(properties, NOTION_CONFIG)
+      }
+      properties.href = properties.slug ?? properties.id
+    }
   } else if (properties.type === 'Page') {
     properties.href = properties.slug ?? properties.id
   } else if (properties.type === 'Menu' || properties.type === 'SubMenu') {


### PR DESCRIPTION
1. 数据库Type创建Post_url选项作为读取数据库外部文章的标签
2. 数据库新增 url 属性，作为读取数据库外部文章的连接，可以填写完整url或者page id
3. 
![PixPin_2024-06-13_17-13-30](https://github.com/tangly1024/NotionNext/assets/57619369/39943936-69b9-45b3-a773-610dcb52bbf0)
修改内容：如果标签是Post_url则手动将数据库对应页面id修改为指向的pageId，数据库的标题、icon和封面图优先读取数据库页面的数据