### PR TITLE
fix: hexo主题中，移动端菜单适配主题色失效

### DIFF
--- a/themes/hexo/style.js
+++ b/themes/hexo/style.js
@@ -116,11 +116,9 @@ const Style = () => {
       .dark #theme-hexo .dark\:bg-indigo-500 {
         background-color: var(--theme-color) !important;
       }
-      /* 移动设备菜单栏背景色 */
-      #theme-hexo .hover\:bg-indigo-500:hover {
-        background-color: var(--theme-color) !important;
-      }
-      .dark #theme-hexo .dark\:hover\:bg-indigo-500:hover {
+
+      // 移动设备菜单栏选中背景色
+      #theme-hexo div[class*='hover:bg-indigo-500']:hover {
         background-color: var(--theme-color) !important;
       }
 


### PR DESCRIPTION
> 尽量按此模板PR内容，或粘贴相关的ISSUE链接。

## 已知问题

fix #3439 

## 解决方案

优化 css 选择器

## 改动收益

手机环境下，菜单栏适配主题色

## 具体改动

/hexo/style.js

## 测试确认

- [x] 本地开发环境测试通过
- [x] 生产环境构建测试通过
- [x] 版本号正确显示
- [x] 环境变量配置正常工作
