### PR TITLE
feat(设置Vercel生产环境下不使用的缓存类型): 针对特性缓存类型进行设置，不影响其他缓存方式，便于扩展

### DIFF
--- a/conf/dev.config.js
+++ b/conf/dev.config.js
@@ -8,7 +8,7 @@ module.exports = {
   BACKGROUND_LIGHT: '#eeeeee', // use hex value, don't forget '#' e.g #fffefc
   BACKGROUND_DARK: '#000000', // use hex value, don't forget '#'
 
-  // Redis 缓存数据库地址
+  // Redis 缓存数据库地址 （警告：缓存时间使用了NEXT_REVALIDATE_SECOND，且无法从Notion获取）
   REDIS_URL: process.env.REDIS_URL || '',
 
   ENABLE_CACHE:

--- a/lib/cache/cache_manager.js
+++ b/lib/cache/cache_manager.js
@@ -4,7 +4,7 @@ import MemoryCache from './memory_cache'
 import RedisCache from './redis_cache'
 
 // 配置是否开启Vercel环境中的缓存，因为Vercel中现有两种缓存方式在无服务环境下基本都是无意义的，纯粹的浪费资源
-const enableCacheInVercel =
+export const isNotVercelProduction =
   process.env.npm_lifecycle_event === 'build' ||
   process.env.npm_lifecycle_event === 'export' ||
   !BLOG['isProd']
@@ -77,7 +77,7 @@ export async function getDataFromCache(key, force) {
  * @returns
  */
 export async function setDataToCache(key, data, customCacheTime) {
-  if (!enableCacheInVercel || !data) {
+  if (!data) {
     return
   }
   //   console.trace('[API-->>缓存写入]:', key)

--- a/lib/cache/local_file_cache.js
+++ b/lib/cache/local_file_cache.js
@@ -1,4 +1,5 @@
 import fs from 'fs'
+import { isNotVercelProduction } from '@/lib/cache/cache_manager'
 
 const path = require('path')
 // 文件缓存持续10秒
@@ -6,7 +7,10 @@ const cacheInvalidSeconds = 1000000000 * 1000
 // 文件名
 const jsonFile = path.resolve('./data.json')
 
-export async function getCache (key) {
+export async function getCache(key) {
+  if (!isNotVercelProduction) {
+    return
+  }
   const exist = await fs.existsSync(jsonFile)
   if (!exist) return null
   const data = await fs.readFileSync(jsonFile)
@@ -19,7 +23,9 @@ export async function getCache (key) {
     return null
   }
   // 缓存超过有效期就作废
-  const cacheValidTime = new Date(parseInt(json[key + '_expire_time']) + cacheInvalidSeconds)
+  const cacheValidTime = new Date(
+    parseInt(json[key + '_expire_time']) + cacheInvalidSeconds
+  )
   const currentTime = new Date()
   if (!cacheValidTime || cacheValidTime < currentTime) {
     return null
@@ -33,7 +39,10 @@ export async function getCache (key) {
  * @param data
  * @returns {Promise<null>}
  */
-export async function setCache (key, data) {
+export async function setCache(key, data) {
+  if (!isNotVercelProduction) {
+    return
+  }
   const exist = await fs.existsSync(jsonFile)
   const json = exist ? JSON.parse(await fs.readFileSync(jsonFile)) : {}
   json[key] = data
@@ -41,7 +50,10 @@ export async function setCache (key, data) {
   fs.writeFileSync(jsonFile, JSON.stringify(json))
 }
 
-export async function delCache (key) {
+export async function delCache(key) {
+  if (!isNotVercelProduction) {
+    return
+  }
   const exist = await fs.existsSync(jsonFile)
   const json = exist ? JSON.parse(await fs.readFileSync(jsonFile)) : {}
   delete json.key
@@ -53,6 +65,9 @@ export async function delCache (key) {
  * 清理缓存
  */
 export async function cleanCache() {
+  if (!isNotVercelProduction) {
+    return
+  }
   const json = {}
   fs.writeFileSync(jsonFile, JSON.stringify(json))
 }

--- a/lib/cache/memory_cache.js
+++ b/lib/cache/memory_cache.js
@@ -1,17 +1,27 @@
 import cache from 'memory-cache'
 import BLOG from 'blog.config'
+import { isNotVercelProduction } from '@/lib/cache/cache_manager'
 
 const cacheTime = BLOG.isProd ? 10 * 60 : 120 * 60 // 120 minutes for dev,10 minutes for prod
 
 export async function getCache(key, options) {
+  if (!isNotVercelProduction) {
+    return
+  }
   return await cache.get(key)
 }
 
 export async function setCache(key, data, customCacheTime) {
+  if (!isNotVercelProduction) {
+    return
+  }
   await cache.put(key, data, (customCacheTime || cacheTime) * 1000)
 }
 
 export async function delCache(key) {
+  if (!isNotVercelProduction) {
+    return
+  }
   await cache.del(key)
 }
 

--- a/lib/cache/redis_cache.js
+++ b/lib/cache/redis_cache.js
@@ -4,7 +4,7 @@ import Redis from 'ioredis'
 
 export const redisClient = BLOG.REDIS_URL ? new Redis(BLOG.REDIS_URL) : {}
 
-const cacheTime = Math.trunc(
+export const redisCacheTime = Math.trunc(
   siteConfig('NEXT_REVALIDATE_SECOND', BLOG.NEXT_REVALIDATE_SECOND) * 1.5
 )
 
@@ -23,7 +23,7 @@ export async function setCache(key, data, customCacheTime) {
       key,
       JSON.stringify(data),
       'EX',
-      customCacheTime || cacheTime
+      customCacheTime || redisCacheTime
     )
   } catch (e) {
     console.error('redisClient写入失败 ' + e)


### PR DESCRIPTION
## 已知问题

1. 现有Vercel缓存方式绕过方式可扩展性弱
2. 导致Redis配置了也无法使用（虽然其实是PR的时候删除了我的REDIS_URL判断，但是多个PR提交的，所以可能觉得没用

## 解决方案

1. 强制设置到不需要使用的缓存类型的调用函数内

## 改动收益

1. 增强可扩展性

# 重要
https://github.com/tangly1024/NotionNext/pull/3123/commits/85d6198498d9a9c05d0e2fee3ce9a864ae1af768 中的
https://github.com/tangly1024/NotionNext/blob/85d6198498d9a9c05d0e2fee3ce9a864ae1af768/lib/utils/index.js#L9
这次两边都定义了相同的检测变量，如果都合并的话，请保留其一，最好是 保留RSS的lib/utils/index.js中的定义，感觉可以全局使用这个参数，特别是涉及到读写文件方面的

## 测试确认

- [x] 本地开发环境测试通过
- [x] 生产环境构建测试通过
- [x] 版本号正确显示
- [x] 环境变量配置正常工作
