### PR TITLE
Notion config的配置项可以使用对象数组等复杂结构和HEO主题的站点信息文案支持从Notion配置

### DIFF
--- a/lib/notion/getNotionConfig.js
+++ b/lib/notion/getNotionConfig.js
@@ -157,19 +157,12 @@ export async function getConfigMapFromConfigPage(allPages) {
       // 只导入生效的配置
       if (config.enable) {
         // console.log('[Notion配置]', config.key, config.value)
-        notionConfig[config.key] = config.value || null
+        notionConfig[config.key] = parseTextToJson(config.value) || config.value || null
         // 配置不能是undefined，至少是null
       }
     }
   }
-
-  // 最后检查Notion_Config页面的INLINE_CONFIG，是否是一个js对象
-  const combine = Object.assign(
-    {},
-    deepClone(notionConfig),
-    parseConfig(notionConfig?.INLINE_CONFIG)
-  )
-  return combine
+  return notionConfig
 }
 
 /**
@@ -189,5 +182,18 @@ export function parseConfig(configString) {
   } catch (evalError) {
     console.error('解析 eval(INLINE_CONFIG)  配置时出错：', evalError)
     return {}
+  }
+}
+
+/**
+ * 解析文本为JSON
+ * @param text
+ * @returns {any|null}
+ */
+export function parseTextToJson(text) {
+  try {
+    return JSON.parse(text);
+  } catch (error) {
+    return null;
   }
 }

--- a/lib/notion/getNotionConfig.js
+++ b/lib/notion/getNotionConfig.js
@@ -157,19 +157,24 @@ export async function getConfigMapFromConfigPage(allPages) {
       // 只导入生效的配置
       if (config.enable) {
         // console.log('[Notion配置]', config.key, config.value)
-        notionConfig[config.key] = parseTextToJson(config.value) || config.value || null
+        notionConfig[config.key] =
+          parseTextToJson(config.value) || config.value || null
         // 配置不能是undefined，至少是null
       }
     }
   }
 
-
-  // 将INLINE_CONFIG合并，@see https://docs.tangly1024.com/article/notion-next-inline-config
-  const combine = Object.assign(
-    {},
-    deepClone(notionConfig),
-    parseConfig(notionConfig?.INLINE_CONFIG)
-  )
+  let combine = notionConfig
+  try {
+    // 将INLINE_CONFIG合并，@see https://docs.tangly1024.com/article/notion-next-inline-config
+    combine = Object.assign(
+      {},
+      deepClone(notionConfig),
+      notionConfig?.INLINE_CONFIG
+    )
+  } catch (err) {
+    console.warn('解析 INLINE_CONFIG 配置时出错,请检查JSON格式', err)
+  }
   return combine
 }
 
@@ -188,7 +193,10 @@ export function parseConfig(configString) {
     const config = eval('(' + configString + ')')
     return config
   } catch (evalError) {
-    console.error('解析 eval(INLINE_CONFIG)  配置时出错：', evalError)
+    console.warn(
+      '解析 eval(INLINE_CONFIG) 配置时出错,请检查JSON格式',
+      evalError
+    )
     return {}
   }
 }
@@ -200,8 +208,8 @@ export function parseConfig(configString) {
  */
 export function parseTextToJson(text) {
   try {
-    return JSON.parse(text);
+    return JSON.parse(text)
   } catch (error) {
-    return null;
+    return null
   }
 }

--- a/lib/notion/getNotionConfig.js
+++ b/lib/notion/getNotionConfig.js
@@ -162,7 +162,15 @@ export async function getConfigMapFromConfigPage(allPages) {
       }
     }
   }
-  return notionConfig
+
+
+  // 将INLINE_CONFIG合并，@see https://docs.tangly1024.com/article/notion-next-inline-config
+  const combine = Object.assign(
+    {},
+    deepClone(notionConfig),
+    parseConfig(notionConfig?.INLINE_CONFIG)
+  )
+  return combine
 }
 
 /**

--- a/themes/heo/components/AnalyticsCard.js
+++ b/themes/heo/components/AnalyticsCard.js
@@ -11,31 +11,35 @@ export function AnalyticsCard(props) {
   const today = new Date()
   const diffTime = today.getTime() - targetDate.getTime() // 获取两个日期之间的毫秒数差值
   const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24)) // 将毫秒数差值转换为天数差值
+  const postCountTitle = siteConfig('HEO_POST_COUNT_TITLE', null, CONFIG)
+  const siteTimeTitle = siteConfig('HEO_SITE_TIME_TITLE', null, CONFIG)
+  const siteVisitTitle = siteConfig('HEO_SITE_VISIT_TITLE', null, CONFIG)
+  const siteVisitorTitle = siteConfig('HEO_SITE_VISITOR_TITLE', null, CONFIG)
 
   const { postCount } = props
   return <>
         <div className='text-md flex flex-col space-y-1 justify-center px-3'>
             <div className='inline'>
                 <div className='flex justify-between'>
-                    <div>文章数:</div>
+                    <div>{postCountTitle}</div>
                     <div>{postCount}</div>
                 </div>
             </div>
             <div className='inline'>
                 <div className='flex justify-between'>
-                    <div>建站天数:</div>
+                    <div>{siteTimeTitle}</div>
                     <div>{diffDays} 天</div>
                 </div>
             </div>
             <div className='hidden busuanzi_container_page_pv'>
                 <div className='flex justify-between'>
-                    <div>访问量:</div>
+                    <div>{siteVisitTitle}</div>
                     <div className='busuanzi_value_page_pv' />
                 </div>
             </div>
             <div className='hidden busuanzi_container_site_uv'>
                 <div className='flex justify-between'>
-                    <div>访客数:</div>
+                    <div>{siteVisitorTitle}</div>
                     <div className='busuanzi_value_site_uv' />
                 </div>
             </div>

--- a/themes/heo/config.js
+++ b/themes/heo/config.js
@@ -122,6 +122,12 @@ const CONFIG = {
   HEO_SOCIAL_CARD_TITLE_3: '点击加入社群',
   HEO_SOCIAL_CARD_URL: 'https://docs.tangly1024.com/article/how-to-question',
 
+  // 底部统计面板文案
+  HEO_POST_COUNT_TITLE: '文章数:',
+  HEO_SITE_TIME_TITLE: '建站天数:',
+  HEO_SITE_VISIT_TITLE: '访问量:',
+  HEO_SITE_VISITOR_TITLE: '访客数:',
+
   // *****  以下配置无效，只是预留开发 ****
   // 菜单配置
   HEO_MENU_INDEX: true, // 显示首页


### PR DESCRIPTION
> 尽量按此模板PR内容，或粘贴相关的ISSUE链接。

## 已知问题

1. Notion config不支持复杂结构的对象配置的，导致部分文案只能写死
2. HEO主题站点信息部分文案不支持从Notion配置

## 解决方案

1. 改为使用JSON parse解析而非eval
## 改动收益

1. 更多的配置项可从Notion获取

## 具体改动

1. 详见commits

## 测试确认

- [x] 本地开发环境测试通过
- [x] 生产环境构建测试通过
- [x] 版本号正确显示
- [x] 环境变量配置正常工作
