### PR TITLE
fix: 修复 sitemap 错误的外链引用，完善 sitemap 生成规则

### DIFF
--- a/pages/sitemap.xml.js
+++ b/pages/sitemap.xml.js
@@ -88,6 +88,8 @@ function generateLocalesSitemap(link, allPages, locale) {
   const postFields =
     allPages
       ?.filter(p => p.status === BLOG.NOTION_PROPERTY_NAME.status_publish)
+      // 过滤掉外部链接(http开头)和锚点链接(#开头)
+      ?.filter(p => p.slug && !p.slug.startsWith('http') && !p.slug.startsWith('#'))
       ?.map(post => {
         const slugWithoutLeadingSlash = post?.slug.startsWith('/')
           ? post?.slug?.slice(1)
@@ -117,4 +119,4 @@ function getUniqueFields(fields) {
   return Array.from(uniqueFieldsMap.values());
 }
 
-export default () => {}
+export default () => { }


### PR DESCRIPTION
## 已知问题

1. Sitemap 中错误的包含了外部链接和锚点
   - Notion 数据库中的菜单项如果配置为外部链接（如 GitHub）或锚点（#），会被错误地当做站内页面处理
   - 导致生成的 Sitemap XML 中出现拼接错误的 URL（例如 `https://blog.xxx/https://github.com/...`）
   - 这些链接对于爬虫来说是 404 死链，影响 SEO 评分

## 解决方案

1. 在生成 Sitemap 时增加过滤逻辑
   - 在 [pages/sitemap.xml.js](cci:7://file:///Users/liaoyongkun/dev/blog/NotionNext/pages/sitemap.xml.js:0:0-0:0) 的 [generateLocalesSitemap](cci:1://file:///Users/liaoyongkun/dev/blog/NotionNext/pages/sitemap.xml.js:39:0-105:1) 函数中添加过滤条件
   - 自动剔除 slug 以 `http` (外部链接) 或 `#` (锚点) 开头的条目
   - 仅保留合法的站内文章和页面

## 改动收益

1. 生成更规范的 Sitemap
   - 确保 Sitemap.xml 只包含本站有效的内部链接
   - 避免向搜索引擎提交无效的死链接
   - 提升网站的 SEO 表现和爬虫抓取效率

## 具体改动

1. [pages/sitemap.xml.js](cci:7://file:///Users/liaoyongkun/dev/blog/NotionNext/pages/sitemap.xml.js:0:0-0:0)
   - 在遍历 `allPages` 生成 URL 列表时，增加了 `.filter()` 逻辑：
     ```javascript
     ?.filter(p => p.slug && !p.slug.startsWith('http') && !p.slug.startsWith('#'))
     ```

## 测试确认

- [x] 本地开发环境测试通过 (验证生成的 sitemap.xml 已成功移除 `https://github.com/...` 等外部链接)
- [x] 生产环境构建测试通过