### PR TITLE
Improved zh-HK translations

### DIFF
--- a/lib/lang/zh-HK.js
+++ b/lib/lang/zh-HK.js
@@ -1,5 +1,5 @@
 export default {
-  LOCALE: '中文(繁体香港)',
+  LOCALE: '中文（繁體香港）',
   NAV: {
     INDEX: '網誌',
     RSS: '訂閱',
@@ -7,10 +7,10 @@ export default {
     ABOUT: '關於',
     MAIL: '電郵',
     NAVIGATOR: '導航',
-    ARCHIVE: '封存'
+    ARCHIVE: '舊存檔'
   },
   COMMON: {
-    ARTICLE_LIST: '文章列表',
+    ARTICLE_LIST: '文章清單',
     MORE: '更多',
     NO_MORE: '沒有更多了',
     LATEST_POSTS: '最新文章',
@@ -22,22 +22,22 @@ export default {
     URL_COPIED: '連結已複製！',
     TABLE_OF_CONTENTS: '目錄',
     RELATE_POSTS: '相關文章',
-    COPYRIGHT: '著作權',
+    COPYRIGHT: '版權',
     AUTHOR: '作者',
     URL: '連結',
     ANALYTICS: '分析',
     POSTS: '篇文章',
     ARTICLE: '文章',
     VISITORS: '位訪客',
-    VIEWS: '次查看',
-    COPYRIGHT_NOTICE: '本文採用 CC BY-NC-SA 4.0 許可協議，轉載請註明出處。',
-    RESULT_OF_SEARCH: '篇搜尋到的结果',
+    VIEWS: '次瀏覽',
+    COPYRIGHT_NOTICE: '本文使用 CC BY-NC-SA 4.0 版權協議，如轉載請註明出處。',
+    RESULT_OF_SEARCH: '篇搜尋结果',
     ARTICLE_DETAIL: '完整文章',
     PASSWORD_ERROR: '密碼錯誤！',
     ARTICLE_LOCK_TIPS: '文章已上鎖，請輸入訪問密碼',
     SUBMIT: '提交',
-    POST_TIME: '发布于',
-    LAST_EDITED_TIME: '最后更新',
+    POST_TIME: '發表於',
+    LAST_EDITED_TIME: '最後更新',
     NEXT_POST: '下一篇',
     PREV_POST: '上一篇'
   },
@@ -51,9 +51,9 @@ export default {
   },
   POST: {
     BACK: '返回',
-    TOP: '回到頂端'
+    TOP: '回到頁頂'
   },
   AI_SUMMARY: {
-    NAME: 'AI智能摘要',
+    NAME: 'AI 智能摘要',
   }
 }


### PR DESCRIPTION
> 尽量按此模板PR内容，或粘贴相关的ISSUE链接。

## 已知问题

現有的繁體中文（香港）翻譯與部分用語不夠一致、自然，例如使用了「封存」等詞彙，香港用語中較少出現；另外一些詞語仍是簡體中文。

## 解决方案

統一並優化繁體中文（香港）翻譯，參考香港本地慣用詞彙。

## 改动收益

提高翻譯質素和在地化體驗

## 具体改动

- LOCALE 語系描述改為「中文（繁體香港）」
- NAV.ARCHIVE：由「封存」改為「舊存檔」
- 部分常用詞彙微調：
1. 「電郵」維持不變
2. 「次查看」改為「次瀏覽」
3. 「著作權」改為「版權」等

## 测试确认

- [x] 本地开发环境测试通过
- [x] 生产环境构建测试通过
- [x] 环境变量配置正常工作
