### PR TITLE
hotfix： 兼容NOTION_API升级

### DIFF
--- a/lib/db/getSiteData.js
+++ b/lib/db/getSiteData.js
@@ -137,6 +137,101 @@ const EmptyData = pageId => {
 }
 
 /**
+ * 可能由于Notion接口升级导致数据格式变化，这里进行统一处理
+ * @param {*} block 
+ * @param {*} pageId 
+ * @returns 
+ */
+function normalizeNotionMetadata(block, pageId) {
+  const rawValue = block?.[pageId]?.value
+  if (!rawValue) return null
+  return rawValue.type ? rawValue : rawValue.value ?? null
+}
+
+/**
+ * 兼容新老 Notion collection 结构 ， 新版会用space_id 包裹一层
+ * 统一返回真正的 collection.value（包含 schema 的那一层）
+ */
+function normalizeCollection(collection) {
+  let current = collection
+
+  // 最多剥 3 层，防止死循环
+  for (let i = 0; i < 3; i++) {
+    if (!current) break
+
+    // 已经是最终形态：有 schema
+    if (current.schema) {
+      return current
+    }
+
+    // 常见包装：{ value: {...}, role }
+    if (current.value) {
+      current = current.value
+      continue
+    }
+
+    break
+  }
+
+  return current ?? {}
+}
+
+/**
+ * 兼容 Notion schema
+ * 保留原始字段 id 作为 key
+ */
+/**
+ * 兼容 Notion schema
+ * 保留原始字段 id 作为 key
+ */
+function normalizeSchema(schema = {}) {
+  const result = {}
+
+  Object.entries(schema).forEach(([key, value]) => {
+    result[key] = {
+      ...value,
+      name: value?.name || '',
+      type: value?.type || ''
+    }
+  })
+
+  return result
+}
+
+
+/**
+ * ✅ 终极版：兼容 Notion 新老 Page Block 结构
+ * 最终一定返回：{ id, type, properties }
+ */
+function normalizePageBlock(blockItem) {
+  if (!blockItem) return null
+
+  let current = blockItem
+
+  // 最多拆 4 层，防止死循环
+  for (let i = 0; i < 4; i++) {
+    if (!current) return null
+
+    // 🎯 命中目标：真正的 page block
+    if (current.type === 'page' && current.properties) {
+      return current
+    }
+
+    // 新版 Notion 常见包裹
+    if (current.value) {
+      current = current.value
+      continue
+    }
+
+    break
+  }
+
+  return null
+}
+
+
+
+/**
  * 将Notion数据转站点数据
  * 这里统一对数据格式化
  * @returns {Promise<JSX.Element|null|*>}
@@ -148,7 +243,7 @@ async function convertNotionToSiteData(pageId, from, pageRecordMap) {
   }
   pageId = idToUuid(pageId)
   let block = pageRecordMap.block || {}
-  const rawMetadata = block[pageId]?.value
+  const rawMetadata = normalizeNotionMetadata(block, pageId)
   // Check Type Page-Database和Inline-Database
   if (
     rawMetadata?.type !== 'collection_view_page' &&
@@ -157,12 +252,17 @@ async function convertNotionToSiteData(pageId, from, pageRecordMap) {
     console.error(`pageId "${pageId}" is not a database`)
     return EmptyData(pageId)
   }
-  const collection = Object.values(pageRecordMap.collection)[0]?.value || {}
   const collectionId = rawMetadata?.collection_id
+
+  const rawCollection =
+    pageRecordMap.collection?.[collectionId] ||
+    pageRecordMap.collection?.[idToUuid(collectionId)] ||
+    {}
+
+  const collection = normalizeCollection(rawCollection)
   const collectionQuery = pageRecordMap.collection_query
   const collectionView = pageRecordMap.collection_view
-  const schema = collection?.schema
-
+  const schema = normalizeSchema(collection?.schema || {})
   const viewIds = rawMetadata?.view_ids
   const collectionData = []
 
@@ -186,26 +286,37 @@ async function convertNotionToSiteData(pageId, from, pageRecordMap) {
     // console.log('有效Page数量', pageIds?.length)
   }
 
-  // 抓取主数据库最多抓取1000个blocks，溢出的数block这里统一抓取一遍
+  // 1️⃣ 找出需要 fetch 的 block
   const blockIdsNeedFetch = []
   for (let i = 0; i < pageIds.length; i++) {
     const id = pageIds[i]
-    const value = block[id]?.value
-    if (!value) {
+    const pageBlock = normalizePageBlock(block[id])
+
+    if (!pageBlock) {
       blockIdsNeedFetch.push(id)
     }
   }
+
+  // 2️⃣ fetch 缺失的 blocks
   const fetchedBlocks = await fetchInBatches(blockIdsNeedFetch)
   block = Object.assign({}, block, fetchedBlocks)
 
-  // 获取每篇文章基础数据
+  // 3️⃣ 只执行一次：生成 collectionData
   for (let i = 0; i < pageIds.length; i++) {
     const id = pageIds[i]
-    const value = block[id]?.value || fetchedBlocks[id]?.value
+
+    const rawBlock = block[id]
+    const pageBlock = normalizePageBlock(rawBlock)
+
+    if (!pageBlock) {
+      console.warn('⚠️ 无法解析 page block:', id, rawBlock)
+      continue
+    }
+
     const properties =
       (await getPageProperties(
         id,
-        value,
+        pageBlock,
         schema,
         null,
         getTagOptions(schema)
@@ -282,6 +393,7 @@ async function convertNotionToSiteData(pageId, from, pageRecordMap) {
   })
   // 新的菜单
   const customMenu = getCustomMenu({ collectionData, NOTION_CONFIG })
+  console.log('自定义菜单', customMenu)
   const latestPosts = getLatestPosts({ allPages, from, latestPostCount: 6 })
   const allNavPages = getNavPages({ allPages })
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "notion-next",
-  "version": "4.9.2",
+  "version": "4.9.2.1",
   "homepage": "https://github.com/tangly1024/NotionNext.git",
   "license": "MIT",
   "engines": {


### PR DESCRIPTION
部分Notion数据库字段不同，做兼容处理

```
pageId "xxxxxxxxxxxxxxxxxxxx is not a database
   Generating static pages (0/32) ...
TypeError: Cannot destructure property 'auth' of 'e' as it is undefined.
    at n (/vercel/path0/.next/server/common.js:88:47644)
    at o (/vercel/path0/.next/server/common.js:88:48333)
    at u (/vercel/path0/.next/server/common.js:83:138211)
    at /vercel/path0/.next/server/common.js:83:134089
    at Object.Kc [as useMemo] (/vercel/path0/node_modules/react-dom/cjs/react-dom-server.browser.production.min.js:60:240)
    at exports.useMemo (/vercel/path0/node_modules/react/cjs/react.production.min.js:26:48)
    at /vercel/path0/.next/server/common.js:83:134005
    at Wc (/vercel/path0/node_modules/react-dom/cjs/react-dom-server.browser.production.min.js:68:44)
    at Zc (/vercel/path0/node_modules/react-dom/cjs/react-dom-server.browser.production.min.js:73:362)
    at Z (/vercel/path0/node_modules/react-dom/cjs/react-dom-server.browser.production.min.js:76:89)
```