### PR TITLE
去除对BootCDN资源的调用

### DIFF
--- a/components/Fireworks.js
+++ b/components/Fireworks.js
@@ -18,7 +18,7 @@ const Fireworks = () => {
     // 异步加载
     async function loadFireworks() {
       loadExternalResource(
-        'https://cdn.bootcdn.net/ajax/libs/animejs/3.2.1/anime.min.js',
+        'https://cdnjs.snrat.com/ajax/libs/animejs/3.2.1/anime.min.js',
         'js'
       ).then(() => {
         loadExternalResource('/js/fireworks.js', 'js').then(() => {

--- a/components/LoadingProgress.js
+++ b/components/LoadingProgress.js
@@ -11,7 +11,7 @@ export default function LoadingProgress() {
   // 加载进度条
   useEffect(() => {
     loadExternalResource(
-      'https://cdn.bootcdn.net/ajax/libs/nprogress/0.2.0/nprogress.min.js',
+      'https://cdnjs.snrat.com/ajax/libs/nprogress/0.2.0/nprogress.min.js',
       'js'
     ).then(() => {
       if (window.NProgress) {
@@ -19,7 +19,7 @@ export default function LoadingProgress() {
         // 调速
         window.NProgress.settings.minimun = 0.1
         loadExternalResource(
-          'https://cdn.bootcdn.net/ajax/libs/nprogress/0.2.0/nprogress.min.css',
+          'https://cdnjs.snrat.com/ajax/libs/nprogress/0.2.0/nprogress.min.css',
           'css'
         )
       }


### PR DESCRIPTION
去除~\components\LoadingProgress.js和~\components\Fireworks.js两个文件里对BootCDN的调用，
将：
https://cdn.bootcdn.net/ajax/libs/nprogress/0.2.0/nprogress.min.js
https://cdn.bootcdn.net/ajax/libs/nprogress/0.2.0/nprogress.min.css
https://cdn.bootcdn.net/ajax/libs/animejs/3.2.1/anime.min.js
修改为：
https://cdnjs.snrat.com/ajax/libs/nprogress/0.2.0/nprogress.min.js
https://cdnjs.snrat.com/ajax/libs/nprogress/0.2.0/nprogress.min.css
https://cdnjs.snrat.com/ajax/libs/animejs/3.2.1/anime.min.js

版本：NotionNext 4.6.1
Fork时间：2024/8/3 16 o'clock