### PR TITLE
fix(修复隐藏文章中无法显示只存在于隐藏文章中的标签的问题):

### DIFF
--- a/lib/db/getSiteData.js
+++ b/lib/db/getSiteData.js
@@ -332,8 +332,6 @@ function handleDataBeforeReturn(db) {
     db.notice = cleanBlock(db?.notice)
     delete db.notice?.id
   }
-
-  db.tagOptions = cleanIds(db?.tagOptions)
   db.categoryOptions = cleanIds(db?.categoryOptions)
   db.customMenu = cleanIds(db?.customMenu)
 
@@ -344,6 +342,8 @@ function handleDataBeforeReturn(db) {
   db.allNavPages = cleanPages(db?.allNavPages, db.tagOptions)
   db.allPages = cleanPages(db.allPages, db.tagOptions)
   db.latestPosts = cleanPages(db.latestPosts, db.tagOptions)
+  // 必须在使用完毕后才能进行清理
+  db.tagOptions = cleanTagOptions(db?.tagOptions)
 
   const POST_SCHEDULE_PUBLISH = siteConfig(
     'POST_SCHEDULE_PUBLISH',
@@ -462,6 +462,22 @@ function cleanIds(items) {
     )
   }
   return items
+}
+
+/**
+ * 清理和过滤tagOptions
+ * @param {*} tagOptions
+ * @returns
+ */
+function cleanTagOptions(tagOptions) {
+  if (tagOptions && Array.isArray(tagOptions)) {
+    return deepClone(
+      tagOptions
+        .filter(tagOption => tagOption.source === 'Published')
+        .map(({ id, source, ...newTagOption }) => newTagOption)
+    )
+  }
+  return tagOptions
 }
 
 /**

--- a/lib/notion/getAllTags.js
+++ b/lib/notion/getAllTags.js
@@ -14,23 +14,38 @@ export function getAllTags({
   tagOptions,
   NOTION_CONFIG
 }) {
+  // 保留Invisible的Page中的Tags，最后再过滤掉
   const allPosts = allPages?.filter(
-    page => page.type === 'Post' && page.status === 'Published'
+    page =>
+      page.type === 'Post' &&
+      (page.status === 'Published' || page.status === 'Invisible')
   )
 
   if (!allPosts || !tagOptions) {
     return []
   }
-  // 计数
-  let tags = allPosts?.map(p => p.tags)
-  tags = [...tags.flat()]
-  const tagObj = {}
-  tags.forEach(tag => {
-    if (tag in tagObj) {
-      tagObj[tag]++
-    } else {
-      tagObj[tag] = 1
-    }
+  // Tag数据统计
+  const AllTagInfos = {}
+  // 遍历所有文章
+  allPosts.forEach(post => {
+    post.tags.forEach(tag => {
+      // 如果标签已经存在
+      if (AllTagInfos[tag]) {
+        if (
+          AllTagInfos[tag].source === 'Invisible' &&
+          post.status === 'Published'
+        ) {
+          AllTagInfos[tag].source = post.status
+        }
+        AllTagInfos[tag].count++
+      } else {
+        // 如果标签不存在，创建一个新的标签对象
+        AllTagInfos[tag] = {
+          count: 1,
+          source: post.status
+        }
+      }
+    })
   })
 
   const list = []
@@ -46,18 +61,18 @@ export function getAllTags({
       const savedTagNames = new Set()
       tagOptions.forEach(c => {
         if (!savedTagNames.has(c.value)) {
-          const count = tagObj[c.value]
-          if (count) {
-            list.push({ id: c.id, name: c.value, color: c.color, count })
+          const tagInfo = AllTagInfos[c.value]
+          if (tagInfo) {
+            list.push({ id: c.id, name: c.value, color: c.color, ...tagInfo })
           }
           savedTagNames.add(c.value)
         }
       })
     } else {
       tagOptions.forEach(c => {
-        const count = tagObj[c.value]
-        if (count) {
-          list.push({ id: c.id, name: c.value, color: c.color, count })
+        const tagInfo = AllTagInfos[c.value]
+        if (tagInfo) {
+          list.push({ id: c.id, name: c.value, color: c.color, ...tagInfo })
         }
       })
     }


### PR DESCRIPTION
具体问题为：对于新打的标签，无法在隐藏文章里显示，只能显示之前添加好的旧标签。而将文章设置为公开，就能全部显示。

Closes #3322 #3038 #3137

> 尽量按此模板PR内容，或粘贴相关的ISSUE链接。

## 已知问题

1. 对于新打的标签，无法在隐藏文章里显示，只能显示之前添加好的旧标签。而将文章设置为公开，就能全部显示。

## 问题原因
https://github.com/tangly1024/NotionNext/pull/2831 ，因为要在多语言中清除多余tags，避免多语言中的tag问题

但是又因为 https://github.com/tangly1024/NotionNext/pull/588 的缘故生成的tagOptions，必须是published的，所以导致出现tagOptions里面一直不会出现这种invisible文章中独有的tag

## 解决方案

1. 临时保留 Invisible 的tag，最后才进行处理和删除

## 测试确认

- [x] 本地开发环境测试通过
- [x] 生产环境构建测试通过
- [x] 版本号正确显示
- [x] 环境变量配置正常工作