### PR TITLE
Meting播放器问题修复

### DIFF
--- a/blog.config.js
+++ b/blog.config.js
@@ -331,7 +331,7 @@ const BLOG = {
   MUSIC_PLAYER_METING_ID:
     process.env.NEXT_PUBLIC_MUSIC_PLAYER_METING_ID || '60198', // 对应歌单的 id
   MUSIC_PLAYER_METING_LRC_TYPE:
-    process.env.NEXT_PUBLIC_MUSIC_PLAYER_METING_LRC_TYPE || '1', // 可选值： 3 | 1 | 0（0：禁用 lrc 歌词，1：lrc 格式的字符串，3：lrc 文件 url）
+    process.env.NEXT_PUBLIC_MUSIC_PLAYER_METING_LRC_TYPE || '1', // 已废弃！！！可选值： 3 | 1 | 0（0：禁用 lrc 歌词，1：lrc 格式的字符串，3：lrc 文件 url）
 
   //   ********挂件组件相关********
   // ----> 评论互动 可同时开启多个支持 WALINE VALINE GISCUS CUSDIS UTTERRANCES GITALK

--- a/components/Player.js
+++ b/components/Player.js
@@ -71,10 +71,10 @@ const Player = () => {
           fixed='true'
           type='playlist'
           preload='auto'
-          lrc-type={siteConfig('MUSIC_PLAYER_METING_LRC_TYPE')}
+        //   lrc-type={siteConfig('MUSIC_PLAYER_METING_LRC_TYPE')}
           api={siteConfig(
             'MUSIC_PLAYER_METING_API',
-            'https://api.i-meto.com/meting/api'
+            'https://api.i-meto.com/meting/api?server=:server&type=:type&id=:id&r=:r'
           )}
           autoplay={autoPlay}
           order={siteConfig('MUSIC_PLAYER_ORDER')}

--- a/components/Player.js
+++ b/components/Player.js
@@ -71,7 +71,6 @@ const Player = () => {
           fixed='true'
           type='playlist'
           preload='auto'
-        //   lrc-type={siteConfig('MUSIC_PLAYER_METING_LRC_TYPE')}
           api={siteConfig(
             'MUSIC_PLAYER_METING_API',
             'https://api.i-meto.com/meting/api?server=:server&type=:type&id=:id&r=:r'


### PR DESCRIPTION
## 已知问题
https://github.com/tangly1024/NotionNext/issues/3098#issuecomment-2566079016

## 解决方案

1. 修改对应METING_API的默认值，修改blog.config.js

## 改动收益

1. MetingJS可以正常使用。

## 具体改动

1. `blog.config.js`
   - 配置废弃 MUSIC_PLAYER_METING_LRC_TYPE
2. `Player.js`
   - 移除 lrcType
   - MUSIC_PLAYER_METING_API 默认值修改

## 测试确认

- [x] 本地开发环境测试通过
- [x] 生产环境构建测试通过
- [x] 版本号正确显示
- [x] 环境变量配置正常工作
