### PR TITLE
fix(下拉子菜单闪烁问题#3154)

### DIFF
--- a/themes/heo/components/MenuItemDrop.js
+++ b/themes/heo/components/MenuItemDrop.js
@@ -28,9 +28,9 @@ export const MenuItemDrop = ({ link }) => {
           <div className='cursor-pointer hover:bg-black hover:bg-opacity-10 rounded-2xl flex justify-center items-center px-3 py-1 no-underline tracking-widest relative'>
             {link?.icon && <i className={link?.icon} />} {link?.name}
             {/* 主菜单下方的安全区域 */}
-            {
+            {show && (
               <div className='absolute w-full h-4 -bottom-4 left-0 bg-transparent z-30'></div>
-            }
+            )}
           </div>
         </>
       )}

--- a/themes/heo/components/MenuItemDrop.js
+++ b/themes/heo/components/MenuItemDrop.js
@@ -34,7 +34,7 @@ export const MenuItemDrop = ({ link }) => {
       {hasSubMenu && (
         <ul
           style={{ backdropFilter: 'blur(3px)' }}
-          className={`${show ? 'visible opacity-100 top-14' : 'invisible opacity-0 top-20'} drop-shadow-md overflow-hidden rounded-xl bg-white dark:bg-[#1e1e1e] transition-all duration-300 z-20 absolute`}>
+          className={`${show ? 'visible opacity-100 top-14 pointer-events-auto' : 'invisible opacity-0 top-20 pointer-events-none'} drop-shadow-md overflow-hidden rounded-xl bg-white dark:bg-[#1e1e1e] transition-all duration-300 z-20 absolute`}>
           {link.subMenus.map((sLink, index) => {
             return (
               <li

--- a/themes/heo/components/MenuItemDrop.js
+++ b/themes/heo/components/MenuItemDrop.js
@@ -25,8 +25,12 @@ export const MenuItemDrop = ({ link }) => {
       {/* 含子菜单的按钮 */}
       {hasSubMenu && (
         <>
-          <div className='cursor-pointer  hover:bg-black hover:bg-opacity-10 rounded-2xl flex justify-center items-center px-3 py-1 no-underline tracking-widest'>
+          <div className='cursor-pointer hover:bg-black hover:bg-opacity-10 rounded-2xl flex justify-center items-center px-3 py-1 no-underline tracking-widest relative'>
             {link?.icon && <i className={link?.icon} />} {link?.name}
+            {/* 主菜单下方的安全区域 */}
+            {
+              <div className='absolute w-full h-4 -bottom-4 left-0 bg-transparent z-30'></div>
+            }
           </div>
         </>
       )}

--- a/themes/hexo/components/MenuItemDrop.js
+++ b/themes/hexo/components/MenuItemDrop.js
@@ -29,10 +29,12 @@ export const MenuItemDrop = ({ link }) => {
 
       {hasSubMenu && (
         <>
-          <div className='cursor-pointer menu-link pl-2 pr-4  no-underline tracking-widest pb-1'>
+          <div className='cursor-pointer menu-link pl-2 pr-4 no-underline tracking-widest pb-1 relative'>
             {link?.icon && <i className={link?.icon} />} {link?.name}
             <i
               className={`px-2 fa fa-angle-down duration-300  ${show ? 'rotate-180' : 'rotate-0'}`}></i>
+            {/* 主菜单下方的安全区域 */}
+            <div className='absolute w-full h-3 -bottom-1 left-0 bg-transparent z-30'></div>
           </div>
         </>
       )}
@@ -41,7 +43,7 @@ export const MenuItemDrop = ({ link }) => {
       {hasSubMenu && (
         <ul
           style={{ backdropFilter: 'blur(3px)' }}
-          className={`${show ? 'visible opacity-100 top-12' : 'invisible opacity-0 top-20'} drop-shadow-md overflow-hidden rounded-md text-black dark:text-white bg-white dark:bg-black transition-all duration-300 z-20 absolute block  `}>
+          className={`${show ? 'visible opacity-100 top-12 pointer-events-auto' : 'invisible opacity-0 top-20 pointer-events-none'} drop-shadow-md overflow-hidden rounded-md text-black dark:text-white bg-white dark:bg-black transition-all duration-300 z-20 absolute block  `}>
           {link.subMenus.map((sLink, index) => {
             return (
               <li

--- a/themes/hexo/components/MenuItemDrop.js
+++ b/themes/hexo/components/MenuItemDrop.js
@@ -34,7 +34,9 @@ export const MenuItemDrop = ({ link }) => {
             <i
               className={`px-2 fa fa-angle-down duration-300  ${show ? 'rotate-180' : 'rotate-0'}`}></i>
             {/* 主菜单下方的安全区域 */}
-            <div className='absolute w-full h-3 -bottom-1 left-0 bg-transparent z-30'></div>
+            {show && (
+              <div className='absolute w-full h-3 -bottom-1 left-0 bg-transparent z-30'></div>
+            )}
           </div>
         </>
       )}

--- a/themes/magzine/components/MenuItemDrop.js
+++ b/themes/magzine/components/MenuItemDrop.js
@@ -52,7 +52,7 @@ export const MenuItemDrop = ({ link }) => {
       {/* 子菜单 */}
       {hasSubMenu && (
         <ul
-          className={`${show ? 'visible opacity-100 top-14' : 'invisible opacity-0 top-20'} p-1 absolute border bg-white dark:bg-black dark:border-gray-800 transition-all duration-150 z-20 block rounded-lg drop-shadow-lg`}>
+          className={`${show ? 'visible opacity-100 top-14 pointer-events-auto' : 'invisible opacity-0 top-20 pointer-events-none'} p-1 absolute border bg-white dark:bg-black dark:border-gray-800 transition-all duration-150 z-20 block rounded-lg drop-shadow-lg`}>
           {link?.subMenus?.map(sLink => {
             return (
               <li

--- a/themes/matery/components/MenuItemDrop.js
+++ b/themes/matery/components/MenuItemDrop.js
@@ -28,10 +28,14 @@ export const MenuItemDrop = ({ link }) => {
 
       {hasSubMenu && (
         <>
-          <div className='cursor-pointer  menu-link pl-2 pr-4  no-underline tracking-widest pb-1'>
+          <div className='cursor-pointer  menu-link pl-2 pr-4  no-underline tracking-widest pb-1 relative'>
             {link?.icon && <i className={link?.icon} />} {link?.name}
             <i
               className={`px-2 fa fa-angle-down duration-300  ${show ? 'rotate-180' : 'rotate-0'}`}></i>
+            {/* 主菜单下方的安全区域 */}
+            {show && (
+              <div className='absolute w-full h-3 -bottom-1 left-0 bg-transparent z-30'></div>
+            )}
           </div>
         </>
       )}
@@ -40,7 +44,7 @@ export const MenuItemDrop = ({ link }) => {
       {hasSubMenu && (
         <ul
           style={{ backdropFilter: 'blur(3px)' }}
-          className={`${show ? 'visible opacity-100 top-12' : 'invisible opacity-0 top-20'} drop-shadow-md overflow-hidden rounded-md bg-white transition-all duration-300 z-20 absolute block  `}>
+          className={`${show ? 'visible opacity-100 top-12 pointer-events-auto' : 'invisible opacity-0 top-20 pointer-events-none'} drop-shadow-md overflow-hidden rounded-md bg-white transition-all duration-300 z-20 absolute block  `}>
           {link.subMenus.map((sLink, index) => {
             return (
               <li

--- a/themes/movie/components/MenuItemDrop.js
+++ b/themes/movie/components/MenuItemDrop.js
@@ -37,7 +37,7 @@ export const MenuItemDrop = ({ link }) => {
       {hasSubMenu && (
         <ul
           style={{ backdropFilter: 'blur(3px)' }}
-          className={`${show ? 'visible opacity-100 top-14' : 'invisible opacity-0 top-20'} drop-shadow-md overflow-hidden rounded-md text-black dark:text-white bg-white dark:bg-black transition-all duration-300 z-30 absolute block  `}>
+          className={`${show ? 'visible opacity-100 top-14 pointer-events-auto' : 'invisible opacity-0 top-20 pointer-events-none'} drop-shadow-md overflow-hidden rounded-md text-black dark:text-white bg-white dark:bg-black transition-all duration-300 z-30 absolute block  `}>
           {link.subMenus.map((sLink, index) => {
             return (
               <li


### PR DESCRIPTION
> 尽量按此模板PR内容，或粘贴相关的ISSUE链接。

## 已知问题

Fixes #3154 
在部分主题中，下拉子菜单存在向下的过渡动画效果。当用户将鼠标从主菜单移动到子菜单，或者从子菜单底部离开时，由于动画效果的存在，会导致子菜单在过渡过程中出现闪烁问题，影响用户体验。

## 解决方案

1. 优化事件处理与动画协调：通过 pointer-events-auto 和 pointer-events-none 类控制元素在不同动画阶段的鼠标事件响应，确保动画过程中鼠标事件处理的一致性。
2. 添加不可见的安全区域：某些主题(hexo、heo等)中主菜单下方需要添加一个透明的连接区域，确保鼠标从主菜单移动到子菜单时有一个连续的交互区域。

## 改动收益

提升用户体验

## 具体改动

/themes/主题/components/MenuItemDrop.js

## 未来优化点

个人觉得未来可以考虑将 onMouseOver/onMouseOut 替换为 onMouseEnter/onMouseLeave。因为经过本地测试发现，onMouseOver/onMouseOut 事件触发频率太高了且冗余

## 测试确认

- [x] 本地开发环境测试通过
- [x] 生产环境构建测试通过
- [x] 版本号正确显示
- [x] 环境变量配置正常工作
