### PR TITLE
custom_api_base_url

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,7 @@
 # 可在此添加环境变量，去掉最左边的（# ）注释即可
 # Notion页面ID,必须
 # NOTION_PAGE_ID=097e5f674880459d8e1b4407758dc4fb
+# API_BASE_URL=https://www.notion.so/api/v3
 
 # 非必须
 # NEXT_PUBLIC_VERSION=

--- a/blog.config.js
+++ b/blog.config.js
@@ -1,7 +1,7 @@
 // 注: process.env.XX是Vercel的环境变量，配置方式见：https://docs.tangly1024.com/article/how-to-config-notion-next#c4768010ae7d44609b744e79e2f9959a
 
 const BLOG = {
-  API_BASE_URL: process.env.API_BASE_URL || 'https://www.notion.so/api/v3', // API默认请求地址
+  API_BASE_URL: process.env.API_BASE_URL || 'https://www.notion.so/api/v3', // API默认请求地址,可以配置成自己的地址例如：https://[xxxxx].notion.site/api/v3
   // Important page_id！！！Duplicate Template from  https://tanghh.notion.site/02ab3b8678004aa69e9e415905ef32a5
   NOTION_PAGE_ID:
     process.env.NOTION_PAGE_ID ||

--- a/blog.config.js
+++ b/blog.config.js
@@ -1,7 +1,8 @@
 // 注: process.env.XX是Vercel的环境变量，配置方式见：https://docs.tangly1024.com/article/how-to-config-notion-next#c4768010ae7d44609b744e79e2f9959a
 
 const BLOG = {
-  // Important page_id！！！Duplicate Template from  https://www.notion.so/tanghh/02ab3b8678004aa69e9e415905ef32a5
+  API_BASE_URL: process.env.API_BASE_URL || 'https://www.notion.so/api/v3', // API默认请求地址
+  // Important page_id！！！Duplicate Template from  https://tanghh.notion.site/02ab3b8678004aa69e9e415905ef32a5
   NOTION_PAGE_ID:
     process.env.NOTION_PAGE_ID ||
     '02ab3b8678004aa69e9e415905ef32a5,en:7c1d570661754c8fbc568e00a01fd70e',

--- a/lib/db/getSiteData.js
+++ b/lib/db/getSiteData.js
@@ -108,7 +108,7 @@ const EmptyData = pageId => {
         type: 'Post',
         slug: 'oops',
         publishDay: '2024-11-13',
-        pageCoverThumbnail: BLOG.HOME_BANNER_IMAGE,
+        pageCoverThumbnail: BLOG.HOME_BANNER_IMAGE || '/bg_image.jpg',
         date: {
           start_date: '2023-04-24',
           lastEditedDay: '2023-04-24',

--- a/lib/notion/getNotionAPI.js
+++ b/lib/notion/getNotionAPI.js
@@ -5,6 +5,7 @@ const notionAPI = getNotionAPI()
 
 function getNotionAPI() {
   return new NotionLibrary({
+    apiBaseUrl: BLOG.API_BASE_URL || 'https://www.notion.so/api/v3', // https://[xxxxx].notion.site/api/v3
     activeUser: BLOG.NOTION_ACTIVE_USER || null,
     authToken: BLOG.NOTION_TOKEN_V2 || null,
     userTimeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,


### PR DESCRIPTION
在blog.config.js 中可以看到多了一行配置:
```
  API_BASE_URL: process.env.API_BASE_URL || 'https://www.notion.so/api/v3', // API默认请求地址 ,可配置成自己的 https://<xxxx>.notion.site/api/v3
```

由于Notion官方域名API(https://www.notion.so/api/v3/queryCollection) 挂了如下图：
<img width="1337" height="877" alt="Image" src="https://github.com/user-attachments/assets/f52f5d2c-fa9c-423b-878c-56df152e25e6" />

解决方法：临时可以使用备用域名进行访问，待notion的dns网络恢复后可以无需再启用此配置。


如果获取自定义的url地址：

每个用户自己的notion共享到公网时，notion会分配一个独立域名，格式为：https://[your-company].notion.site/
只需将您的notion页面链接复制到浏览器中打开，即可看到地址栏已自动跳转到个性链接地址。

<img width="1397" height="862" alt="image" src="https://github.com/user-attachments/assets/673ce8f0-92c0-4ee3-bc45-b18cff4410a8" />

理论上，可以共用一个api地址，但是为了避免接口网络拥堵，大家千万**不要**都用我的个性域名**tanghh.notion.site**。请各自获取自己的个性域名，作为api地址的前缀




将个性域名地址拼接成完成的api地址例如：`http://xxxx.notion.site/api/v3`，然后添加到NotionNext的环境变量`API_BASE_URL`中即可。(前提是升级到最新版本的NotionNext)








