### PR TITLE
优化spoiler-text.css，平滑过渡符合现代审美

### DIFF
--- a/public/css/spoiler-text.css
+++ b/public/css/spoiler-text.css
@@ -1,15 +1,19 @@
-/* Spoiler text styles */
+/* Spoiler text styles with sharp edges */
 .spoiler-text {
     color: transparent;  /* 文字透明 */
-    background-color: #808080; /* 背景为黑色 */
-    border-color: #808080;
-    text-decoration-color: #808080;
-    text-emphasis-color: #808080;
-    border-radius: 8px;
-    filter: blur(1px);  /* 初始模糊 */
+    background-color: #000000; /* 背景为黑色 */
+    border-color: #000000;  /* 边框颜色 */
+    text-decoration-color: #000000; /* 删除线颜色 */
+    text-emphasis-color: #000000; /* 强调文字颜色 */
+    filter: none;  /* 移除模糊效果 */
     --hide-transition: 0.3s ease-out;
-    transition: opacity var(--hide-transition),
-    filter var(--hide-transition);
+    transition: 
+        color var(--hide-transition),
+        background-color var(--hide-transition),
+        border-color var(--hide-transition),
+        text-decoration-color var(--hide-transition),
+        text-emphasis-color var(--hide-transition),
+        opacity 0.35s cubic-bezier(.25,.46,.45,.94); /* 平滑过渡 */
 }
 
 .spoiler-text:hover {
@@ -19,5 +23,26 @@
     text-decoration-color: inherit;
     text-emphasis-color: inherit;
     opacity: 1;  /* 鼠标悬停时恢复不透明度 */
-    filter: blur(0);  /* 鼠标悬停时解除模糊 */
+}
+
+/* Spoiler child elements with transition */
+.spoiler-text * {
+    transition: opacity 0.35s cubic-bezier(.25,.46,.45,.94); /* 子元素透明度平滑过渡 */
+}
+
+/* Spoiler when not hovered */
+.spoiler-text:not(:hover) {
+    color: transparent!important; /* 非悬停时文字透明 */
+    background-color: #000000!important; /* 非悬停时背景为黑色 */
+    border-color: #000000!important; /* 非悬停时边框为黑色 */
+}
+
+.spoiler-text:not(:hover) * {
+    opacity: 0!important; /* 非悬停时子元素透明 */
+}
+
+/* Remove border in non-hover states */
+.spoiler-text:not(:hover),
+.spoiler-text:not(:hover) * {
+    border: none!important;
 }


### PR DESCRIPTION
## 修改内容
更新`./public/css/spoiler-text.css`，使spoiler-text样式更加符合现代化审美（悬浮显示剧透文本）
动图被github压缩了，实际上动画效果仅需0.35秒完成平滑过渡，比图中显示的快
![](https://github.com/user-attachments/assets/5f0d42ab-ca99-4134-a3aa-ac31a373b2de)
## 未来可以优化的方向
- 现有方案多个[sp]段落连续排版，spoiler样式会失效（如上图gif中的二、三自然段，原版即存在此问题，不是因为我的css改动），我随后去提个issue吧- -
- 希望可以把spoiler改为前缀和后缀在`blog.config.js`设置，如
```
SPOILER_TEXT_PREFIX = process.env.NEXT_PUBLIC_SPOILER_TEXT_PREFIX || "[sp]",
SPOILER_TEXT_SUFFIX = process.env.NEXT_PUBLIC_SPOILER_TEXT_SUFFIX || "[/sp]"
```
- 希望可以加入telegram样式的毛玻璃剧透样式，通过点击（而非hover）揭露剧透文本，在`blog.config.js`中切换
```
SPOILER_TEXT_TRIGGER = process.env.NEXT_PUBLIC_SPOILER_TEXT_TRIGGER || "" // hover或者click, hover对应悬浮显示，click对应telegram样式，单击显示
```
## 测试确认
- [x] 本地开发环境测试通过
- [x] 生产环境构建测试通过
- [x] 版本号正确显示
- [x] 环境变量配置正常工作
