### PR TITLE
fix：仅对以 attachment 开头的上传文件进行签名，避免 embed 链接被错误处理

### DIFF
--- a/lib/notion/getPostBlocks.js
+++ b/lib/notion/getPostBlocks.js
@@ -143,7 +143,8 @@ function convertNotionBlocksToPost(id, blockMap, slice) {
         b?.value?.type === 'pdf' ||
         b?.value?.type === 'video' ||
         b?.value?.type === 'audio') &&
-      b?.value?.properties?.source?.[0][0]
+      b?.value?.properties?.source?.[0][0] &&
+      b?.value?.properties?.source?.[0][0].indexOf('attachment') === 0
     ) {
       const oldUrl = b?.value?.properties?.source?.[0][0]
       const newUrl = `https://notion.so/signed/${encodeURIComponent(oldUrl)}?table=block&id=${b?.value?.id}`


### PR DESCRIPTION
> 尽量按此模板PR内容，或粘贴相关的ISSUE链接。

## 已知问题

notion 中通过 embed 嵌入的文件链接不会以 attachment 开头，原有代码会错误地对所有文件类型进行签名，导致嵌入链接失效。

## 解决方案

仅对以 `attachment` 开头的上传文件进行签名处理，embed 嵌入链接的形式将被跳过。

## 改动收益

upload上传文件和embed嵌入链接功能均正常使用

## 具体改动

/lib/notion/getPostBlocks.js

## 测试确认

- [x] 本地开发环境测试通过
- [x] 生产环境构建测试通过
- [x] 版本号正确显示
- [x] 环境变量配置正常工作
