### PR TITLE
修复sitemap多个斜杠导致无法自动编入索引#3260；修复自定义备案链接不生效#3267 #3244

### DIFF
--- a/lib/sitemap.xml.js
+++ b/lib/sitemap.xml.js
@@ -6,7 +6,11 @@ import { siteConfig } from './config'
  * @param {*} param0
  */
 export async function generateSitemapXml({ allPages, NOTION_CONFIG }) {
-  const link = siteConfig('LINK', BLOG.LINK, NOTION_CONFIG)
+  let link = siteConfig('LINK', BLOG.LINK, NOTION_CONFIG)
+  // 确保链接不以斜杠结尾
+  if (link && link.endsWith('/')) {
+    link = link.slice(0, -1)
+  }
   const urls = [
     {
       loc: `${link}`,

--- a/pages/sitemap.xml.js
+++ b/pages/sitemap.xml.js
@@ -38,6 +38,11 @@ export const getServerSideProps = async ctx => {
 }
 
 function generateLocalesSitemap(link, allPages, locale) {
+  // 确保链接不以斜杠结尾
+  if (link && link.endsWith('/')) {
+    link = link.slice(0, -1)
+  }
+
   if (locale && locale.length > 0 && locale.indexOf('/') !== 0) {
     locale = '/' + locale
   }

--- a/themes/fukasawa/components/SiteInfo.js
+++ b/themes/fukasawa/components/SiteInfo.js
@@ -22,7 +22,7 @@ function SiteInfo({ title }) {
         {siteConfig('BEI_AN') && (
           <>
             <i className='fas fa-shield-alt' />
-            <a href='https://beian.miit.gov.cn/' className='mr-2'>
+            <a href={siteConfig('BEI_AN_LINK')} className='mr-2'>
               {siteConfig('BEI_AN')}
             </a>
             <br />

--- a/themes/gitbook/components/Footer.js
+++ b/themes/gitbook/components/Footer.js
@@ -33,7 +33,7 @@ const Footer = ({ siteInfo }) => {
       {siteConfig('BEI_AN') && (
         <>
           <i className='fas fa-shield-alt' />{' '}
-          <a href='https://beian.miit.gov.cn/' className='mr-2'>
+          <a href={siteConfig('BEI_AN_LINK')} className='mr-2'>
             {siteConfig('BEI_AN')}
           </a>
           <BeiAnGongAn />

--- a/themes/heo/components/Footer.js
+++ b/themes/heo/components/Footer.js
@@ -9,6 +9,7 @@ import SocialButton from './SocialButton'
  */
 const Footer = () => {
   const BEI_AN = siteConfig('BEI_AN')
+  const BEI_AN_LINK = siteConfig('BEI_AN_LINK')
   const BIO = siteConfig('BIO')
   return (
     <footer className='relative flex-shrink-0 bg-white dark:bg-[#1a191d] justify-center text-center m-auto w-full leading-6  text-gray-600 dark:text-gray-100 text-sm'>
@@ -46,7 +47,7 @@ const Footer = () => {
           {BEI_AN && (
             <>
               <i className='fas fa-shield-alt' />{' '}
-              <a href='https://beian.miit.gov.cn/' className='mr-2'>
+              <a href={BEI_AN_LINK} className='mr-2'>
                 {siteConfig('BEI_AN')}
               </a>
             </>

--- a/themes/matery/components/Footer.js
+++ b/themes/matery/components/Footer.js
@@ -31,7 +31,7 @@ const Footer = ({ title }) => {
         {siteConfig('BEI_AN') && (
           <>
             <i className='fas fa-shield-alt' />{' '}
-            <a href='https://beian.miit.gov.cn/' className='mr-2'>
+            <a href={siteConfig('BEI_AN_LINK')} className='mr-2'>
               {siteConfig('BEI_AN')}
             </a>
             <br />

--- a/themes/medium/components/Footer.js
+++ b/themes/medium/components/Footer.js
@@ -24,7 +24,7 @@ const Footer = ({ title }) => {
         {siteConfig('BEI_AN') && (
           <>
             <i className='fas fa-shield-alt' />
-            <a href='https://beian.miit.gov.cn/' className='mr-2'>
+            <a href={siteConfig('BEI_AN_LINK')} className='mr-2'>
               {siteConfig('BEI_AN')}
             </a>
             <br />

--- a/themes/movie/components/Footer.js
+++ b/themes/movie/components/Footer.js
@@ -27,7 +27,7 @@ export const Footer = props => {
           {/* <a href="#" className="text-black no-underline hover:underline">Privacy Policy</a> */}
           {siteConfig('BEI_AN') && (
             <a
-              href='https://beian.miit.gov.cn/'
+              href={siteConfig('BEI_AN_LINK')}
               className='text-black dark:text-gray-200 no-underline hover:underline ml-4'>
               {siteConfig('BEI_AN')}
             </a>

--- a/themes/nav/components/Footer.js
+++ b/themes/nav/components/Footer.js
@@ -37,7 +37,7 @@ const Footer = ({ siteInfo }) => {
       {siteConfig('BEI_AN') && (
         <>
           <i className='fas fa-shield-alt' />{' '}
-          <a href='https://beian.miit.gov.cn/' className='mr-2'>
+          <a href={siteConfig('BEI_AN_LINK')} className='mr-2'>
             {siteConfig('BEI_AN')}
           </a>
           <br />

--- a/themes/next/components/Footer.js
+++ b/themes/next/components/Footer.js
@@ -24,7 +24,7 @@ const Footer = ({ title }) => {
         {siteConfig('BEI_AN') && (
           <>
             <i className='fas fa-shield-alt' />{' '}
-            <a href='https://beian.miit.gov.cn/' className='mr-2'>
+            <a href={siteConfig('BEI_AN_LINK')} className='mr-2'>
               {siteConfig('BEI_AN')}
             </a>
             <br />

--- a/themes/photo/components/Footer.js
+++ b/themes/photo/components/Footer.js
@@ -27,7 +27,7 @@ export const Footer = props => {
           {/* <a href="#" className="text-black no-underline hover:underline">Privacy Policy</a> */}
           {siteConfig('BEI_AN') && (
             <a
-              href='https://beian.miit.gov.cn/'
+              href={siteConfig('BEI_AN_LINK')}
               className='text-black dark:text-gray-200 no-underline hover:underline ml-4'>
               {siteConfig('BEI_AN')}
             </a>


### PR DESCRIPTION
> 尽量按此模板PR内容，或粘贴相关的ISSUE链接。

Fixes #3260 
Fixes #3267 
Fixes #3244 
Fixes #3239 

## 已知问题
sitemap多了个斜杠导致Google Search Console无法自动编入索引
相关ISSUE链接：
https://github.com/tangly1024/NotionNext/issues/3260

## 解决方案

在 /lib/sitemap.xml.js 和 pages/sitemap.xml.js 中添加了链接处理逻辑，确保link变量不会以斜杠结尾。
无论用户在配置中设置的链接是否包含末尾斜杠，生成的 sitemap 中的 URL 都会是正确的格式。

## 改动收益

## 具体改动

在 /lib/sitemap.xml.js 和 pages/sitemap.xml.js 中确保link变量不会以斜杠结尾

## 测试确认

- [x] 本地开发环境测试通过
- [x] 生产环境构建测试通过
- [x] 版本号正确显示
- [x] 环境变量配置正常工作
