### PR TITLE
Notion数据库支持配置视图索引

### DIFF
--- a/conf/notion.config.js
+++ b/conf/notion.config.js
@@ -1,8 +1,13 @@
 /**
  * 读取Notion相关的配置
  * 如果需要在Notion中添加自定义字段，可以修改此文件
+ * 此文件内容可以通过环境变量覆盖，但是不支持用NOTION_CONFIG覆盖
  */
 module.exports = {
+  // Notion数据库索引，取notion的第几个视图作为站点数据和排序依据
+  NOTION_INDEX: process.env.NEXT_PUBLIC_NOTION_INDEX || 0,  // 默认取Notion数据库中的第1个视图
+  // 由于计算机是从0开始计数、而非从1开始。因此如果要取第二个视图，可以传1，取第三个视图传2，以此类推,取数据库的最后一个视图可以传-1。
+
   // 自定义配置notion数据库字段名
   NOTION_PROPERTY_NAME: {
     password: process.env.NEXT_PUBLIC_NOTION_PROPERTY_PASSWORD || 'password',

--- a/lib/notion/getAllPageIds.js
+++ b/lib/notion/getAllPageIds.js
@@ -1,13 +1,14 @@
+import BLOG from "@/blog.config"
 
 export default function getAllPageIds (collectionQuery, collectionId, collectionView, viewIds) {
   if (!collectionQuery && !collectionView) {
     return []
   }
-  // 优先按照第一个视图排序
   let pageIds = []
   try {
+    // Notion数据库中的第几个视图用于站点展示和排序：
+    const groupIndex = BLOG.NOTION_INDEX || 0
     if (viewIds && viewIds.length > 0) {
-      const groupIndex = viewIds.length  > 0 ? viewIds.length - 1 : 0
       const ids = collectionQuery[collectionId][viewIds[groupIndex]]?.collection_group_results?.blockIds || []
       for (const id of ids) {
         pageIds.push(id)


### PR DESCRIPTION
```
 // Notion数据库中的第几个视图用于站点展示和排序：
    const groupIndex = BLOG.NOTION_INDEX || 0
    if (viewIds && viewIds.length > 0) {
      const ids = collectionQuery[collectionId][viewIds[groupIndex]]?.collection_group_results?.blockIds || []
      for (const id of ids) {
        pageIds.push(id)
      }
    }
```

使用方法

```
// Notion数据库索引，取notion的第几个视图作为站点数据和排序依据
  NOTION_INDEX: process.env.NEXT_PUBLIC_NOTION_INDEX || 0,  // 默认取Notion数据库中的第1个视图
  // 由于计算机是从0开始计数、而非从1开始。因此如果要取第二个视图，可以传1，取第三个视图传2，以此类推,取数据库的最后一个视图可以传-1。

```

截图示例：
![image](https://github.com/user-attachments/assets/2be9e707-8e86-4874-8395-2d8f12f2b01d)
