### PR TITLE
fix(文章排序)

### DIFF
--- a/lib/db/getSiteData.js
+++ b/lib/db/getSiteData.js
@@ -245,7 +245,7 @@ async function convertNotionToSiteDate(pageId, from, pageRecordMap) {
   })
 
   // Sort by date
-  if (siteConfig('POSTS_SORT_BY', '', NOTION_CONFIG) === 'date') {
+  if (siteConfig('POSTS_SORT_BY', null, NOTION_CONFIG) === 'date') {
     allPages.sort((a, b) => {
       return b?.publishDate - a?.publishDate
     })


### PR DESCRIPTION
> 尽量按此模板PR内容，或粘贴相关的ISSUE链接。

Fixes #2727 
Fixes #3007 
 
## 已知问题

当用户在 post.config.js 中设置 POSTS_SORT_BY 为 'date' 或者在 Vercel 中设置环境变量 NEXT_PUBLIC_POST_SORT_BY 时，文章列表并没有按照发布日期进行排序。

## 解决方案

将 getSiteData.js 中调用 siteConfig 函数时传入的默认值从空字符串 '' 改为 null，这样当 NOTION_CONFIG 中没有设置 POSTS_SORT_BY 时，会正确回退到 blog.config.js 中的配置值。

## 改动收益

文章可以根据用户的喜好正确排序

## 具体改动

/lib/db/getSiteData.js

## 测试确认

- [x] 本地开发环境测试通过
- [x] 生产环境构建测试通过
- [x] 版本号正确显示
- [x] 环境变量配置正常工作
