### PR TITLE
feat(start主题 链接设置默认值与多语言化): 可能的站内链接部分使用Link，而非a，使其能正确多语言跳转

### DIFF
--- a/themes/starter/components/About.js
+++ b/themes/starter/components/About.js
@@ -1,6 +1,7 @@
 /* eslint-disable @next/next/no-img-element */
 /* eslint-disable react/no-unescaped-entities */
 import { siteConfig } from '@/lib/config'
+import Link from 'next/link'
 
 /**
  * 首页的关于模块
@@ -27,11 +28,11 @@ export const About = () => {
                       __html: siteConfig('STARTER_ABOUT_TEXT')
                     }}></p>
 
-                  <a
-                    href={siteConfig('STARTER_ABOUT_BUTTON_URL')}
+                  <Link
+                    href={siteConfig('STARTER_ABOUT_BUTTON_URL', '')}
                     className='inline-flex items-center justify-center rounded-md border border-primary bg-primary px-7 py-3 text-center text-base font-medium text-white hover:border-blue-dark hover:bg-blue-dark'>
                     {siteConfig('STARTER_ABOUT_BUTTON_TEXT')}
-                  </a>
+                  </Link>
                 </div>
               </div>
 

--- a/themes/starter/components/CTA.js
+++ b/themes/starter/components/CTA.js
@@ -1,4 +1,5 @@
 import { siteConfig } from '@/lib/config'
+import Link from 'next/link'
 
 /**
  * CTA，用于创建一个呼吁用户行动的部分（Call To Action，简称 CTA）。
@@ -29,11 +30,11 @@ export const CTA = () => {
                   </p>
                   {siteConfig('STARTER_CTA_BUTTON') && (
                     <>
-                      <a
-                        href={siteConfig('STARTER_CTA_BUTTON_URL')}
+                      <Link
+                        href={siteConfig('STARTER_CTA_BUTTON_URL', '')}
                         className='inline-block rounded-md border border-transparent bg-secondary px-7 py-3 text-base font-medium text-white transition hover:bg-[#0BB489]'>
                         {siteConfig('STARTER_CTA_BUTTON_TEXT')}
-                      </a>
+                      </Link>
                     </>
                   )}
                 </div>

--- a/themes/starter/components/Features.js
+++ b/themes/starter/components/Features.js
@@ -3,6 +3,7 @@ import { SVGDesign } from './svg/SVGDesign'
 import { SVGEssential } from './svg/SVGEssential'
 import { SVGGifts } from './svg/SVGGifts'
 import { SVGTemplate } from './svg/SVGTemplate'
+import Link from 'next/link'
 /**
  * 产品特性相关，将显示在首页中
  * @returns
@@ -41,11 +42,11 @@ export const Features = () => {
                 <p className='mb-8 text-body-color dark:text-dark-6 lg:mb-9'>
                   {siteConfig('STARTER_FEATURE_1_TEXT_1')}
                 </p>
-                <a
-                  href={siteConfig('STARTER_FEATURE_1_BUTTON_URL')}
+                <Link
+                  href={siteConfig('STARTER_FEATURE_1_BUTTON_URL', '')}
                   className='text-base font-medium text-dark hover:text-primary dark:text-white dark:hover:text-primary'>
                   {siteConfig('STARTER_FEATURE_1_BUTTON_TEXT')}
-                </a>
+                </Link>
               </div>
             </div>
             <div className='w-full px-4 md:w-1/2 lg:w-1/4'>
@@ -60,11 +61,11 @@ export const Features = () => {
                 <p className='mb-8 text-body-color dark:text-dark-6 lg:mb-9'>
                   {siteConfig('STARTER_FEATURE_2_TEXT_1')}
                 </p>
-                <a
-                  href={siteConfig('STARTER_FEATURE_2_BUTTON_URL')}
+                <Link
+                  href={siteConfig('STARTER_FEATURE_2_BUTTON_URL', '')}
                   className='text-base font-medium text-dark hover:text-primary dark:text-white dark:hover:text-primary'>
                   {siteConfig('STARTER_FEATURE_2_BUTTON_TEXT')}
-                </a>
+                </Link>
               </div>
             </div>
             <div className='w-full px-4 md:w-1/2 lg:w-1/4'>
@@ -79,11 +80,11 @@ export const Features = () => {
                 <p className='mb-8 text-body-color dark:text-dark-6 lg:mb-9'>
                   {siteConfig('STARTER_FEATURE_3_TEXT_1')}
                 </p>
-                <a
-                  href={siteConfig('STARTER_FEATURE_3_BUTTON_URL')}
+                <Link
+                  href={siteConfig('STARTER_FEATURE_3_BUTTON_URL', '')}
                   className='text-base font-medium text-dark hover:text-primary dark:text-white dark:hover:text-primary'>
                   {siteConfig('STARTER_FEATURE_3_BUTTON_TEXT')}
-                </a>
+                </Link>
               </div>
             </div>
             <div className='w-full px-4 md:w-1/2 lg:w-1/4'>
@@ -98,11 +99,11 @@ export const Features = () => {
                 <p className='mb-8 text-body-color dark:text-dark-6 lg:mb-9'>
                   {siteConfig('STARTER_FEATURE_4_TEXT_1')}
                 </p>
-                <a
-                  href={siteConfig('STARTER_FEATURE_4_BUTTON_URL')}
+                <Link
+                  href={siteConfig('STARTER_FEATURE_4_BUTTON_URL', '')}
                   className='text-base font-medium text-dark hover:text-primary dark:text-white dark:hover:text-primary'>
                   {siteConfig('STARTER_FEATURE_3_BUTTON_TEXT')}
-                </a>
+                </Link>
               </div>
             </div>
           </div>

--- a/themes/starter/components/Footer.js
+++ b/themes/starter/components/Footer.js
@@ -2,6 +2,7 @@ import { siteConfig } from '@/lib/config'
 import SocialButton from '@/themes/fukasawa/components/SocialButton'
 import { Logo } from './Logo'
 import { SVGFooterCircleBG } from './svg/SVGFooterCircleBG'
+import Link from 'next/link'
 
 /* eslint-disable @next/next/no-img-element */
 export const Footer = props => {
@@ -48,11 +49,11 @@ export const Footer = props => {
                       {item?.LINK_GROUP?.map((l, i) => {
                         return (
                           <li key={i}>
-                            <a
+                            <Link
                               href={l.URL}
                               className='mb-3 inline-block text-base text-gray-7 hover:text-primary'>
                               {l.TITLE}
-                            </a>
+                            </Link>
                           </li>
                         )
                       })}
@@ -72,7 +73,7 @@ export const Footer = props => {
                 <div className='flex flex-col gap-8'>
                   {latestPosts?.map((item, index) => {
                     return (
-                      <a
+                      <Link
                         key={index}
                         href={item?.href}
                         className='group flex items-center gap-[22px]'>
@@ -87,7 +88,7 @@ export const Footer = props => {
                         <span className='line-clamp-2 max-w-[180px] text-base text-gray-7 group-hover:text-white'>
                           {item.title}
                         </span>
-                      </a>
+                      </Link>
                     )
                   })}
                 </div>
@@ -104,27 +105,27 @@ export const Footer = props => {
               <div className='w-full px-4 md:w-2/3 lg:w-1/2'>
                 <div className='my-1'>
                   <div className='-mx-3 flex items-center justify-center md:justify-start'>
-                    <a
-                      href={siteConfig('STARTER_FOOTER_PRIVACY_POLICY_URL')}
+                    <Link
+                      href={siteConfig('STARTER_FOOTER_PRIVACY_POLICY_URL', '')}
                       className='px-3 text-base text-gray-7 hover:text-white hover:underline'>
                       {siteConfig('STARTER_FOOTER_PRIVACY_POLICY_TEXT')}
-                    </a>
-                    <a
+                    </Link>
+                    <Link
                       href={siteConfig(
-                        'STARTER_FOOTER_PRIVACY_LEGAL_NOTICE_URL'
+                        'STARTER_FOOTER_PRIVACY_LEGAL_NOTICE_URL', ''
                       )}
                       className='px-3 text-base text-gray-7 hover:text-white hover:underline'>
                       {siteConfig('STARTER_FOOTER_PRIVACY_LEGAL_NOTICE_TEXT')}
-                    </a>
-                    <a
+                    </Link>
+                    <Link
                       href={siteConfig(
-                        'STARTER_FOOTER_PRIVACY_TERMS_OF_SERVICE_URL'
+                        'STARTER_FOOTER_PRIVACY_TERMS_OF_SERVICE_URL', ''
                       )}
                       className='px-3 text-base text-gray-7 hover:text-white hover:underline'>
                       {siteConfig(
-                        'STARTER_FOOTER_PRIVACY_TERMS_OF_SERVICE_TEXT'
+                        'STARTER_FOOTER_PRIVACY_TERMS_OF_SERVICE_TEXT', ''
                       )}
-                    </a>
+                    </Link>
                   </div>
                 </div>
               </div>

--- a/themes/starter/components/Header.js
+++ b/themes/starter/components/Header.js
@@ -75,12 +75,12 @@ export const Header = props => {
                     <SignedOut>
                       <div className='hidden sm:flex gap-4'>
                         <Link
-                          href={siteConfig('STARTER_NAV_BUTTON_1_URL')}
+                          href={siteConfig('STARTER_NAV_BUTTON_1_URL', '')}
                           className={`loginBtn ${buttonTextColor} p-2 text-base font-medium hover:opacity-70`}>
                           {siteConfig('STARTER_NAV_BUTTON_1_TEXT')}
                         </Link>
                         <Link
-                          href={siteConfig('STARTER_NAV_BUTTON_2_URL')}
+                          href={siteConfig('STARTER_NAV_BUTTON_2_URL', '')}
                           className={`signUpBtn ${buttonTextColor} p-2 rounded-md bg-white bg-opacity-20 py-2 text-base font-medium duration-300 ease-in-out hover:bg-opacity-100 hover:text-dark`}>
                           {siteConfig('STARTER_NAV_BUTTON_2_TEXT')}
                         </Link>
@@ -94,16 +94,16 @@ export const Header = props => {
                 )}
                 {!enableClerk && (
                   <div className='hidden sm:flex gap-4'>
-                    <a
-                      href={siteConfig('STARTER_NAV_BUTTON_1_URL')}
+                    <Link
+                      href={siteConfig('STARTER_NAV_BUTTON_1_URL', '')}
                       className={`loginBtn ${buttonTextColor} p-2 text-base font-medium hover:opacity-70`}>
                       {siteConfig('STARTER_NAV_BUTTON_1_TEXT')}
-                    </a>
-                    <a
-                      href={siteConfig('STARTER_NAV_BUTTON_2_URL')}
+                    </Link>
+                    <Link
+                      href={siteConfig('STARTER_NAV_BUTTON_2_URL', '')}
                       className={`signUpBtn ${buttonTextColor} p-2 rounded-md bg-white bg-opacity-20 py-2 text-base font-medium duration-300 ease-in-out hover:bg-opacity-100 hover:text-dark`}>
                       {siteConfig('STARTER_NAV_BUTTON_2_TEXT')}
-                    </a>
+                    </Link>
                   </div>
                 )}
               </div>

--- a/themes/starter/components/Hero.js
+++ b/themes/starter/components/Hero.js
@@ -2,6 +2,7 @@
 import LazyImage from '@/components/LazyImage'
 import { siteConfig } from '@/lib/config'
 import CONFIG from '../config'
+import Link from 'next/link'
 
 /**
  * 英雄大图区块
@@ -32,16 +33,16 @@ export const Hero = props => {
                 <ul className='mb-10 flex flex-wrap items-center justify-center gap-5'>
                   {siteConfig('STARTER_HERO_BUTTON_1_TEXT', null, config) && (
                     <li>
-                      <a
-                        href={siteConfig('STARTER_HERO_BUTTON_1_URL')}
+                      <Link
+                        href={siteConfig('STARTER_HERO_BUTTON_1_URL', '')}
                         className='inline-flex items-center justify-center rounded-md bg-white px-7 py-[14px] text-center text-base font-medium text-dark shadow-1 transition duration-300 ease-in-out hover:bg-gray-2 hover:text-body-color'>
                         {siteConfig('STARTER_HERO_BUTTON_1_TEXT', null, config)}
-                      </a>
+                      </Link>
                     </li>
                   )}
                   {siteConfig('STARTER_HERO_BUTTON_2_TEXT', null, config) && (
                     <li>
-                      <a
+                      <Link
                         href={siteConfig(
                           'STARTER_HERO_BUTTON_2_URL',
                           null,
@@ -65,7 +66,7 @@ export const Hero = props => {
                           />
                         )}
                         {siteConfig('STARTER_HERO_BUTTON_2_TEXT', null, config)}
-                      </a>
+                      </Link>
                     </li>
                   )}
                 </ul>

--- a/themes/starter/components/Pricing.js
+++ b/themes/starter/components/Pricing.js
@@ -1,4 +1,5 @@
 import { siteConfig } from '@/lib/config'
+import Link from 'next/link'
 
 /**
  * 价格板块
@@ -65,11 +66,11 @@ export const Pricing = () => {
                       })}
                   </div>
                 </div>
-                <a
-                  href={siteConfig('STARTER_PRICING_1_BUTTON_URL')}
+                <Link
+                  href={siteConfig('STARTER_PRICING_1_BUTTON_URL', '')}
                   className='inline-block rounded-md bg-primary px-7 py-3 text-center text-base font-medium text-white transition hover:bg-blue-dark'>
                   {siteConfig('STARTER_PRICING_1_BUTTON_TEXT')}
-                </a>
+                </Link>
               </div>
             </div>
 
@@ -117,11 +118,11 @@ export const Pricing = () => {
                       })}
                   </div>
                 </div>
-                <a
-                  href={siteConfig('STARTER_PRICING_2_BUTTON_URL')}
+                <Link
+                  href={siteConfig('STARTER_PRICING_2_BUTTON_URL', '')}
                   className='inline-block rounded-md bg-primary px-7 py-3 text-center text-base font-medium text-white transition hover:bg-blue-dark'>
                   {siteConfig('STARTER_PRICING_2_BUTTON_TEXT')}
-                </a>
+                </Link>
               </div>
             </div>
 
@@ -161,11 +162,11 @@ export const Pricing = () => {
                       })}
                   </div>
                 </div>
-                <a
-                  href={siteConfig('STARTER_PRICING_3_BUTTON_URL')}
+                <Link
+                  href={siteConfig('STARTER_PRICING_3_BUTTON_URL', '')}
                   className='inline-block rounded-md bg-primary px-7 py-3 text-center text-base font-medium text-white transition hover:bg-blue-dark'>
                   {siteConfig('STARTER_PRICING_3_BUTTON_TEXT')}
-                </a>
+                </Link>
               </div>
             </div>
           </div>


### PR DESCRIPTION
> 尽量按此模板PR内容，或粘贴相关的ISSUE链接。

## 已知问题

1. 全部链接都使用a标签无法正确多语言

## 解决方案

1. 可能的站内链接部分使用Link，而非a

## 改动收益

1. 使链接能正确多语言跳转

## 具体改动

1. 详见commits

## 测试确认

- [x] 本地开发环境测试通过
- [x] 生产环境构建测试通过
- [x] 版本号正确显示
- [x] 环境变量配置正常工作
