### PR TITLE
fix: APlayer url update

### DIFF
--- a/components/Player.js
+++ b/components/Player.js
@@ -64,7 +64,7 @@ const Player = () => {
       <link
         rel='stylesheet'
         type='text/css'
-        href='https://lf9-cdn-tos.bytecdntp.com/cdn/expire-1-M/aplayer/1.10.1/APlayer.min.css'
+        href='https://cdn.jsdelivr.net/npm/aplayer@1.10.0/dist/APlayer.min.css'
       />
       {meting ? (
         <meting-js

--- a/conf/widget.config.js
+++ b/conf/widget.config.js
@@ -32,7 +32,7 @@ module.exports = {
   MUSIC_PLAYER_LRC_TYPE: process.env.NEXT_PUBLIC_MUSIC_PLAYER_LRC_TYPE || '0', // 歌词显示类型，可选值： 3 | 1 | 0（0：禁用 lrc 歌词，1：lrc 格式的字符串，3：lrc 文件 url）（前提是有配置歌词路径，对 meting 无效）
   MUSIC_PLAYER_CDN_URL:
     process.env.NEXT_PUBLIC_MUSIC_PLAYER_CDN_URL ||
-    'https://lf9-cdn-tos.bytecdntp.com/cdn/expire-1-M/aplayer/1.10.1/APlayer.min.js',
+    'https://cdn.jsdelivr.net/npm/aplayer@1.10.0/dist/APlayer.min.js',
   MUSIC_PLAYER_ORDER: process.env.NEXT_PUBLIC_MUSIC_PLAYER_ORDER || 'list', // 默认播放方式，顺序 list，随机 random
   MUSIC_PLAYER_AUDIO_LIST: [
     // 示例音乐列表。除了以下配置外，还可配置歌词，具体配置项看此文档 https://aplayer.js.org/#/zh-Hans/


### PR DESCRIPTION
## 已知问题

原有Aplayer url已失效404， 导致插件无法正常运行
<img width="817" height="165" alt="Xnip2025-07-27_17-48-59" src="https://github.com/user-attachments/assets/97b6b586-fe2a-4db0-80c9-d90266f2cd2e" />


## 解决方案

- 更新为正常可用url



## 具体改动

2处Aplayer Url更新
- components/Player.js
- conf/widget.config.js

## 测试确认

- [x] 本地开发环境测试通过
- [x] 生产环境构建测试通过
- [x] 版本号正确显示
- [x] 环境变量配置正常工作
