### PR TITLE
fix: search bar function

### DIFF
--- a/themes/simple/components/NavBar.js
+++ b/themes/simple/components/NavBar.js
@@ -25,7 +25,7 @@ export default function NavBar(props) {
 
   const onKeyUp = e => {
     if (e.keyCode === 13) {
-      const search = document.getElementById('simple-search').innerText
+      const search = document.getElementById('simple-search').value
       if (search) {
         router.push({ pathname: '/search/' + search })
       }


### PR DESCRIPTION
Issue: https://github.com/tangly1024/NotionNext/issues/2843

## 已知问题

在 NavBar.js 中，搜尋框使用 document.getElementById('simple-search').innerText 嘗試取得輸入值。
但 <input> 元素沒有 innerText 屬性，因此無法正確讀取用戶輸入的搜尋關鍵字。
導致點擊 Enter 鍵後無法跳轉至 /search/xxx 頁面，搜尋功能無效。

## 解决方案

將搜尋框的值取得方式修正為 .value 屬性：
```
const search = document.getElementById('simple-search').value
````
.value 是取得 <input> 使用者輸入內容的正確方式。

## 改动收益

修復 simple 主題中搜尋功能無效的問題。
改動範圍小，無副作用。

## 具体改动

見解決方案。

## 测试确认

- [x] 本地開發環境測試通過
- [x] 部署至 Vercel 測試搜尋功能正常
- [x] 搜尋框可正常讀取使用者輸入
- [x] 點擊 Enter 能跳轉至 /search/xxx 頁面
