### PR TITLE
fix : 修复 Artalk 评论插件在浅色/深色切换时的显示 Bug

### DIFF
--- a/components/Artalk.js
+++ b/components/Artalk.js
@@ -20,18 +20,32 @@ const Artalk = ({ siteInfo }) => {
 
   const initArtalk = async () => {
     await loadExternalResource(artalkCss, 'css')
-    window?.Artalk?.init({
-      server: artalkServer, // 后端地址
-      el: '#artalk', // 容器元素
+    const artalk = window?.Artalk?.init({
+      server: artalkServer,
+      el: '#artalk',
       locale: artalkLocale,
-      //   pageKey: '/post/1', // 固定链接 (留空自动获取)
-      //   pageTitle: '关于引入 Artalk 的这档子事', // 页面标题 (留空自动获取)
-      site: site // 你的站点名
+      site: site,
+      darkMode: document.documentElement.classList.contains('dark')
     })
+
+    const observer = new MutationObserver((mutations) => {
+      mutations.forEach((mutation) => {
+        if (mutation.attributeName === 'class') {
+          const isDark = document.documentElement.classList.contains('dark')
+          artalk?.setDarkMode(isDark)
+        }
+      })
+    })
+
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ['class']
+    })
+
+    return () => observer.disconnect()
   }
-  return (
-        <div id="artalk"></div>
-  )
+
+  return <div id="artalk"></div>
 }
 
 export default Artalk


### PR DESCRIPTION
## 已知问题

1. Artalk 评论组件显示异常
   - 默认 Artalk 为浅色模式, 当点击网页的深色/浅色切换按钮时, artalk 评论区无法切换深浅, 但 twikoo 可以
   - 理论上可以在 artalk 后端中 `设置`->`界面配置` 中将`夜间模式`配置为 `auto` 来解决此 bug
   - 但实际上仅仅修改这个 auto 值是无效的, 只是简单地把浅色换成了深色, 无法实现根据博客的明暗自动变化
   - 这个 bug 会导致明暗切换后评论的文字的颜色和背景颜色几乎相同, 无法阅读, 之前杜老师有发现过此问题 https://github.com/ArtalkJS/Artalk/discussions/185
   - 所以要修改 components/artalk.js 来让 auto 成为真正的 auto

![Screenshot 2024-12-23 194545](https://github.com/user-attachments/assets/eb9cf30b-f112-4225-9c7f-b126fc096fe4)

![Screenshot 2024-12-23 124250](https://github.com/user-attachments/assets/184ce3e6-0825-4936-8b07-f71db4be2845)


## 解决方案

1. 修改 components/artalk.js
   - 使用官方推荐的 setDarkMode() 方法进行主题切换
   - 添加 MutationObserver 监听主题变化

## 改动收益

1. 修复 Artalk 评论区深色模式切换问题
   - 评论区主题能够跟随网站主题实时切换
   - 优化用户深色模式下的阅读体验

## 具体改动

1. `components/Artalk.js`
   - 保存 Artalk 实例到变量
   - 添加 MutationObserver 监听主题变化
   - 使用 setDarkMode 方法切换主题

## 测试确认

- [x] 本地开发环境测试通过
- [x] 深色/浅色模式切换正常工作
- [x] 页面刷新后主题状态保持正确
- [x] 组件卸载时正确清理资源

## 相关文档

- Artalk 深色模式文档: https://artalk.js.org/zh/guide/env.html#%E7%95%8C%E9%9D%A2%E9%85%8D%E7%BD%AE