### PR TITLE
修复：game主题下，向后翻页"Next"按钮不显示

### DIFF
--- a/themes/game/components/BlogListPage.js
+++ b/themes/game/components/BlogListPage.js
@@ -1,3 +1,4 @@
+import { siteConfig } from '@/lib/config'
 import { useGlobal } from '@/lib/global'
 import { GameListIndexCombine } from './GameListIndexCombine'
 import PaginationSimple from './PaginationSimple'
@@ -9,7 +10,8 @@ import PaginationSimple from './PaginationSimple'
 export const BlogListPage = props => {
   const { page = 1, postCount } = props
   const { NOTION_CONFIG } = useGlobal()
-  const totalPage = Math.ceil(postCount / NOTION_CONFIG)
+  const POSTS_PER_PAGE = siteConfig('POSTS_PER_PAGE', null, NOTION_CONFIG)
+  const totalPage = Math.ceil(postCount / POSTS_PER_PAGE)
   const showNext = page < totalPage
 
   return (


### PR DESCRIPTION
# 修复详情
修复game主题的Page文章列表样式下，向后翻页"Next->"按钮不显示的问题。

# 问题定位
发生问题的文件为themes\game\components\BlogListPage.js
```js
const totalPage = Math.ceil(postCount / NOTION_CONFIG)
const showNext = page < totalPage
```
NOTION_CONFIG不是数字，导致totalPage = NaN，showNext始终为false，向后翻页按钮"Next->"总是不显示. 

# 修复思路
其它主题下可以正确显示翻页按钮，因此可以参考其它主题下的文件，例如themes\simple\components\BlogListPage.js，以修复game主题下向后翻页按钮"Next->"不显示的问题。