### PR TITLE
feat: upgrade twikoo to v1.6.44

### DIFF
--- a/conf/comment.config.js
+++ b/conf/comment.config.js
@@ -21,7 +21,7 @@ module.exports = {
     process.env.NEXT_PUBLIC_COMMENT_TWIKOO_COUNT_ENABLE || false, // 博客列表是否显示评论数
   COMMENT_TWIKOO_CDN_URL:
     process.env.NEXT_PUBLIC_COMMENT_TWIKOO_CDN_URL ||
-    'https://cdn.jsdelivr.net/npm/twikoo@1.6.44/dist/twikoo.all.min.js', // twikoo客户端cdn
+    'https://s4.zstatic.net/npm/twikoo@1.6.44/dist/twikoo.min.js', // twikoo客户端cdn
 
   // utterance
   COMMENT_UTTERRANCES_REPO:

--- a/conf/comment.config.js
+++ b/conf/comment.config.js
@@ -21,7 +21,7 @@ module.exports = {
     process.env.NEXT_PUBLIC_COMMENT_TWIKOO_COUNT_ENABLE || false, // 博客列表是否显示评论数
   COMMENT_TWIKOO_CDN_URL:
     process.env.NEXT_PUBLIC_COMMENT_TWIKOO_CDN_URL ||
-    'https://cdn.jsdelivr.net/npm/twikoo@1.6.42/dist/twikoo.all.min.js', // twikoo客户端cdn
+    'https://cdn.jsdelivr.net/npm/twikoo@1.6.44/dist/twikoo.all.min.js', // twikoo客户端cdn
 
   // utterance
   COMMENT_UTTERRANCES_REPO:


### PR DESCRIPTION
> 尽量按此模板PR内容，或粘贴相关的ISSUE链接。

## 已知问题

1. 默认的 twikoo 前端版本低于官方最新版本。
2. jsdelivr 提供的镜像速度较慢且有时无法打开。

## 解决方案

1. 将 twikoo 的默认版本从 `1.6.42` 升级到 `1.6.44`。
2. 更换 cdn 镜像地址至 zstatic（与 cdnjs 保持同步）。

## 改动收益

1. 更新到 twikoo 官方最新的前端版本。
解决评论头像可能出现字符串的问题。
2. 提升国内加载 twikoo 速度。

## 具体改动

1. conf/comment.config.js
COMMENT_TWIKOO_CDN_URL 配置项的默认值修改为：`https://s4.zstatic.net/npm/twikoo@1.6.44/dist/twikoo.min.js`

## 测试确认

- [x] 本地开发环境测试通过
- [x] 生产环境构建测试通过
- [x] 版本号正确显示
- [x] 环境变量配置正常工作
