### PR TITLE
build(nodejs): enforce Node.js >=20 in engines and .nvmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ARG NOTION_PAGE_ID
 ARG NEXT_PUBLIC_THEME
 
-FROM node:18-alpine3.18 AS base
+FROM node:20-alpine AS base
 
 # 1. Install dependencies only when needed
 FROM base AS deps

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "4.8.4",
   "homepage": "https://github.com/tangly1024/NotionNext.git",
   "license": "MIT",
+  "engines": {
+    "node": ">=20"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/tangly1024/NotionNext.git"


### PR DESCRIPTION
reason: https://github.com/tangly1024/NotionNext/pull/3374#issuecomment-2879323753

BREAKING CHANGE:
- Node.js 20 is now the minimum required version
- Updated .nvmrc and package.json "engines"
- Please upgrade local environment or CI setup


## 已知问题

1. 因react-notion-x升级的缘故，node为18时存在，无法获取数据

## 解决方案

1. 强制升级到node 20

## 测试确认

- [x] 本地开发环境测试通过
- [x] 生产环境构建测试通过
- [x] 版本号正确显示
- [x] 环境变量配置正常工作
