### PR TITLE
修复外链编译打包问题

### DIFF
--- a/lib/db/getSiteData.js
+++ b/lib/db/getSiteData.js
@@ -526,7 +526,7 @@ async function getDataBaseInfoByNotionAPI({ pageId, from }) {
     return (
       post &&
       post?.slug &&
-      !post?.slug?.startsWith('http') &&
+      //   !post?.slug?.startsWith('http') &&
       (post?.status === 'Invisible' || post?.status === 'Published')
     )
   })

--- a/lib/notion/getPageProperties.js
+++ b/lib/notion/getPageProperties.js
@@ -8,8 +8,7 @@ import { siteConfig } from '../config'
 import {
   checkStartWithHttp,
   convertUrlStartWithOneSlash,
-  getLastSegmentFromUrl,
-  sliceUrlFromHttp
+  getLastSegmentFromUrl
 } from '../utils'
 import { extractLangPrefix } from '../utils/pageId'
 import { mapImgUrl } from './mapImage'
@@ -188,29 +187,26 @@ export function adjustPageProperties(properties, NOTION_CONFIG) {
     properties.name = properties.title ?? ''
   }
 
-  // 开启伪静态路径
-  if (siteConfig('PSEUDO_STATIC', false, NOTION_CONFIG)) {
-    if (
-      !properties?.href?.endsWith('.html') &&
-      !properties?.href?.startsWith('http') &&
-      properties?.href !== '' &&
-      properties?.href !== '#' &&
-      properties?.href !== '/'
-    ) {
-      properties.href += '.html'
-    }
-  }
-
-  // 检查处理外链
-  properties.href = checkStartWithHttp(properties?.href)
-    ? sliceUrlFromHttp(properties?.href)
-    : convertUrlStartWithOneSlash(properties?.href)
-
-  // 设置链接在页内或新页面打开
-  if (properties.href?.indexOf('http') === 0) {
+  // http or https 开头的视为外链
+  if (checkStartWithHttp(properties?.slug)) {
+    properties.href = properties?.slug
     properties.target = '_blank'
   } else {
     properties.target = '_self'
+    // 伪静态路径右侧拼接.html
+    if (siteConfig('PSEUDO_STATIC', false, NOTION_CONFIG)) {
+      if (
+        !properties?.href?.endsWith('.html') &&
+        !properties?.href?.startsWith('http') &&
+        properties?.href !== '' &&
+        properties?.href !== '#' &&
+        properties?.href !== '/'
+      ) {
+        properties.href += '.html'
+      }
+    }
+    // 相对路径转绝对路径：url左侧拼接 /
+    convertUrlStartWithOneSlash(properties?.href)
   }
 
   // 如果跳转链接是多语言，则在新窗口打开
@@ -239,6 +235,10 @@ export function adjustPageProperties(properties, NOTION_CONFIG) {
  * @returns
  */
 function generateCustomizeSlug(postProperties, NOTION_CONFIG) {
+  // 外链不处理
+  if (checkStartWithHttp(postProperties.slug)) {
+    return postProperties.slug
+  }
   let fullPrefix = ''
   const allSlugPatterns = siteConfig(
     'POST_URL_PREFIX',

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -47,7 +47,12 @@ export const memorize = Component => {
   return memo(MemoizedComponent)
 }
 
-// 转换外链
+/**
+ * 诸如 article/https://test.com 等被错误拼接前缀的slug进行处理
+ * 转换为 https://test.com
+ * @param {*} str
+ * @returns
+ */
 export function sliceUrlFromHttp(str) {
   // 检查字符串是否包含http
   if (str?.includes('http:') || str?.includes('https:')) {
@@ -99,7 +104,7 @@ export function checkStartWithHttp(str) {
   // 检查字符串是否包含http
   if (str?.indexOf('http:') === 0 || str?.indexOf('https:') === 0) {
     // 如果包含，找到http的位置
-    return str?.indexOf('http') > -1
+    return true
   } else {
     // 不包含
     return false


### PR DESCRIPTION
相关问题：
https://github.com/tangly1024/NotionNext/pull/2525

https://github.com/tangly1024/NotionNext/issues/2521

当slug为http:或https:开头的外链时会产生的bug。