### PR TITLE
初步实现UUID 重定向至slug功能

### DIFF
--- a/blog.config.js
+++ b/blog.config.js
@@ -271,15 +271,10 @@ const BLOG = {
   STARRY_SKY: process.env.NEXT_PUBLIC_STARRY_SKY || false, // 开关
 
   // AI 文章摘要生成
-  AI_SUMMARY_API:
-      process.env.AI_SUMMARY_API||
-      '',
-  AI_SUMMARY_KEY:
-      process.env.AI_SUMMARY_KEY ||
-      '',
+  AI_SUMMARY_API: process.env.AI_SUMMARY_API || '',
+  AI_SUMMARY_KEY: process.env.AI_SUMMARY_KEY || '',
   AI_SUMMARY_CACHE_TIME: process.env.AI_SUMMARY_CACHE_TIME || 1800, // 缓存时间，单位秒
   AI_SUMMARY_WORD_LIMIT: process.env.AI_SUMMARY_WORD_LIMIT || 1000,
-
 
   //   ********挂件组件相关********
   // AI 文章摘要生成 @see https://docs_s.tianli0.top/
@@ -531,6 +526,9 @@ const BLOG = {
   ENABLE_RSS: process.env.NEXT_PUBLIC_ENABLE_RSS || true, // 是否开启RSS订阅功能
   MAILCHIMP_LIST_ID: process.env.MAILCHIMP_LIST_ID || null, // 开启mailichimp邮件订阅 客户列表ID ，具体使用方法参阅文档
   MAILCHIMP_API_KEY: process.env.MAILCHIMP_API_KEY || null, // 开启mailichimp邮件订阅 APIkey
+
+  // uuid重定向至 slug
+  UUID_REDIRECT: process.env.UUID_REDIRECT || false,
 
   // ANIMATE.css 动画
   ANIMATE_CSS_URL:

--- a/lib/config.js
+++ b/lib/config.js
@@ -42,6 +42,7 @@ export const siteConfig = (key, defaultVal = null, extendConfig = {}) => {
     case 'AI_SUMMARY_KEY':
     case 'AI_SUMMARY_CACHE_TIME':
     case 'AI_SUMMARY_WORD_LIMIT':
+    case 'UUID_REDIRECT':
       // LINK比较特殊，
       if (key === 'LINK') {
         if (!extendConfig || Object.keys(extendConfig).length === 0) {

--- a/lib/redirect.js
+++ b/lib/redirect.js
@@ -1,0 +1,15 @@
+import fs from 'fs'
+
+export function generateRedirectJson({ allPages }) {
+  let uuidSlugMap = {}
+  allPages.forEach(page => {
+    if (page.type === 'Post' && page.status === 'Published') {
+      uuidSlugMap[page.id] = page.slug
+    }
+  })
+  try {
+    fs.writeFileSync('./public/redirect.json', JSON.stringify(uuidSlugMap))
+  } catch (error) {
+    console.warn('无法写入文件', error)
+  }
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -2,7 +2,7 @@ import { clerkMiddleware, createRouteMatcher } from '@clerk/nextjs/server'
 import { NextRequest, NextResponse } from 'next/server'
 import { checkStrIsNotionId, getLastPartOfUrl } from '@/lib/utils'
 import { idToUuid } from 'notion-utils'
-import { siteConfig } from '@/lib/config'
+import BLOG from './blog.config'
 
 /**
  * Clerk 身份验证中间件
@@ -35,7 +35,7 @@ const isTenantAdminRoute = createRouteMatcher([
 // eslint-disable-next-line @typescript-eslint/require-await, @typescript-eslint/no-explicit-any, @typescript-eslint/no-unused-vars
 const noAuthMiddleware = async (req: NextRequest, ev: any) => {
   // 如果没有配置 Clerk 相关环境变量，返回一个默认响应或者继续处理请求
-  if (siteConfig('UUID_REDIRECT')) {
+  if (BLOG['UUID_REDIRECT']) {
     let redirectJson: Record<string, string> = {}
     try {
       const response = await fetch(`${req.nextUrl.origin}/redirect.json`)

--- a/middleware.ts
+++ b/middleware.ts
@@ -55,7 +55,7 @@ const noAuthMiddleware = async (req: NextRequest, ev: any) => {
       console.log(
         `redirect from ${req.nextUrl.pathname} to ${redirectToUrl.pathname}`
       )
-      return NextResponse.redirect(redirectToUrl)
+      return NextResponse.redirect(redirectToUrl, 308)
     }
   }
   return NextResponse.next()

--- a/middleware.ts
+++ b/middleware.ts
@@ -2,6 +2,7 @@ import { clerkMiddleware, createRouteMatcher } from '@clerk/nextjs/server'
 import { NextRequest, NextResponse } from 'next/server'
 import { checkStrIsNotionId, getLastPartOfUrl } from '@/lib/utils'
 import { idToUuid } from 'notion-utils'
+import { siteConfig } from '@/lib/config'
 
 /**
  * Clerk 身份验证中间件
@@ -34,26 +35,28 @@ const isTenantAdminRoute = createRouteMatcher([
 // eslint-disable-next-line @typescript-eslint/require-await, @typescript-eslint/no-explicit-any, @typescript-eslint/no-unused-vars
 const noAuthMiddleware = async (req: NextRequest, ev: any) => {
   // 如果没有配置 Clerk 相关环境变量，返回一个默认响应或者继续处理请求
-  let redirectJson: Record<string, string> = {}
-  try {
-    const response = await fetch(`${req.nextUrl.origin}/redirect.json`)
-    if (response.ok) {
-      redirectJson = (await response.json()) as Record<string, string>
+  if (siteConfig('UUID_REDIRECT')) {
+    let redirectJson: Record<string, string> = {}
+    try {
+      const response = await fetch(`${req.nextUrl.origin}/redirect.json`)
+      if (response.ok) {
+        redirectJson = (await response.json()) as Record<string, string>
+      }
+    } catch (err) {
+      console.error('Error fetching static file:', err)
     }
-  } catch (err) {
-    console.error('Error fetching static file:', err)
-  }
-  let lastPart = getLastPartOfUrl(req.nextUrl.pathname) as string
-  if (checkStrIsNotionId(lastPart)) {
-    lastPart = idToUuid(lastPart)
-  }
-  if (lastPart && redirectJson[lastPart]) {
-    const redirectToUrl = req.nextUrl.clone()
-    redirectToUrl.pathname = '/' + redirectJson[lastPart]
-    console.log(
-      `redirect from ${req.nextUrl.pathname} to ${redirectToUrl.pathname}`
-    )
-    return NextResponse.redirect(redirectToUrl)
+    let lastPart = getLastPartOfUrl(req.nextUrl.pathname) as string
+    if (checkStrIsNotionId(lastPart)) {
+      lastPart = idToUuid(lastPart)
+    }
+    if (lastPart && redirectJson[lastPart]) {
+      const redirectToUrl = req.nextUrl.clone()
+      redirectToUrl.pathname = '/' + redirectJson[lastPart]
+      console.log(
+        `redirect from ${req.nextUrl.pathname} to ${redirectToUrl.pathname}`
+      )
+      return NextResponse.redirect(redirectToUrl)
+    }
   }
   return NextResponse.next()
 }

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,5 +1,7 @@
 import { clerkMiddleware, createRouteMatcher } from '@clerk/nextjs/server'
-import { NextResponse } from 'next/server'
+import { NextRequest, NextResponse } from 'next/server'
+import { checkStrIsNotionId, getLastPartOfUrl } from '@/lib/utils'
+import { idToUuid } from 'notion-utils'
 
 /**
  * Clerk 身份验证中间件
@@ -30,8 +32,29 @@ const isTenantAdminRoute = createRouteMatcher([
  * @returns
  */
 // eslint-disable-next-line @typescript-eslint/require-await, @typescript-eslint/no-explicit-any, @typescript-eslint/no-unused-vars
-const noAuthMiddleware = async (req: any, ev: any) => {
+const noAuthMiddleware = async (req: NextRequest, ev: any) => {
   // 如果没有配置 Clerk 相关环境变量，返回一个默认响应或者继续处理请求
+  let redirectJson: Record<string, string> = {}
+  try {
+    const response = await fetch(`${req.nextUrl.origin}/redirect.json`)
+    if (response.ok) {
+      redirectJson = (await response.json()) as Record<string, string>
+    }
+  } catch (err) {
+    console.error('Error fetching static file:', err)
+  }
+  let lastPart = getLastPartOfUrl(req.nextUrl.pathname) as string
+  if (checkStrIsNotionId(lastPart)) {
+    lastPart = idToUuid(lastPart)
+  }
+  if (lastPart && redirectJson[lastPart]) {
+    const redirectToUrl = req.nextUrl.clone()
+    redirectToUrl.pathname = '/' + redirectJson[lastPart]
+    console.log(
+      `redirect from ${req.nextUrl.pathname} to ${redirectToUrl.pathname}`
+    )
+    return NextResponse.redirect(redirectToUrl)
+  }
   return NextResponse.next()
 }
 /**

--- a/pages/index.js
+++ b/pages/index.js
@@ -5,6 +5,7 @@ import { generateRobotsTxt } from '@/lib/robots.txt'
 import { generateRss } from '@/lib/rss'
 import { generateSitemapXml } from '@/lib/sitemap.xml'
 import { DynamicLayout } from '@/themes/theme'
+import { generateRedirectJson } from '@/lib/redirect'
 
 /**
  * 首页布局
@@ -60,6 +61,8 @@ export async function getStaticProps(req) {
   generateRss(props)
   // 生成
   generateSitemapXml(props)
+  // 生成重定向 JSON
+  generateRedirectJson(props)
 
   // 生成全文索引 - 仅在 yarn build 时执行 && process.env.npm_lifecycle_event === 'build'
 

--- a/pages/index.js
+++ b/pages/index.js
@@ -61,8 +61,10 @@ export async function getStaticProps(req) {
   generateRss(props)
   // 生成
   generateSitemapXml(props)
-  // 生成重定向 JSON
-  generateRedirectJson(props)
+  if (siteConfig('UUID_REDIRECT', false, props?.NOTION_CONFIG)) {
+    // 生成重定向 JSON
+    generateRedirectJson(props)
+  }
 
   // 生成全文索引 - 仅在 yarn build 时执行 && process.env.npm_lifecycle_event === 'build'
 

--- a/themes/theme.js
+++ b/themes/theme.js
@@ -6,7 +6,7 @@ import { useRouter } from 'next/router'
 import { getQueryParam, getQueryVariable, isBrowser } from '../lib/utils'
 
 // 在next.config.js中扫描所有主题
-export const { THEMES = [] } = getConfig().publicRuntimeConfig
+export const { THEMES = [] } = getConfig()?.publicRuntimeConfig || {}
 
 /**
  * 获取主题配置


### PR DESCRIPTION
> 尽量按此模板PR内容，或粘贴相关的ISSUE链接。

## 已知问题

1. https://github.com/tangly1024/NotionNext/issues/3087

## 解决方案

1. 利用中间件和读写文件的形式进行重定向
2. 发现一个问题，没有考虑多语言的重定向
3.  [Redis](https://github.com/tangly1024/NotionNext/pull/3117) 基本写好了，打算用 hash结构再次实现 


## 改动收益

1. 支持重定向原来的可能的被收录的UUID形式老链接
5. 甚至可以不重新映射文章内UUID链接，直接重定向过去

## 测试确认

- [x] 本地开发环境测试通过
- [x] 生产环境构建测试通过
- [x] 版本号正确显示
- [x] 环境变量配置正常工作
