### PR TITLE
FIX:替换Twikoo默认CDN

### DIFF
--- a/blog.config.js
+++ b/blog.config.js
@@ -353,7 +353,7 @@ const BLOG = {
     process.env.NEXT_PUBLIC_COMMENT_TWIKOO_COUNT_ENABLE || false, // 博客列表是否显示评论数
   COMMENT_TWIKOO_CDN_URL:
     process.env.NEXT_PUBLIC_COMMENT_TWIKOO_CDN_URL ||
-    'https://cdn.staticfile.net/twikoo/1.6.17/twikoo.min.js', // twikoo客户端cdn
+    'https://cdn.jsdelivr.net/npm/twikoo@1.6.17/dist/twikoo.all.min.js', // twikoo客户端cdn
 
   // utterance
   COMMENT_UTTERRANCES_REPO:


### PR DESCRIPTION
staticfile.org等CDN服务因恶意攻击代码被uBlock屏蔽，替换默认CDN为Twikoo官方文档中的地址
FIX:https://github.com/tangly1024/NotionNext/issues/2742
![141425](https://github.com/user-attachments/assets/0aaf6074-9fdb-4fd6-a5ec-b6b1280fd425)

