### PR TITLE
feat(更换short_id实现方式): 避免因为缩短导致的潜在bug

### DIFF
--- a/lib/notion/convertInnerUrl.js
+++ b/lib/notion/convertInnerUrl.js
@@ -27,8 +27,7 @@ export const convertInnerUrl = allPages => {
       const slug = getLastPartOfUrl(anchorTag.href)
       if (checkStrIsNotionId(slug)) {
         const slugPage = allPages?.find(page => {
-          const find = idToUuid(slug).indexOf(page.short_id) === 0
-          return find
+          return idToUuid(slug).indexOf(page.short_id) === 14
         })
         if (slugPage) {
           anchorTag.href = slugPage?.href

--- a/lib/utils/pageId.js
+++ b/lib/utils/pageId.js
@@ -38,10 +38,7 @@ function getShortId(uuid) {
   if (!uuid || uuid.indexOf('-') < 0) {
     return uuid
   }
-  // 找到第一个 '-' 的位置
-  const index = uuid.indexOf('-')
-  // 截取从开始到第一个 '-' 之前的部分
-  return uuid.substring(0, index)
+  return uuid.substring(14)
 }
 
 module.exports = { extractLangPrefix, extractLangId, getShortId }

--- a/themes/gitbook/index.js
+++ b/themes/gitbook/index.js
@@ -78,7 +78,7 @@ function getNavPagesWithLatest(allNavPages, latestPosts, post) {
     }
     // 属于最新文章通常6篇 && (无阅读记录 || 最近更新时间大于上次阅读时间)
     if (
-      latestPosts.some(post => post?.id.indexOf(item?.short_id) === 0) &&
+      latestPosts.some(post => post?.id.indexOf(item?.short_id) === 14) &&
       (!postReadTime[item.short_id] ||
         postReadTime[item.short_id] < new Date(item.lastEditedDate).getTime())
     ) {


### PR DESCRIPTION
## 已知问题

1. shortid不具有唯一性，容易出现重复问题
   -  https://github.com/tangly1024/NotionNext/issues/3071

## 解决方案

1. 保留shortid，但选择取最后三部分，最不容易重复的部分
## 改动收益

1. 优化性能的同时减小出错概率
   - 虽然不一定这样能有太多优化效果吧，但比之前出现问题好

## 具体改动

1. 详见commits
   - 修改shortid获取函数
   - 以及目前所使用过的shortid匹配部分

## 测试确认

- [x] 本地开发环境测试通过
- [x] 生产环境构建测试通过
- [x] 版本号正确显示
- [x] 环境变量配置正常工作
