### PR TITLE
修复了Next主题无法解密邮件地址

### DIFF
--- a/themes/next/components/SocialButton.js
+++ b/themes/next/components/SocialButton.js
@@ -1,4 +1,6 @@
 import { siteConfig } from '@/lib/config'
+import { useRef } from 'react'
+import { handleEmailClick } from '@/lib/plugins/mailEncrypt'
 
 /**
  * 社交联系方式按钮组
@@ -6,6 +8,10 @@ import { siteConfig } from '@/lib/config'
  * @constructor
  */
 const SocialButton = () => {
+
+  const emailIcon = useRef(null)
+  const CONTACT_EMAIL = siteConfig('CONTACT_EMAIL')
+
   return (
     <div className='w-52 justify-center flex-wrap flex'>
       <div className='space-x-3 text-xl text-gray-600 dark:text-gray-400 text-center'>
@@ -63,12 +69,12 @@ const SocialButton = () => {
             <i className='fab fa-instagram transform hover:scale-125 duration-150' />
           </a>
         )}
-        {siteConfig('CONTACT_EMAIL') && (
+        {CONTACT_EMAIL && (
           <a
-            target='_blank'
-            rel='noreferrer'
-            title={'email'}
-            href={`mailto:${siteConfig('CONTACT_EMAIL')}`}>
+            onClick={e => handleEmailClick(e, emailIcon, CONTACT_EMAIL)}
+            title='email'
+            className='cursor-pointer'
+            ref={emailIcon}>
             <i className='fas fa-envelope transform hover:scale-125 duration-150' />
           </a>
         )}


### PR DESCRIPTION
#3708 

Next 主题下电子邮件地址不能正确的解密

## 解决方案

修复 Next 主题下有关社交按钮类下的邮件相关代码，添加解密函数。

## 改动收益

点击电子邮件按钮后可以正确解密电子邮件地址，显示出正确的邮件地址。

## 具体改动

在 themes\next\components\SocialButton.js 下，正确引入 useRef 及 handleEmailClick，修改了电子邮件链接点击事件。

## 测试确认

- 点击邮件按钮可以正确解密邮件地址
- 可以正确调转解密后的邮件地址
- 环境变量配置正常工作
- 本地构建验证正常
