### PR TITLE
fix: remove browser language based auto-redirect

### DIFF
--- a/lib/lang.js
+++ b/lib/lang.js
@@ -118,7 +118,7 @@ export const redirectUserLang = (lang, pageId) => {
     return
   }
   // 只在首页处理跳转
-  if (!window.location.pathname === '/') {
+  if (window.location.pathname !== '/') {
     return
   }
   // 没有开启多语言

--- a/lib/lang.js
+++ b/lib/lang.js
@@ -126,13 +126,19 @@ export const redirectUserLang = (lang, pageId) => {
     return
   }
 
-  const userLang =
-    getQueryVariable('locale') ||
-    getQueryVariable('lang') ||
-    window?.navigator?.language
-  const siteIds = pageId?.split(',') || []
+  // 页面语言由以下因素决定（优先级从高到低）：
+  // 1. URL中的locale或lang参数
+  // 2. URL路径中的语言前缀(如 /en)
+  // 3. 默认语言
+  // 注：不支持根据浏览器语言设置自动重定向，避免影响用户体验
+  const userLang = getQueryVariable('locale') || getQueryVariable('lang')
+  if (!userLang) {
+    return
+  }
 
-  // 默认是进首页; 如果检测到有一个多语言匹配了用户浏览器，则自动跳转过去
+  const siteIds = pageId?.split(',') || []
+  
+  // 仅当URL参数指定了支持的语言时才进行重定向
   for (let index = 0; index < siteIds.length; index++) {
     const siteId = siteIds[index]
     const prefix = extractLangPrefix(siteId)


### PR DESCRIPTION
## 已知问题

1. 多语言自动重定向逻辑不合理
   - 基于浏览器语言设置的自动重定向影响用户体验
   - 比如，我们使用英文浏览器访问默认语言为中文的根域名时，就会自动跳转到英文版本
   - 这就违背了用户访问根域名应该显示默认语言的预期

## 解决方案

1. 简化语言选择逻辑
   - 移除基于浏览器语言设置的自动重定向
   - 通过注释明确定义语言选择的优先级规则
   - 保持对URL参数和路径前缀的支持

## 改动收益

1. 更好的用户体验
   - 访问根域名时始终显示默认语言
   - 语言切换行为更可预测
   - 避免不必要的页面跳转

## 具体改动

1. lib/lang.js
   - 移除`window?.navigator?.language`相关逻辑
   - 更新注释说明语言选择的优先级规则
   - 保持对 locale/lang URL参数的支持

## 测试确认

- [x] 本地开发环境测试通过

## 相关Issue/PR

这是对 #2926  的后续修复。

