### PR TITLE
feat: Update Twikoo dependency from 1.6.17 to 1.6.42

### DIFF
--- a/conf/comment.config.js
+++ b/conf/comment.config.js
@@ -21,7 +21,7 @@ module.exports = {
     process.env.NEXT_PUBLIC_COMMENT_TWIKOO_COUNT_ENABLE || false, // 博客列表是否显示评论数
   COMMENT_TWIKOO_CDN_URL:
     process.env.NEXT_PUBLIC_COMMENT_TWIKOO_CDN_URL ||
-    'https://cdn.jsdelivr.net/npm/twikoo@1.6.17/dist/twikoo.all.min.js', // twikoo客户端cdn
+    'https://cdn.jsdelivr.net/npm/twikoo@1.6.42/dist/twikoo.all.min.js', // twikoo客户端cdn
 
   // utterance
   COMMENT_UTTERRANCES_REPO:


### PR DESCRIPTION
- Update Twikoo dependency from 1.6.17 to 1.6.42

## 已知问题

- 默认的Twikoo前端版本偏低
   - 无法支持新的后端 / 云函数
   - 对新部署Twikoo的用户造成困扰
    https://github.com/tangly1024/NotionNext/issues/1770

## 解决方案

- 将Twikoo的默认版本从 `1.6.17` 升级到 `1.6.42`

## 改动收益

- Twikoo官方最新的前端版本

## 具体改动

- `conf/comment.config.js`
   - COMMENT_TWIKOO_CDN_URL 配置项的默认值修改为：'https://cdn.jsdelivr.net/npm/twikoo@1.6.42/dist/twikoo.all.min.js'

## 测试确认

- [x] 本地开发环境测试通过
- [x] 生产环境构建测试通过
- [x] 版本号正确显示
- [x] 环境变量配置正常工作
