### PR TITLE
feat&fix(支持私有页面的数据访问): 使用react-notion-x要求的方式进行NotionAPI的配置

### DIFF
--- a/blog.config.js
+++ b/blog.config.js
@@ -541,7 +541,8 @@ const BLOG = {
     process.env.NEXT_PUBLIC_DESCRIPTION || '这是一个由NotionNext生成的站点', // 站点描述，被notion中的页面描述覆盖
 
   // 开发相关
-  NOTION_ACCESS_TOKEN: process.env.NOTION_ACCESS_TOKEN || '', // Useful if you prefer not to make your database public
+  NOTION_ACTIVE_USER: process.env.NOTION_ACTIVE_USER || '',
+  NOTION_TOKEN_V2: process.env.NOTION_TOKEN_V2 || '', // Useful if you prefer not to make your database public
   DEBUG: process.env.NEXT_PUBLIC_DEBUG || false, // 是否显示调试按钮
   ENABLE_CACHE:
     process.env.ENABLE_CACHE ||

--- a/lib/notion/getNotionAPI.js
+++ b/lib/notion/getNotionAPI.js
@@ -1,0 +1,10 @@
+import { NotionAPI } from 'notion-client'
+import BLOG from '@/blog.config'
+
+export default function getNotionAPI() {
+  return new NotionAPI({
+    activeUser: BLOG.NOTION_ACTIVE_USER || null,
+    authToken: BLOG.NOTION_TOKEN_V2 || null,
+    userTimeZone: Intl.DateTimeFormat().resolvedOptions().timeZone
+  })
+}

--- a/lib/notion/getPageProperties.js
+++ b/lib/notion/getPageProperties.js
@@ -12,6 +12,7 @@ import {
 } from '../utils'
 import { extractLangPrefix } from '../utils/pageId'
 import { mapImgUrl } from './mapImage'
+import getNotionAPI from '@/lib/notion/getNotionAPI'
 
 /**
  * 获取页面元素成员属性
@@ -56,7 +57,7 @@ export default async function getPageProperties(
         case 'person': {
           const rawUsers = val.flat()
           const users = []
-          const api = new NotionAPI({ authToken })
+          const api = getNotionAPI()
 
           for (let i = 0; i < rawUsers.length; i++) {
             if (rawUsers[i][0][1]) {

--- a/lib/notion/getPostBlocks.js
+++ b/lib/notion/getPostBlocks.js
@@ -2,6 +2,7 @@ import BLOG from '@/blog.config'
 import { getDataFromCache, setDataToCache } from '@/lib/cache/cache_manager'
 import { NotionAPI } from 'notion-client'
 import { deepClone, delay } from '../utils'
+import getNotionAPI from '@/lib/notion/getNotionAPI'
 
 /**
  * 获取文章内容
@@ -42,11 +43,7 @@ export async function getPageWithRetry(id, from, retryAttempts = 3) {
       retryAttempts < 3 ? `剩余重试次数:${retryAttempts}` : ''
     )
     try {
-      const authToken = BLOG.NOTION_ACCESS_TOKEN || null
-      const api = new NotionAPI({
-        authToken,
-        userTimeZone: Intl.DateTimeFormat().resolvedOptions().timeZone
-      })
+      const api = getNotionAPI()
       const start = new Date().getTime()
       const pageData = await api.getPage(id)
       const end = new Date().getTime()
@@ -166,11 +163,7 @@ export const fetchInBatches = async (ids, batchSize = 100) => {
     ids = [ids]
   }
 
-  const authToken = BLOG.NOTION_ACCESS_TOKEN || null
-  const api = new NotionAPI({
-    authToken,
-    userTimeZone: Intl.DateTimeFormat().resolvedOptions().timeZone
-  })
+  const api = getNotionAPI()
 
   let fetchedBlocks = {}
   for (let i = 0; i < ids.length; i += batchSize) {


### PR DESCRIPTION
(cherry picked from commit d5ae329e2c3a1e18b5fd5fc3507791be9da9b4ed)

> 尽量按此模板PR内容，或粘贴相关的ISSUE链接。

## 已知问题

1. 现有Notion不公开部署方式无法使用

## 解决方案

1. 根据原有[react-notion-x的指南](https://github.com/NotionX/react-notion-x?tab=readme-ov-file#private-pages)进行修改
2. 统一获取API对象的方式

## 改动收益

1. 支持从不公开Notion获取，但存在无法正确加载图片等文件的问题，[react-notion-x也放弃了支持](https://github.com/NotionX/react-notion-x/issues/529#issuecomment-2451293909)，根本想要实现还是得更换为私人页面从Notion官方JS SDK进行获取

## 具体改动

1. 详见commits

## 测试确认

- [x] 本地开发环境测试通过
- [x] 生产环境构建测试通过
- [x] 版本号正确显示
- [x] 环境变量配置正常工作
