### PR TITLE
fix: 🐛 修復 Hexo 主題下 404 頁面無法在地化

### DIFF
--- a/lib/lang/en-US.js
+++ b/lib/lang/en-US.js
@@ -69,7 +69,8 @@ export default {
     WORD_COUNT: 'Words',
     READ_TIME: 'Read Time',
     NEXT_POST: 'Next',
-    PREV_POST: 'Prev'
+    PREV_POST: 'Prev',
+    NOT_FOUND: 'Page not found.'
   },
   PAGINATION: {
     PREV: 'Prev',
@@ -89,6 +90,6 @@ export default {
     EMAIL: 'Email'
   },
   AI_SUMMARY: {
-    NAME: 'AI intelligent summary',
+    NAME: 'AI intelligent summary'
   }
 }

--- a/lib/lang/fr-FR.js
+++ b/lib/lang/fr-FR.js
@@ -38,7 +38,8 @@ export default {
     SUBMIT: 'Valider',
     POST_TIME: 'Date de publication',
     LAST_EDITED_TIME: 'Date de modification',
-    RECENT_COMMENTS: 'Nouveau commentaire'
+    RECENT_COMMENTS: 'Nouveau commentaire',
+    NOT_FOUND: ''
   },
   PAGINATION: {
     PREV: 'PREV',
@@ -53,6 +54,6 @@ export default {
     TOP: 'Haut'
   },
   AI_SUMMARY: {
-    NAME: "Résumé intelligent par l'IA",
+    NAME: "Résumé intelligent par l'IA"
   }
 }

--- a/lib/lang/ja-JP.js
+++ b/lib/lang/ja-JP.js
@@ -45,7 +45,8 @@ export default {
     DEBUG_CLOSE: 'デバッグをオフにする',
     THEME_SWITCH: 'テーマの切り替え',
     ANNOUNCEMENT: 'お知らせ',
-    START_READING: '読み始める'
+    START_READING: '読み始める',
+    NOT_FOUND: ''
   },
   PAGINATION: {
     PREV: '前のページ',
@@ -60,6 +61,6 @@ export default {
     TOP: '上に戻る'
   },
   AI_SUMMARY: {
-    NAME: 'AIインテリジェントサマリー',
+    NAME: 'AIインテリジェントサマリー'
   }
 }

--- a/lib/lang/tr-TR.js
+++ b/lib/lang/tr-TR.js
@@ -40,7 +40,8 @@ export default {
     DEBUG_OPEN: 'Hata Ayıklama',
     DEBUG_CLOSE: 'Kapat',
     THEME_SWITCH: 'Temayı Değiştir',
-    ANNOUNCEMENT: 'Duyuru'
+    ANNOUNCEMENT: 'Duyuru',
+    NOT_FOUND: ''
   },
   PAGINATION: {
     PREV: 'Önceki',
@@ -55,6 +56,6 @@ export default {
     TOP: 'Yukarı'
   },
   AI_SUMMARY: {
-    NAME: 'Yapay Zeka Akıllı Özet',
+    NAME: 'Yapay Zeka Akıllı Özet'
   }
 }

--- a/lib/lang/zh-CN.js
+++ b/lib/lang/zh-CN.js
@@ -69,7 +69,8 @@ export default {
     WORD_COUNT: '字数',
     READ_TIME: '阅读时长',
     NEXT_POST: '下一篇',
-    PREV_POST: '上一篇'
+    PREV_POST: '上一篇',
+    NOT_FOUND: '页面未找到'
   },
   PAGINATION: {
     PREV: '上页',
@@ -89,6 +90,6 @@ export default {
     EMAIL: '邮箱'
   },
   AI_SUMMARY: {
-    NAME: 'AI智能摘要',
+    NAME: 'AI智能摘要'
   }
 }

--- a/lib/lang/zh-HK.js
+++ b/lib/lang/zh-HK.js
@@ -39,7 +39,8 @@ export default {
     POST_TIME: '發表於',
     LAST_EDITED_TIME: '最後更新',
     NEXT_POST: '下一篇',
-    PREV_POST: '上一篇'
+    PREV_POST: '上一篇',
+    NOT_FOUND: ''
   },
   PAGINATION: {
     PREV: '上一頁',
@@ -54,6 +55,6 @@ export default {
     TOP: '回到頁頂'
   },
   AI_SUMMARY: {
-    NAME: 'AI 智能摘要',
+    NAME: 'AI 智能摘要'
   }
 }

--- a/lib/lang/zh-TW.js
+++ b/lib/lang/zh-TW.js
@@ -69,7 +69,8 @@ export default {
     WORD_COUNT: '字數',
     READ_TIME: '閱讀時間',
     NEXT_POST: '下一篇',
-    PREV_POST: '上一篇'
+    PREV_POST: '上一篇',
+    NOT_FOUND: '未找到該頁面'
   },
   PAGINATION: {
     PREV: '上一頁',
@@ -89,6 +90,6 @@ export default {
     EMAIL: '電子信箱'
   },
   AI_SUMMARY: {
-    NAME: 'AI 智慧摘要',
+    NAME: 'AI 智慧摘要'
   }
 }

--- a/themes/hexo/index.js
+++ b/themes/hexo/index.js
@@ -330,6 +330,7 @@ const LayoutSlug = props => {
  */
 const Layout404 = props => {
   const router = useRouter()
+  const { locale } = useGlobal()
   useEffect(() => {
     // 延时3秒如果加载失败就返回首页
     setTimeout(() => {
@@ -351,7 +352,7 @@ const Layout404 = props => {
             404
           </h2>
           <div className='inline-block text-left h-32 leading-10 items-center'>
-            <h2 className='m-0 p-0'>页面未找到</h2>
+            <h2 className='m-0 p-0'>{locale.COMMON.NOT_FOUND}</h2>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## 註記

- 此 PR 僅修復 Hexo 主題下的錯誤。
- 因不確定翻譯須放在哪一類，因此名稱（`NOT_FOUND`）與類別（`COMMON`）為臨時起的，還請原作者再做修改。

## 已知問題

1. #3157 
   - 無法使用 `/lib/lang` 下的語言檔翻譯

## 解決方案

1. 修改 `/theme/hexo/index.js` 程式碼
   - 新增翻譯鍵 `COMMON.NOT_FOUND`
   - 使用 `const { locale } = useGlobal()` 導入在地化翻譯
   - 使用 `locale.COMMON.NOT_FOUND` 提取在地化翻譯

## 改動收益

1. 使 404 頁面顯示文字可以套用在地化翻譯

## 具體改動

1. `themes/hexo/index.js`：
```diff
# themes/hexo/index.js L333
+ const { locale } = useGlobal()

# themes/hexo/index.js L355
- <h2 className='m-0 p-0'>页面未找到</h2>
+ <h2 className='m-0 p-0'>{locale.COMMON.NOT_FOUND}</h2>
```


## 測試確認

- [x] 本地開發環境測試通過
- [x] 生產環境構建測試通過
- [x] 版本號正確顯示
- [x] 環境變數配置正常工作
