### PR TITLE
Update version number in package.json to 4.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "notion-next",
-  "version": "4.8.6",
+  "version": "4.9.0",
   "homepage": "https://github.com/tangly1024/NotionNext.git",
   "license": "MIT",
   "engines": {


### PR DESCRIPTION
## 已知问题

1. 版本号未修改，还停留在 `V4.8.6`
   - Release 版本已发布到 `V4.9.0`

## 解决方案

1. 将 `package.json` 中的 `version` 更新为 `V4.9.0`

## 改动收益

1. 版本号与 `Release` 页面保持一致

## 具体改动

1. 将 `package.json` 中的 `version` 更新为 `V4.9.0`

## 测试确认

- [x] 本地开发环境测试通过
- [x] 生产环境构建测试通过
- [x] 版本号正确显示
- [x] 环境变量配置正常工作
