### PR TITLE
Fix 404

### DIFF
--- a/components/WordCount.js
+++ b/components/WordCount.js
@@ -28,7 +28,7 @@ export default function WordCount() {
  * 更新字数统计和阅读时间
  */
 function countWords() {
-  const articleText = deleteHtmlTag(document.getElementById('notion-article')?.innerHTML)
+  const articleText = deleteHtmlTag(document.querySelector('#article-wrapper #notion-article')?.innerHTML)
   const wordCount = fnGetCpmisWords(articleText)
   // 阅读速度 300-500每分钟
   document.getElementById('wordCount').innerHTML = wordCount

--- a/themes/commerce/index.js
+++ b/themes/commerce/index.js
@@ -304,7 +304,7 @@ const Layout404 = props => {
     // 延时3秒如果加载失败就返回首页
     setTimeout(() => {
       if (isBrowser) {
-        const article = document.getElementById('notion-article')
+        const article = document.querySelector('#article-wrapper #notion-article')
         if (!article) {
           router.push('/').then(() => {
             // console.log('找不到页面', router.asPath)

--- a/themes/commerce/index.js
+++ b/themes/commerce/index.js
@@ -246,7 +246,7 @@ const LayoutSlug = props => {
       <div className='w-full max-w-screen-xl mx-auto lg:hover:shadow lg:border lg:px-2 lg:py-4 bg-white dark:bg-hexo-black-gray dark:border-black article'>
         {lock && <ArticleLock validPassword={validPassword} />}
 
-        {!lock && (
+        {!lock && post && (
           <div
             id='article-wrapper'
             className='overflow-x-auto flex-grow mx-auto md:w-full md:px-5 '>

--- a/themes/example/index.js
+++ b/themes/example/index.js
@@ -162,7 +162,7 @@ const LayoutSlug = props => {
       setTimeout(
         () => {
           if (isBrowser) {
-            const article = document.getElementById('notion-article')
+            const article = document.querySelector('#article-wrapper #notion-article')
             if (!article) {
               router.push('/404').then(() => {
                 console.warn('找不到页面', router.asPath)

--- a/themes/example/index.js
+++ b/themes/example/index.js
@@ -178,7 +178,7 @@ const LayoutSlug = props => {
     <>
       {lock ? (
         <PostLock validPassword={validPassword} />
-      ) : (
+      ) : post && (
         <div>
           <PostMeta post={post} />
           <div id='article-wrapper'>

--- a/themes/fukasawa/index.js
+++ b/themes/fukasawa/index.js
@@ -143,7 +143,7 @@ const LayoutSlug = props => {
       setTimeout(
         () => {
           if (isBrowser) {
-            const article = document.getElementById('notion-article')
+            const article = document.querySelector('#article-wrapper #notion-article')
             if (!article) {
               router.push('/404').then(() => {
                 console.warn('找不到页面', router.asPath)

--- a/themes/fukasawa/index.js
+++ b/themes/fukasawa/index.js
@@ -159,7 +159,7 @@ const LayoutSlug = props => {
     <>
       {lock ? (
         <ArticleLock validPassword={validPassword} />
-      ) : (
+      ) : post && (
         <ArticleDetail {...props} />
       )}
     </>

--- a/themes/game/index.js
+++ b/themes/game/index.js
@@ -307,7 +307,7 @@ const LayoutSlug = props => {
     <>
       {lock && <ArticleLock validPassword={validPassword} />}
 
-      {!lock && (
+      {!lock && post && (
         <div id='article-wrapper'>
           <div className='game-detail-wrapper w-full grow flex'>
             <div className={`w-full md:py-2`}>

--- a/themes/gitbook/index.js
+++ b/themes/gitbook/index.js
@@ -255,7 +255,7 @@ const LayoutIndex = props => {
         // 重定向到指定文章
         router.push(index).then(() => {
           setTimeout(() => {
-            const article = document.getElementById('notion-article')
+            const article = document.querySelector('#article-wrapper #notion-article')
             if (!article) {
               console.log(
                 '请检查您的Notion数据库中是否包含此slug页面： ',
@@ -309,7 +309,7 @@ const LayoutSlug = props => {
       setTimeout(
         () => {
           if (isBrowser) {
-            const article = document.getElementById('notion-article')
+            const article = document.querySelector('#article-wrapper #notion-article')
             if (!article) {
               router.push('/404').then(() => {
                 console.warn('找不到页面', router.asPath)

--- a/themes/heo/index.js
+++ b/themes/heo/index.js
@@ -292,7 +292,7 @@ const LayoutSlug = props => {
         {/* 文章锁 */}
         {lock && <PostLock validPassword={validPassword} />}
 
-        {!lock && (
+        {!lock && post && (
           <div className='mx-auto md:w-full md:px-5'>
             {/* 文章主体 */}
             <article

--- a/themes/heo/index.js
+++ b/themes/heo/index.js
@@ -273,7 +273,7 @@ const LayoutSlug = props => {
       setTimeout(
         () => {
           if (isBrowser) {
-            const article = document.getElementById('notion-article')
+            const article = document.querySelector('#article-wrapper #notion-article')
             if (!article) {
               router.push('/404').then(() => {
                 console.warn('找不到页面', router.asPath)

--- a/themes/hexo/index.js
+++ b/themes/hexo/index.js
@@ -269,7 +269,7 @@ const LayoutSlug = props => {
       setTimeout(
         () => {
           if (isBrowser) {
-            const article = document.getElementById('notion-article')
+            const article = document.querySelector('#article-wrapper #notion-article')
             if (!article) {
               router.push('/404').then(() => {
                 console.warn('找不到页面', router.asPath)
@@ -333,7 +333,7 @@ const Layout404 = props => {
     // 延时3秒如果加载失败就返回首页
     setTimeout(() => {
       if (isBrowser) {
-        const article = document.getElementById('notion-article')
+        const article = document.querySelector('#article-wrapper #notion-article')
         if (!article) {
           router.push('/').then(() => {
             // console.log('找不到页面', router.asPath)

--- a/themes/hexo/index.js
+++ b/themes/hexo/index.js
@@ -286,7 +286,7 @@ const LayoutSlug = props => {
       <div className='w-full lg:hover:shadow lg:border rounded-t-xl lg:rounded-xl lg:px-2 lg:py-4 bg-white dark:bg-hexo-black-gray dark:border-black article'>
         {lock && <ArticleLock validPassword={validPassword} />}
 
-        {!lock && (
+        {!lock && post && (
           <div className='overflow-x-auto flex-grow mx-auto md:w-full md:px-5 '>
             <article
               id='article-wrapper'

--- a/themes/landing/index.js
+++ b/themes/landing/index.js
@@ -82,7 +82,7 @@ const LayoutSlug = props => {
       setTimeout(
         () => {
           if (isBrowser) {
-            const article = document.getElementById('notion-article')
+            const article = document.querySelector('#article-wrapper #notion-article')
             if (!article) {
               router.push('/404').then(() => {
                 console.warn('找不到页面', router.asPath)

--- a/themes/magzine/index.js
+++ b/themes/magzine/index.js
@@ -155,7 +155,7 @@ const LayoutSlug = props => {
       setTimeout(
         () => {
           if (isBrowser) {
-            const article = document.getElementById('notion-article')
+            const article = document.querySelector('#article-wrapper #notion-article')
             if (!article) {
               router.push('/404').then(() => {
                 console.warn('找不到页面', router.asPath)

--- a/themes/magzine/index.js
+++ b/themes/magzine/index.js
@@ -177,7 +177,7 @@ const LayoutSlug = props => {
         {/* 文章锁 */}
         {lock && <ArticleLock validPassword={validPassword} />}
 
-        {!lock && (
+        {!lock && post && (
           <div className='w-full max-w-screen-3xl mx-auto'>
             {/* 文章信息 */}
             <ArticleInfo {...props} />

--- a/themes/matery/components/WordCount.js
+++ b/themes/matery/components/WordCount.js
@@ -29,7 +29,7 @@ export default function WordCount() {
  * 更新字数统计和阅读时间
  */
 function countWords() {
-  const articleText = deleteHtmlTag(document.getElementById('notion-article')?.innerHTML)
+  const articleText = deleteHtmlTag(document.querySelector('#article-wrapper #notion-article')?.innerHTML)
   const wordCount = fnGetCpmisWords(articleText)
   // 阅读速度 300-500每分钟
   document.getElementById('wordCount').innerHTML = wordCount

--- a/themes/matery/index.js
+++ b/themes/matery/index.js
@@ -253,7 +253,7 @@ const LayoutSlug = props => {
           className={`${fullWidth ? '' : '-mt-32'} transition-all duration-300 rounded-md mx-3 lg:border lg:rounded-xl lg:py-4 bg-white dark:bg-hexo-black-gray  dark:border-black`}>
           {lock && <ArticleLock validPassword={validPassword} />}
 
-          {!lock && (
+          {!lock && post && (
             <div className='overflow-x-auto md:w-full px-3 '>
               {/* 文章信息 */}
               {post?.type && post?.type === 'Post' && (

--- a/themes/matery/index.js
+++ b/themes/matery/index.js
@@ -231,7 +231,7 @@ const LayoutSlug = props => {
       setTimeout(
         () => {
           if (isBrowser) {
-            const article = document.getElementById('notion-article')
+            const article = document.querySelector('#article-wrapper #notion-article')
             if (!article) {
               router.push('/404').then(() => {
                 console.warn('找不到页面', router.asPath)
@@ -320,7 +320,7 @@ const Layout404 = props => {
     setTimeout(() => {
       const article =
         typeof document !== 'undefined' &&
-        document.getElementById('notion-article')
+        document.querySelector('#article-wrapper #notion-article')
       if (!article) {
         router.push('/').then(() => {
           // console.log('找不到页面', router.asPath)

--- a/themes/medium/index.js
+++ b/themes/medium/index.js
@@ -209,7 +209,7 @@ const LayoutSlug = props => {
       {/* 文章锁 */}
       {lock && <ArticleLock validPassword={validPassword} />}
 
-      {!lock && (
+      {!lock && post && (
         <div>
           {/* 文章信息 */}
           <ArticleInfo {...props} />

--- a/themes/medium/index.js
+++ b/themes/medium/index.js
@@ -191,7 +191,7 @@ const LayoutSlug = props => {
       setTimeout(
         () => {
           if (isBrowser) {
-            const article = document.getElementById('notion-article')
+            const article = document.querySelector('#article-wrapper #notion-article')
             if (!article) {
               router.push('/404').then(() => {
                 console.warn('找不到页面', router.asPath)

--- a/themes/movie/index.js
+++ b/themes/movie/index.js
@@ -156,7 +156,7 @@ const LayoutSlug = props => {
     // 用js 实现将页面中的多个视频聚合为一个分集的视频
     function combineVideo() {
       // 找到 id 为 notion-article 的元素
-      const notionArticle = document.getElementById('notion-article')
+      const notionArticle = document.querySelector('#article-wrapper #notion-article')
       if (!notionArticle) return // 如果找不到对应的元素，则退出函数
 
       // 找到所有的 .notion-asset-wrapper 元素
@@ -291,7 +291,7 @@ const LayoutSlug = props => {
       setTimeout(
         () => {
           if (isBrowser) {
-            const article = document.getElementById('notion-article')
+            const article = document.querySelector('#article-wrapper #notion-article')
             if (!article) {
               router.push('/404').then(() => {
                 console.warn('找不到页面', router.asPath)

--- a/themes/movie/index.js
+++ b/themes/movie/index.js
@@ -315,7 +315,7 @@ const LayoutSlug = props => {
 
   return (
     <>
-      {!lock ? (
+      {!lock ? post && (
         <div
           id='article-wrapper'
           className='px-2 max-w-5xl 2xl:max-w-[70%] mx-auto'>

--- a/themes/nav/index.js
+++ b/themes/nav/index.js
@@ -261,7 +261,7 @@ const LayoutSlug = props => {
       setTimeout(
         () => {
           if (isBrowser) {
-            const article = document.getElementById('notion-article')
+            const article = document.querySelector('#article-wrapper #notion-article')
             if (!article) {
               router.push('/404').then(() => {
                 console.warn('找不到页面', router.asPath)

--- a/themes/next/components/WordCount.js
+++ b/themes/next/components/WordCount.js
@@ -23,7 +23,7 @@ export default function WordCount() {
  * 更新字数统计和阅读时间
  */
 function countWords() {
-  const articleText = deleteHtmlTag(document.getElementById('notion-article')?.innerHTML)
+  const articleText = deleteHtmlTag(document.querySelector('#article-wrapper #notion-article')?.innerHTML)
   const wordCount = fnGetCpmisWords(articleText)
   // 阅读速度 300-500每分钟
   document.getElementById('wordCount').innerHTML = wordCount

--- a/themes/next/index.js
+++ b/themes/next/index.js
@@ -328,7 +328,7 @@ const LayoutSlug = props => {
       setTimeout(
         () => {
           if (isBrowser) {
-            const article = document.getElementById('notion-article')
+            const article = document.querySelector('#article-wrapper #notion-article')
             if (!article) {
               router.push('/404').then(() => {
                 console.warn('找不到页面', router.asPath)

--- a/themes/nobelium/index.js
+++ b/themes/nobelium/index.js
@@ -227,7 +227,7 @@ const LayoutSlug = props => {
       setTimeout(
         () => {
           if (isBrowser) {
-            const article = document.getElementById('notion-article')
+            const article = document.querySelector('#article-wrapper #notion-article')
             if (!article) {
               router.push('/404').then(() => {
                 console.warn('找不到页面', router.asPath)

--- a/themes/nobelium/index.js
+++ b/themes/nobelium/index.js
@@ -243,7 +243,7 @@ const LayoutSlug = props => {
     <>
       {lock && <ArticleLock validPassword={validPassword} />}
 
-      {!lock && (
+      {!lock && post && (
         <div className='px-2'>
           <>
             <ArticleInfo post={post} />

--- a/themes/photo/index.js
+++ b/themes/photo/index.js
@@ -156,7 +156,7 @@ const LayoutSlug = props => {
     // 用js 实现将页面中的多个视频聚合为一个分集的视频
     function combineVideo() {
       // 找到 id 为 notion-article 的元素
-      const notionArticle = document.getElementById('notion-article')
+      const notionArticle = document.querySelector('#article-wrapper #notion-article')
       if (!notionArticle) return // 如果找不到对应的元素，则退出函数
 
       // 找到所有的 .notion-asset-wrapper 元素
@@ -291,7 +291,7 @@ const LayoutSlug = props => {
       setTimeout(
         () => {
           if (isBrowser) {
-            const article = document.getElementById('notion-article')
+            const article = document.querySelector('#article-wrapper #notion-article')
             if (!article) {
               router.push('/404').then(() => {
                 console.warn('找不到页面', router.asPath)

--- a/themes/photo/index.js
+++ b/themes/photo/index.js
@@ -315,7 +315,7 @@ const LayoutSlug = props => {
 
   return (
     <>
-      {!lock ? (
+      {!lock ? post && (
         <div
           id='article-wrapper'
           className='px-2 max-w-5xl 2xl:max-w-[70%] mx-auto'>

--- a/themes/plog/index.js
+++ b/themes/plog/index.js
@@ -182,7 +182,7 @@ const LayoutSlug = props => {
       setTimeout(
         () => {
           if (isBrowser) {
-            const article = document.getElementById('notion-article')
+            const article = document.querySelector('#article-wrapper #notion-article')
             if (!article) {
               router.push('/404').then(() => {
                 console.warn('找不到页面', router.asPath)

--- a/themes/plog/index.js
+++ b/themes/plog/index.js
@@ -198,7 +198,7 @@ const LayoutSlug = props => {
     <>
       {lock && <ArticleLock validPassword={validPassword} />}
 
-      {!lock && (
+      {!lock && post && (
         <div className='px-2 my-16 max-w-6xl mx-auto'>
           <>
             <ArticleInfo post={post} />

--- a/themes/simple/index.js
+++ b/themes/simple/index.js
@@ -224,35 +224,37 @@ const LayoutSlug = props => {
     <>
       {lock && <ArticleLock validPassword={validPassword} />}
 
-      <div className={`px-2  ${fullWidth ? '' : 'xl:max-w-4xl 2xl:max-w-6xl'}`}>
-        {/* 文章信息 */}
-        <ArticleInfo post={post} />
+      {!lock && post && (
+        <div className={`px-2  ${fullWidth ? '' : 'xl:max-w-4xl 2xl:max-w-6xl'}`}>
+          {/* 文章信息 */}
+          <ArticleInfo post={post} />
 
-        {/* 广告嵌入 */}
-        {/* <AdSlot type={'in-article'} /> */}
-        <WWAds orientation='horizontal' className='w-full' />
+          {/* 广告嵌入 */}
+          {/* <AdSlot type={'in-article'} /> */}
+          <WWAds orientation='horizontal' className='w-full' />
 
-        <div id='article-wrapper'>
-          {/* Notion文章主体 */}
-          {!lock && <NotionPage post={post} />}
+          <div id='article-wrapper'>
+            {/* Notion文章主体 */}
+            {!lock && <NotionPage post={post} />}
+          </div>
+
+          {/* 分享 */}
+          <ShareBar post={post} />
+
+          {/* 广告嵌入 */}
+          <AdSlot type={'in-article'} />
+
+          {post?.type === 'Post' && (
+            <>
+              <ArticleAround prev={prev} next={next} />
+              <RecommendPosts recommendPosts={recommendPosts} />
+            </>
+          )}
+
+          {/* 评论区 */}
+          <Comment frontMatter={post} />
         </div>
-
-        {/* 分享 */}
-        <ShareBar post={post} />
-
-        {/* 广告嵌入 */}
-        <AdSlot type={'in-article'} />
-
-        {post?.type === 'Post' && (
-          <>
-            <ArticleAround prev={prev} next={next} />
-            <RecommendPosts recommendPosts={recommendPosts} />
-          </>
-        )}
-
-        {/* 评论区 */}
-        <Comment frontMatter={post} />
-      </div>
+      )}
     </>
   )
 }

--- a/themes/simple/index.js
+++ b/themes/simple/index.js
@@ -273,7 +273,7 @@ const Layout404 = props => {
       setTimeout(
         () => {
           if (isBrowser) {
-            const article = document.getElementById('notion-article')
+            const article = document.querySelector('#article-wrapper #notion-article')
             if (!article) {
               router.push('/404').then(() => {
                 console.warn('找不到页面', router.asPath)

--- a/themes/starter/index.js
+++ b/themes/starter/index.js
@@ -159,7 +159,7 @@ const LayoutSlug = props => {
           <div id='container-inner' className='w-full p-4'>
             {lock && <ArticleLock validPassword={validPassword} />}
 
-            {!lock && (
+            {!lock && post && (
               <div id='article-wrapper' className='mx-auto'>
                 <NotionPage {...props} />
                 <Comment frontMatter={post} />


### PR DESCRIPTION
修复以下以及类似的无法跳转404问题
https://github.com/tangly1024/NotionNext/issues/2464
https://github.com/tangly1024/NotionNext/issues/2650

问题原因：将404判断逻辑下放到主题时，部分主题404判断逻辑的 document.getElementById('notion-article') 因为加载元素时没有判断post是否存在就加载了文章外部框架，导致一直判断是未404


注：二次提交限制了文章DOM元素的范围，排除了公告导致的两个 #notion-article 的问题，但是也可能部分主题没有定义 #article-wrapper 导致新的问题