### PR TITLE
Gitbook 主题伪静态自动展开异常

### DIFF
--- a/themes/gitbook/components/NavPostList.js
+++ b/themes/gitbook/components/NavPostList.js
@@ -14,7 +14,7 @@ import NavPostItem from './NavPostItem'
  * @constructor
  */
 const NavPostList = props => {
-  const { filteredNavPages, post } = props
+  const { filteredNavPages } = props
   const { locale, currentSearch } = useGlobal()
   const router = useRouter()
 
@@ -31,16 +31,17 @@ const NavPostList = props => {
     CONFIG
   )
 
-  // 展开文件夹
   useEffect(() => {
+    // 展开文件夹
     setTimeout(() => {
-      // 默认展开一个
+      const currentPath = decodeURIComponent(router.asPath.split('?')[0])
       const defaultOpenIndex = getDefaultOpenIndexByPath(
         categoryFolders,
-        decodeURIComponent(router.asPath.split('?')[0])
+        currentPath
       )
       setExpandedGroups([defaultOpenIndex])
     }, 500)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [router, filteredNavPages])
 
   // 折叠项切换，当折叠或展开数组时会调用
@@ -149,19 +150,16 @@ function groupArticles(filteredNavPages) {
  * @returns {number} 返回需要展开的菜单索引
  */
 function getDefaultOpenIndexByPath(categoryFolders, path) {
-  // 默认展开第一个索引
-  let defaultIndex = 0
-
   // 查找满足条件的第一个索引
   const index = categoryFolders.findIndex(group => {
-    return group.items.some(post => path === '/' + post.slug)
+    return group.items.some(post => path === post.href)
   })
 
   // 如果找到满足条件的索引，则设置为该索引
   if (index !== -1) {
-    defaultIndex = index
+    return index
   }
 
-  return defaultIndex
+  return 0
 }
 export default NavPostList

--- a/themes/gitbook/components/PageNavDrawer.js
+++ b/themes/gitbook/components/PageNavDrawer.js
@@ -22,6 +22,7 @@ const PageNavDrawer = props => {
 
   useEffect(() => {
     changePageNavVisible(false)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [router])
 
   return (


### PR DESCRIPTION
伪静态开启后，左侧的菜单组自动展开会异常。

此次提交修复了本问题