### PR TITLE
fix(giscus): add padding to prevent iframe overflow

### DIFF
--- a/public/js/giscus.js
+++ b/public/js/giscus.js
@@ -109,6 +109,7 @@
       return (a = a[1]) && giscusIframe.setAttribute(g, a)
     })
     giscusIframe.style.opacity = '0'
+    giscusIframe.style.paddingRight = '1px'
     giscusIframe.addEventListener('load', function () {
       giscusIframe.style.removeProperty('opacity')
       giscusIframe.classList.remove('giscus-frame--loading')


### PR DESCRIPTION
fixes #3115

> 尽量按此模板PR内容，或粘贴相关的ISSUE链接。

## 已知问题

1. #3115

## 解决方案

1. 加padding强行兼容

## 测试确认

- [x] 本地开发环境测试通过
- [x] 生产环境构建测试通过
- [x] 版本号正确显示
- [x] 环境变量配置正常工作
