### PR TITLE
feat(localization): introduce localization to 404 texts

### DIFF
--- a/components/SEO.js
+++ b/components/SEO.js
@@ -247,7 +247,7 @@ const getSEOMeta = (props, router, locale) => {
       }
     case '/404':
       return {
-        title: `${siteInfo?.title} | 页面找不到啦`,
+        title: `${siteInfo?.title} | ${locale.NAV.PAGE_NOT_FOUND}`,
         image: `${siteInfo?.pageCover}`
       }
     case '/tag':

--- a/lib/lang/en-US.js
+++ b/lib/lang/en-US.js
@@ -17,7 +17,9 @@ export default {
     NAVIGATOR: 'NAV',
     ABOUT: 'About',
     MAIL: 'E-Mail',
-    ARCHIVE: 'Archive'
+    ARCHIVE: 'Archive',
+    PAGE_NOT_FOUND: 'Page Not Found',
+    PAGE_NOT_FOUND_REDIRECT: 'Page Not Found, Redirecting to Home Page...'
   },
   COMMON: {
     THEME: 'Theme',

--- a/lib/lang/zh-CN.js
+++ b/lib/lang/zh-CN.js
@@ -17,7 +17,9 @@ export default {
     ABOUT: '关于',
     NAVIGATOR: '导航',
     MAIL: '邮箱',
-    ARCHIVE: '归档'
+    ARCHIVE: '归档',
+    PAGE_NOT_FOUND: '页面找不到啦',
+    PAGE_NOT_FOUND_REDIRECT: '页面无法加载，即将返回首页'
   },
   COMMON: {
     THEME: 'Theme',

--- a/themes/fukasawa/index.js
+++ b/themes/fukasawa/index.js
@@ -215,6 +215,7 @@ const LayoutArchive = props => {
  */
 const Layout404 = props => {
   const router = useRouter()
+  const { locale } = useGlobal()
   useEffect(() => {
     // 延时3秒如果加载失败就返回首页
     setTimeout(() => {
@@ -232,7 +233,7 @@ const Layout404 = props => {
             <div className='dark:text-gray-200'>
                 <h2 className='inline-block border-r-2 border-gray-600 mr-2 px-3 py-2 align-top'><i className='mr-2 fas fa-spinner animate-spin' />404</h2>
                 <div className='inline-block text-left h-32 leading-10 items-center'>
-                    <h2 className='m-0 p-0'>页面无法加载，即将返回首页</h2>
+                    <h2 className='m-0 p-0'>{locale.NAV.PAGE_NOT_FOUND_REDIRECT}</h2>
                 </div>
             </div>
         </div>

--- a/themes/game/index.js
+++ b/themes/game/index.js
@@ -354,6 +354,7 @@ const LayoutSlug = props => {
  */
 const Layout404 = props => {
   const router = useRouter()
+  const { locale } = useGameGlobal()
   useEffect(() => {
     // 延时3秒如果加载失败就返回首页
     setTimeout(() => {
@@ -371,7 +372,7 @@ const Layout404 = props => {
             <div className='dark:text-gray-200'>
                 <h2 className='inline-block border-r-2 border-gray-600 mr-2 px-3 py-2 align-top'><i className='mr-2 fas fa-spinner animate-spin' />404</h2>
                 <div className='inline-block text-left h-32 leading-10 items-center'>
-                    <h2 className='m-0 p-0'>页面无法加载，即将返回首页</h2>
+                    <h2 className='m-0 p-0'>{locale.NAV.PAGE_NOT_FOUND_REDIRECT}</h2>
                 </div>
             </div>
         </div>

--- a/themes/game/index.js
+++ b/themes/game/index.js
@@ -6,9 +6,11 @@ import NotionPage from '@/components/NotionPage'
 import { PWA as initialPWA } from '@/components/PWA'
 import ShareBar from '@/components/ShareBar'
 import { siteConfig } from '@/lib/config'
+import { useGlobal } from '@/lib/global'
 import { loadWowJS } from '@/lib/plugins/wow'
 import { deepClone, isBrowser, shuffleArray } from '@/lib/utils'
 import Link from 'next/link'
+import { useRouter } from 'next/router'
 import { createContext, useContext, useEffect, useRef, useState } from 'react'
 import Announcement from './components/Announcement'
 import { ArticleLock } from './components/ArticleLock'
@@ -30,7 +32,6 @@ import SideBarContent from './components/SideBarContent'
 import SideBarDrawer from './components/SideBarDrawer'
 import CONFIG from './config'
 import { Style } from './style'
-import { useRouter } from 'next/router'
 
 // const AlgoliaSearchModal = dynamic(() => import('@/components/AlgoliaSearchModal'), { ssr: false })
 
@@ -354,7 +355,7 @@ const LayoutSlug = props => {
  */
 const Layout404 = props => {
   const router = useRouter()
-  const { locale } = useGameGlobal()
+  const { locale } = useGlobal()
   useEffect(() => {
     // 延时3秒如果加载失败就返回首页
     setTimeout(() => {
@@ -367,16 +368,21 @@ const Layout404 = props => {
     }, 3000)
   }, [])
 
-  return <>
-        <div className='md:-mt-20 text-black w-full h-screen text-center justify-center content-center items-center flex flex-col'>
-            <div className='dark:text-gray-200'>
-                <h2 className='inline-block border-r-2 border-gray-600 mr-2 px-3 py-2 align-top'><i className='mr-2 fas fa-spinner animate-spin' />404</h2>
-                <div className='inline-block text-left h-32 leading-10 items-center'>
-                    <h2 className='m-0 p-0'>{locale.NAV.PAGE_NOT_FOUND_REDIRECT}</h2>
-                </div>
-            </div>
+  return (
+    <>
+      <div className='md:-mt-20 text-black w-full h-screen text-center justify-center content-center items-center flex flex-col'>
+        <div className='dark:text-gray-200'>
+          <h2 className='inline-block border-r-2 border-gray-600 mr-2 px-3 py-2 align-top'>
+            <i className='mr-2 fas fa-spinner animate-spin' />
+            404
+          </h2>
+          <div className='inline-block text-left h-32 leading-10 items-center'>
+            <h2 className='m-0 p-0'>{locale.NAV.PAGE_NOT_FOUND_REDIRECT}</h2>
+          </div>
         </div>
+      </div>
     </>
+  )
 }
 
 /**

--- a/themes/gitbook/index.js
+++ b/themes/gitbook/index.js
@@ -438,6 +438,7 @@ const LayoutArchive = props => {
  */
 const Layout404 = props => {
   const router = useRouter()
+  const { locale } = useGlobal()
   useEffect(() => {
     // 延时3秒如果加载失败就返回首页
     setTimeout(() => {
@@ -455,7 +456,7 @@ const Layout404 = props => {
             <div className='dark:text-gray-200'>
                 <h2 className='inline-block border-r-2 border-gray-600 mr-2 px-3 py-2 align-top'><i className='mr-2 fas fa-spinner animate-spin' />404</h2>
                 <div className='inline-block text-left h-32 leading-10 items-center'>
-                    <h2 className='m-0 p-0'>页面无法加载，即将返回首页</h2>
+                <h2 className='m-0 p-0'>{locale.NAV.PAGE_NOT_FOUND_REDIRECT}</h2>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
> 尽量按此模板PR内容，或粘贴相关的ISSUE链接。

## 已知问题

1. https://github.com/tangly1024/NotionNext/issues/3157
   - 404 组件和页面没有本地化

## 解决方案

1. 主题和组件中添加本地化

## 改动收益

1. 404 页面本地化

## 具体改动

1. `components/SEO.js`
    - 使用 `locale.NAV.PAGE_NOT_FOUND`

3. `themes/{game,fukasawa,gitbook}/index.js`
    - 使用 `locale.NAV.PAGE_NOT_FOUND_REDIRECT`

4. `lib/lang/{en-US,zh-CN}.js`
    - 引入 `locale.NAV.PAGE_NOT_FOUND_REDIRECT` 和 `locale.NAV.PAGE_NOT_FOUND`

## 测试确认

- [x] 本地开发环境测试通过
- [x] 生产环境构建测试通过
- [x] 版本号正确显示
- [x] 环境变量配置正常工作

成功证明：https://yesyouken.space/404
