### PR TITLE
修复画廊视图左右边线不展示Bug

### DIFF
--- a/styles/notion.css
+++ b/styles/notion.css
@@ -2082,3 +2082,8 @@ figure.notion-asset-wrapper.notion-asset-wrapper-video > div {
   height: 100% !important;
   width: 100% !important;
 }
+
+/* 画廊左右边线不展示Bug */
+.notion-gallery {
+  padding: 0 16px;
+}


### PR DESCRIPTION
## 已知问题

1. 在友链页面使用画廊视图最左右的图片边线没有展示出来
2. 修改前的展示：
![友链-修复前](https://github.com/user-attachments/assets/adad3806-cbee-4065-8cab-cef0693d9e35)

## 解决方案

1. 修改全局 css 样式，添加 padding 值

## 改动收益

1. 更完整的展示友链画廊图片
2. 修改后的展示：
![友链-修复后](https://github.com/user-attachments/assets/bb6d3689-c5d5-4c0c-8d31-daa5f50608f5)


## 具体改动

1. `styles/notion.css`
   - 添加 `.notion-gallery  { padding: 0 16px; }`

## 测试确认

- 本地开发环境测试通过
- 生产环境构建测试通过
