### PR TITLE
http字符可能出现在字符串中间，修复slug填写外联报错bug

### DIFF
--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -97,7 +97,7 @@ export function isUrl(str) {
 // 检查是否外链
 export function checkStartWithHttp(str) {
   // 检查字符串是否包含http
-  if (str?.indexOf('http:') === 0 || str?.indexOf('https:') === 0) {
+  if (str?.indexOf('http:') > -1 || str?.indexOf('https:') > -1 ) {
     // 如果包含，找到http的位置
     return str?.indexOf('http') > -1
   } else {


### PR DESCRIPTION
#2521 修复这个问题，根据代码注释看来这个函数应该是判断是否包含http，但是你在 [external css 修复 ](https://github.com/tangly1024/NotionNext/commit/be048bb51e2c8d4dbe26fcc2769f9a8a895162ed)这个提交里头引入了问题，请确认