### PR TITLE
feat: 添加备案查询链接配置

### DIFF
--- a/blog.config.js
+++ b/blog.config.js
@@ -20,6 +20,7 @@ const BLOG = {
   KEYWORDS: process.env.NEXT_PUBLIC_KEYWORD || 'Notion, 博客', // 网站关键词 英文逗号隔开
   BLOG_FAVICON: process.env.NEXT_PUBLIC_FAVICON || '/favicon.ico', // blog favicon 配置, 默认使用 /public/favicon.ico，支持在线图片，如 https://img.imesong.com/favicon.png
   BEI_AN: process.env.NEXT_PUBLIC_BEI_AN || '', // 备案号 闽ICP备XXXXXX
+  BEI_AN_LINK: process.env.NEXT_PUBLIC_BEI_AN_LINK || 'https://beian.miit.gov.cn/', // 备案查询链接，如果用了萌备等备案请在这里填写
 
   // RSS订阅
   ENABLE_RSS: process.env.NEXT_PUBLIC_ENABLE_RSS || true, // 是否开启RSS订阅功能

--- a/components/BeiAnSite.js
+++ b/components/BeiAnSite.js
@@ -6,14 +6,15 @@ import { siteConfig } from '@/lib/config'
  */
 export default function BeiAnSite() {
   const beian = siteConfig('BEI_AN')
+  const beianLink = siteConfig('BEI_AN_LINK')
   if (!beian) {
     return null
   }
   return (
     <span>
       <i className='fas fa-shield-alt' />
-      <a href='https://beian.miit.gov.cn/' className='mx-1'>
-        {siteConfig('BEI_AN')}
+      <a href={beianLink} className='mx-1'>
+        {beian}
       </a>
       <br />
     </span>


### PR DESCRIPTION
feat: 添加备案查询链接配置

## 已知问题

1. 备案查询链接在代码里写死，如果使用萌备等非官方备案则更改挂载链接很麻烦

## 解决方案

1. 添加环境变量 `NEXT_PUBLIC_BEI_AN_LINK`
   - 默认值是 `https://beian.miit.gov.cn/`
   - 可更改为萌备如 `https://icp.gov.moe/?keyword=<keyword>`

## 改动收益

1. 能够通过环境变量直接修改备案查询链接
   - 增加对萌备圈的亲和力

## 具体改动

1. `components/BeiAnSite.js`
   - `const beianLink = siteConfig('BEI_AN_LINK')`
   - `<a href={beianLink} className='mx-1'> {beian} </a>`

## 测试确认

- [√] 本地开发环境测试通过
- [√] 生产环境构建测试通过
- [√] 环境变量配置正常工作
- [√] 挂载链接配置正常生效