### PR TITLE
feat(支持同步块格式的目录识别):

### DIFF
--- a/lib/notion/getPageTableOfContents.js
+++ b/lib/notion/getPageTableOfContents.js
@@ -12,7 +12,7 @@ const indentLevels = {
  * H1, H2, and H3 elements.
  */
 export const getPageTableOfContents = (page, recordMap) => {
-  const contents = (page.content ?? [])
+  const contents = page.content ?? []
   const toc = getBlockHeader(contents, recordMap)
   const indentLevelStack = [
     {
@@ -69,20 +69,28 @@ function getBlockHeader(contents, recordMap, toc) {
       continue
     }
     const { type } = block
-    if (type.indexOf('header') >= 0) {
-      const existed = toc.find(e => e.id === blockId)
-      if (!existed) {
-        toc.push({
-          id: blockId,
-          type,
-          text: getTextContent(block.properties?.title),
-          indentLevel: indentLevels[type]
-        })
-      }
-    }
-
     if (block.content?.length > 0) {
       getBlockHeader(block.content, recordMap, toc)
+    } else {
+      if (type.indexOf('header') >= 0) {
+        const existed = toc.find(e => e.id === blockId)
+        if (!existed) {
+          toc.push({
+            id: blockId,
+            type,
+            text: getTextContent(block.properties?.title),
+            indentLevel: indentLevels[type]
+          })
+        }
+      } else if (type === 'transclusion_reference') {
+        getBlockHeader(
+          [block.format.transclusion_reference_pointer.id],
+          recordMap,
+          toc
+        )
+      } else if (type === 'transclusion_container') {
+          getBlockHeader(block.content, recordMap, toc)
+      }
     }
   }
 


### PR DESCRIPTION
> 尽量按此模板PR内容，或粘贴相关的ISSUE链接。

## 已知问题

1. 同步块格式的目录不会被正确显示 
https://github.com/tangly1024/NotionNext/issues/2629

## 解决方案

1. 生成目录数组时，额外处理和考虑同步块情况

## 改动收益

1. 更好的目录体验

## 具体改动

1. getPageTableOfContents.js
- 生成目录数组时，额外处理和考虑同步块情况

## 测试确认

- [x] 本地开发环境测试通过
- [x] 生产环境构建测试通过
- [x] 版本号正确显示
- [x] 环境变量配置正常工作
