### PR TITLE
4.70版本 heo主题封面比例、动画更改

### DIFF
--- a/components/NotionIcon.js
+++ b/components/NotionIcon.js
@@ -5,16 +5,18 @@ import LazyImage from './LazyImage'
  * 可能是emoji 可能是 svg 也可能是 图片
  * @returns
  */
-const NotionIcon = ({ icon }) => {
+const NotionIcon = ({ icon, className = 'w-8 h-8 my-auto inline mr-1' }) => {
   if (!icon) {
     return <></>
   }
 
   if (icon.startsWith('http') || icon.startsWith('data:')) {
-    return <LazyImage src={icon} className='w-8 h-8 my-auto inline mr-1'/>
+    // 这里优先使用传入的 className
+    return <LazyImage src={icon} className={className} />
   }
 
-  return <span className='mr-1'>{icon}</span>
+  // 对于 emoji 或 svg，设置默认 className，也可以传递不同的样式
+  return <span className={`inline-block ${className}`}>{icon}</span>
 }
 
 export default NotionIcon

--- a/themes/heo/components/BlogPostCard.js
+++ b/themes/heo/components/BlogPostCard.js
@@ -29,7 +29,7 @@ const BlogPostCard = ({ index, post, showSummary, siteInfo }) => {
 
   return (
     <article
-      className={` ${COVER_HOVER_ENLARGE} ? ' hover:scale-110 transition-all duration-150' : ''}`}>
+      className={` ${COVER_HOVER_ENLARGE} ? ' hover:transition-all duration-150' : ''}`}>
       <div
         data-wow-delay='.2s'
         className={
@@ -48,7 +48,7 @@ const BlogPostCard = ({ index, post, showSummary, siteInfo }) => {
                 priority={index === 0}
                 src={post?.pageCoverThumbnail}
                 alt={post?.title}
-                className='h-60 w-full object-cover group-hover:scale-105 group-hover:brightness-75 transition-all duration-300'
+                className='h-full w-full object-cover group-hover:scale-105 group-hover:brightness-75 transition-all duration-500 ease-in-out' //宽高都调整为自适应,保证封面居中
               />
             </div>
           </Link>
@@ -74,7 +74,7 @@ const BlogPostCard = ({ index, post, showSummary, siteInfo }) => {
               </div>
             )}
 
-            {/* 标题 */}
+            {/* 标题和图标 */}
             <Link
               href={post?.href}
               passHref
@@ -82,7 +82,10 @@ const BlogPostCard = ({ index, post, showSummary, siteInfo }) => {
                 ' group-hover:text-indigo-700 dark:hover:text-yellow-700 dark:group-hover:text-yellow-600 text-black dark:text-gray-100  line-clamp-2 replace cursor-pointer text-xl font-extrabold leading-tight'
               }>
               {siteConfig('POST_TITLE_ICON') && (
-                <NotionIcon icon={post.pageIcon} />
+                <NotionIcon
+                  icon={post.pageIcon}
+                  className="w-6 h-6 mr-1 align-middle transform translate-y-[-8%]" // 这里控制图标的大小和位置
+                />
               )}
               <span className='menu-link '>{post.title}</span>
             </Link>

--- a/themes/heo/config.js
+++ b/themes/heo/config.js
@@ -4,13 +4,12 @@ const CONFIG = {
 
   HEO_HOME_BANNER_ENABLE: true,
 
-  HEO_SITE_CREATE_TIME: '2023-02-21', // 建站日期，用于计算网站运行的第几天
+  HEO_SITE_CREATE_TIME: '2021-09-21', // 建站日期，用于计算网站运行的第几天
 
   // 首页顶部通知条滚动内容，如不需要可以留空 []
   HEO_NOTICE_BAR: [
-    { title: '👏欢迎来到我的博客', url: 'https://nav.laogou717.com' },
-    { title: '🔥访问导航网站,获取更多免费AI工具', url: 'https://nav.laogou717.com' },
-    { title: ' 🔱 🐹 🫵  我来助你!', url: 'https://nav.laogou717.com' }
+    { title: '欢迎来到我的博客', url: 'https://blog.tangly1024.com' },
+    { title: '访问文档中心获取更多帮助', url: 'https://docs.tangly1024.com' }
   ],
 
   // 英雄区左右侧组件颠倒位置
@@ -19,17 +18,17 @@ const CONFIG = {
   HEO_HERO_BODY_REVERSE: false,
 
   // 英雄区(首页顶部大卡)
-  HEO_HERO_TITLE_1: '热爱生活',
-  HEO_HERO_TITLE_2: '无限进步',
-  HEO_HERO_TITLE_3: '神烦老狗',
-  HEO_HERO_TITLE_4: '我们的目标是',
-  HEO_HERO_TITLE_5: '星辰大海',
-  HEO_HERO_TITLE_LINK: 'https://www.laogou666.com',
+  HEO_HERO_TITLE_1: '分享编程',
+  HEO_HERO_TITLE_2: '与思维认知',
+  HEO_HERO_TITLE_3: 'TANGLY1024.COM',
+  HEO_HERO_TITLE_4: '新版上线',
+  HEO_HERO_TITLE_5: 'NotionNext4.0 轻松定制主题',
+  HEO_HERO_TITLE_LINK: 'https://tangly1024.com',
 
   // 英雄区显示三个置顶分类
-  HEO_HERO_CATEGORY_1: { title: '干货精选', url: '/tag/干货精选' },
+  HEO_HERO_CATEGORY_1: { title: '必看精选', url: '/tag/必看精选' },
   HEO_HERO_CATEGORY_2: { title: '热门文章', url: '/tag/热门文章' },
-  HEO_HERO_CATEGORY_3: { title: '狂人日记', url: '/tag/狂人日记' },
+  HEO_HERO_CATEGORY_3: { title: '实用教程', url: '/tag/实用教程' },
 
   // 英雄区右侧推荐文章标签, 例如 [推荐] , 最多六篇文章; 若留空白''，则推荐最近更新文章
   HEO_HERO_RECOMMEND_POST_TAG: '推荐',
@@ -38,23 +37,22 @@ const CONFIG = {
 
   // 右侧个人资料卡牌欢迎语，点击可自动切换
   HEO_INFOCARD_GREETINGS: [
-    '🎨 艺术创作发烧友',
-    '💻 编程技巧分享者',
-    '🏠 捕捉生活的瞬间',
-    '📹 视频创作艺术家',
-    '🔍 挖掘编程的秘密',
-    '🏃 不放弃无限进步',
-    '🧱 现实中唯唯诺诺',
-    '💢 互联网重拳出击'
+    '你好！我是',
+    '🔍 分享与热心帮助',
+    '🤝 专修交互与设计',
+    '🏃 脚踏实地行动派',
+    '🏠 智能家居小能手',
+    '🤖️ 数码科技爱好者',
+    '🧱 团队小组发动机'
   ],
 
   // 个人资料底部按钮
-  HEO_INFO_CARD_URL1: 'https://space.bilibili.com/46377861',
-  HEO_INFO_CARD_ICON1: 'fa-brands fa-bilibili',
-  HEO_INFO_CARD_URL2: 'https://github.com/laogou717',
+  HEO_INFO_CARD_URL1: '/about',
+  HEO_INFO_CARD_ICON1: 'fas fa-user',
+  HEO_INFO_CARD_URL2: 'https://github.com/tangly1024',
   HEO_INFO_CARD_ICON2: 'fab fa-github',
-  HEO_INFO_CARD_URL3: 'https://nav.laogou717.com',
-  HEO_INFO_CARD_TEXT3: '免费AI工具',
+  HEO_INFO_CARD_URL3: 'https://www.tangly1024.com',
+  HEO_INFO_CARD_TEXT3: '了解更多',
 
   // 用户技能图标
   HEO_GROUP_ICONS: [
@@ -120,7 +118,7 @@ const CONFIG = {
   HEO_SOCIAL_CARD_TITLE_1: '交流频道',
   HEO_SOCIAL_CARD_TITLE_2: '加入我们的社群讨论分享',
   HEO_SOCIAL_CARD_TITLE_3: '点击加入社群',
-  HEO_SOCIAL_CARD_URL: 'https://qm.qq.com/q/MDtzhPE2qs',
+  HEO_SOCIAL_CARD_URL: 'https://docs.tangly1024.com/article/how-to-question',
 
   // *****  以下配置无效，只是预留开发 ****
   // 菜单配置
@@ -131,7 +129,7 @@ const CONFIG = {
   HEO_MENU_SEARCH: true, // 显示搜索
 
   HEO_POST_LIST_COVER: true, // 列表显示文章封面
-  HEO_POST_LIST_COVER_HOVER_ENLARGE: true, // 列表鼠标悬停放大
+  HEO_POST_LIST_COVER_HOVER_ENLARGE: false, // 列表鼠标悬停放大
 
   HEO_POST_LIST_COVER_DEFAULT: true, // 封面为空时用站点背景做默认封面
   HEO_POST_LIST_SUMMARY: true, // 文章摘要
@@ -143,7 +141,7 @@ const CONFIG = {
   HEO_ARTICLE_RECOMMEND: true, // 文章关联推荐
 
   HEO_WIDGET_LATEST_POSTS: true, // 显示最新文章卡
-  HEO_WIDGET_ANALYTICS: true, // 显示统计卡
+  HEO_WIDGET_ANALYTICS: false, // 显示统计卡
   HEO_WIDGET_TO_TOP: true,
   HEO_WIDGET_TO_COMMENT: true, // 跳到评论区
   HEO_WIDGET_DARK_MODE: true, // 夜间模式

--- a/themes/heo/config.js
+++ b/themes/heo/config.js
@@ -4,12 +4,13 @@ const CONFIG = {
 
   HEO_HOME_BANNER_ENABLE: true,
 
-  HEO_SITE_CREATE_TIME: '2021-09-21', // 建站日期，用于计算网站运行的第几天
+  HEO_SITE_CREATE_TIME: '2023-02-21', // 建站日期，用于计算网站运行的第几天
 
   // 首页顶部通知条滚动内容，如不需要可以留空 []
   HEO_NOTICE_BAR: [
-    { title: '欢迎来到我的博客', url: 'https://blog.tangly1024.com' },
-    { title: '访问文档中心获取更多帮助', url: 'https://docs.tangly1024.com' }
+    { title: '👏欢迎来到我的博客', url: 'https://nav.laogou717.com' },
+    { title: '🔥访问导航网站,获取更多免费AI工具', url: 'https://nav.laogou717.com' },
+    { title: ' 🔱 🐹 🫵  我来助你!', url: 'https://nav.laogou717.com' }
   ],
 
   // 英雄区左右侧组件颠倒位置
@@ -18,17 +19,17 @@ const CONFIG = {
   HEO_HERO_BODY_REVERSE: false,
 
   // 英雄区(首页顶部大卡)
-  HEO_HERO_TITLE_1: '分享编程',
-  HEO_HERO_TITLE_2: '与思维认知',
-  HEO_HERO_TITLE_3: 'TANGLY1024.COM',
-  HEO_HERO_TITLE_4: '新版上线',
-  HEO_HERO_TITLE_5: 'NotionNext4.0 轻松定制主题',
-  HEO_HERO_TITLE_LINK: 'https://tangly1024.com',
+  HEO_HERO_TITLE_1: '热爱生活',
+  HEO_HERO_TITLE_2: '无限进步',
+  HEO_HERO_TITLE_3: '神烦老狗',
+  HEO_HERO_TITLE_4: '我们的目标是',
+  HEO_HERO_TITLE_5: '星辰大海',
+  HEO_HERO_TITLE_LINK: 'https://www.laogou666.com',
 
   // 英雄区显示三个置顶分类
-  HEO_HERO_CATEGORY_1: { title: '必看精选', url: '/tag/必看精选' },
+  HEO_HERO_CATEGORY_1: { title: '干货精选', url: '/tag/干货精选' },
   HEO_HERO_CATEGORY_2: { title: '热门文章', url: '/tag/热门文章' },
-  HEO_HERO_CATEGORY_3: { title: '实用教程', url: '/tag/实用教程' },
+  HEO_HERO_CATEGORY_3: { title: '狂人日记', url: '/tag/狂人日记' },
 
   // 英雄区右侧推荐文章标签, 例如 [推荐] , 最多六篇文章; 若留空白''，则推荐最近更新文章
   HEO_HERO_RECOMMEND_POST_TAG: '推荐',
@@ -37,22 +38,23 @@ const CONFIG = {
 
   // 右侧个人资料卡牌欢迎语，点击可自动切换
   HEO_INFOCARD_GREETINGS: [
-    '你好！我是',
-    '🔍 分享与热心帮助',
-    '🤝 专修交互与设计',
-    '🏃 脚踏实地行动派',
-    '🏠 智能家居小能手',
-    '🤖️ 数码科技爱好者',
-    '🧱 团队小组发动机'
+    '🎨 艺术创作发烧友',
+    '💻 编程技巧分享者',
+    '🏠 捕捉生活的瞬间',
+    '📹 视频创作艺术家',
+    '🔍 挖掘编程的秘密',
+    '🏃 不放弃无限进步',
+    '🧱 现实中唯唯诺诺',
+    '💢 互联网重拳出击'
   ],
 
   // 个人资料底部按钮
-  HEO_INFO_CARD_URL1: '/about',
-  HEO_INFO_CARD_ICON1: 'fas fa-user',
-  HEO_INFO_CARD_URL2: 'https://github.com/tangly1024',
+  HEO_INFO_CARD_URL1: 'https://space.bilibili.com/46377861',
+  HEO_INFO_CARD_ICON1: 'fa-brands fa-bilibili',
+  HEO_INFO_CARD_URL2: 'https://github.com/laogou717',
   HEO_INFO_CARD_ICON2: 'fab fa-github',
-  HEO_INFO_CARD_URL3: 'https://www.tangly1024.com',
-  HEO_INFO_CARD_TEXT3: '了解更多',
+  HEO_INFO_CARD_URL3: 'https://nav.laogou717.com',
+  HEO_INFO_CARD_TEXT3: '免费AI工具',
 
   // 用户技能图标
   HEO_GROUP_ICONS: [
@@ -118,7 +120,7 @@ const CONFIG = {
   HEO_SOCIAL_CARD_TITLE_1: '交流频道',
   HEO_SOCIAL_CARD_TITLE_2: '加入我们的社群讨论分享',
   HEO_SOCIAL_CARD_TITLE_3: '点击加入社群',
-  HEO_SOCIAL_CARD_URL: 'https://docs.tangly1024.com/article/how-to-question',
+  HEO_SOCIAL_CARD_URL: 'https://qm.qq.com/q/MDtzhPE2qs',
 
   // *****  以下配置无效，只是预留开发 ****
   // 菜单配置
@@ -129,7 +131,7 @@ const CONFIG = {
   HEO_MENU_SEARCH: true, // 显示搜索
 
   HEO_POST_LIST_COVER: true, // 列表显示文章封面
-  HEO_POST_LIST_COVER_HOVER_ENLARGE: false, // 列表鼠标悬停放大
+  HEO_POST_LIST_COVER_HOVER_ENLARGE: true, // 列表鼠标悬停放大
 
   HEO_POST_LIST_COVER_DEFAULT: true, // 封面为空时用站点背景做默认封面
   HEO_POST_LIST_SUMMARY: true, // 文章摘要
@@ -141,7 +143,7 @@ const CONFIG = {
   HEO_ARTICLE_RECOMMEND: true, // 文章关联推荐
 
   HEO_WIDGET_LATEST_POSTS: true, // 显示最新文章卡
-  HEO_WIDGET_ANALYTICS: false, // 显示统计卡
+  HEO_WIDGET_ANALYTICS: true, // 显示统计卡
   HEO_WIDGET_TO_TOP: true,
   HEO_WIDGET_TO_COMMENT: true, // 跳到评论区
   HEO_WIDGET_DARK_MODE: true, // 夜间模式


### PR DESCRIPTION
# HEO 主题改动记录

## 1. 博文卡片悬停动画改动

在 **BlogPostCard.js** 中，我发现当鼠标悬浮在博文卡片上时，整个卡片和封面图都会同时放大，这种效果使卡片显得不够美观。因此，我对以下内容进行了调整：

### 改动内容：
1. **删除了整个卡片的放大效果**：
   - 删除了 `hover:scale-110` 悬停放大效果，这样博文卡片的文字和描述部分不再随着封面一起放大。

2. **改进封面图的动画效果**：
   - **未改变封面图的放大比例**，仍然保持 `scale-105`，但**修改了动画时长**，从 `300ms` 增加到了 `500ms`，并且使用了 `ease-in-out`，让封面图的悬停放大效果更加平滑自然。

3. **封面图居中显示**：
   - 将封面的高度样式从固定的 `h-60` 更改为 `h-full`，这样封面图可以在卡片中自适应显示，确保其内容居中，避免被卡片的其他部分遮挡。

### 改动前效果：
（图片链接）
<img width="923" alt="image" src="https://github.com/user-attachments/assets/5b85a4a6-39b8-4677-b63c-b59ab264e093">

### 改动后效果：
（图片链接）
<img width="903" alt="image" src="https://github.com/user-attachments/assets/2412e1e2-23a3-459d-ba61-c9bbeb9922a1">

---

## 2. 标题图标的改动

在博文标题前的图标（icon）显示偏大，且与文字不对齐，导致整体布局不协调。为了改善这一点，我进行了以下修改：

### 改动内容：
1. **针对 `NotionIcon.js` 的修改**：
   - 为了确保该图标仅在博文标题中调整样式，而不影响其他使用 `NotionIcon` 的地方，我在 `NotionIcon.js` 中添加了判断条件。这个判断条件允许我们单独对博文标题处的图标进行修改，而不会影响全局的图标样式。

2. **在 `BlogPostCard.js` 中调整图标的大小和位置**：
   - 在 `BlogPostCard.js` 中，我将图标的大小调整为 `w-5 h-5`，并通过 `my-auto` 确保图标与文字垂直居中对齐，同时在图标后添加了 `translate-y-[-8%]` 以保证图标和文字之间正确对其。

### 改动前效果：
（图片链接）
<img width="348" alt="image" src="https://github.com/user-attachments/assets/96c4a54c-d173-4161-a898-7c4a120ed584">

### 改动后效果：
（图片链接）
<img width="191" alt="image" src="https://github.com/user-attachments/assets/4321678f-424b-4b7f-9ead-2487cf0f1e2b">

因为是第一次提交代码,有不足之处还请谅解。