### PR TITLE
Do not compress svg image

### DIFF
--- a/lib/notion/mapImage.js
+++ b/lib/notion/mapImage.js
@@ -110,6 +110,8 @@ const compressImage = (image, width, quality = 50, fmt = 'webp') => {
     return image
   }
 
+  if (image.includes(".svg")) return image
+
   if (!width || width === 0) {
     width = siteConfig('IMAGE_COMPRESS_WIDTH')
   }


### PR DESCRIPTION
Since svg is not a pixel image, it shouldn't be compress through oss, and it will also lead to error.