### PR TITLE
feat: 优化代码折叠逻辑，引入行数阈值检测与极简 S1 UI

### DIFF
--- a/blog.config.js
+++ b/blog.config.js
@@ -24,6 +24,8 @@ const BLOG = {
   BEI_AN_LINK: process.env.NEXT_PUBLIC_BEI_AN_LINK || 'https://beian.miit.gov.cn/', // 备案查询链接，如果用了萌备等备案请在这里填写
   BEI_AN_GONGAN: process.env.NEXT_PUBLIC_BEI_AN_GONGAN || '', // 公安备案号，例如 '浙公网安备3xxxxxxxx8号'
 
+ CODE_COLLAPSE_MIN_LINES: 30,//“长代码”阈值
+  
   // RSS订阅
   ENABLE_RSS: process.env.NEXT_PUBLIC_ENABLE_RSS || true, // 是否开启RSS订阅功能
 

--- a/blog.config.js
+++ b/blog.config.js
@@ -24,9 +24,6 @@ const BLOG = {
   BEI_AN_LINK: process.env.NEXT_PUBLIC_BEI_AN_LINK || 'https://beian.miit.gov.cn/', // 备案查询链接，如果用了萌备等备案请在这里填写
   BEI_AN_GONGAN: process.env.NEXT_PUBLIC_BEI_AN_GONGAN || '', // 公安备案号，例如 '浙公网安备3xxxxxxxx8号'
 
-  // 只有超过该行数的代码块才显示折叠条，默认 20
-  CODE_COLLAPSE_MIN_LINES: 20,
-  
   // RSS订阅
   ENABLE_RSS: process.env.NEXT_PUBLIC_ENABLE_RSS || true, // 是否开启RSS订阅功能
 

--- a/blog.config.js
+++ b/blog.config.js
@@ -24,7 +24,8 @@ const BLOG = {
   BEI_AN_LINK: process.env.NEXT_PUBLIC_BEI_AN_LINK || 'https://beian.miit.gov.cn/', // 备案查询链接，如果用了萌备等备案请在这里填写
   BEI_AN_GONGAN: process.env.NEXT_PUBLIC_BEI_AN_GONGAN || '', // 公安备案号，例如 '浙公网安备3xxxxxxxx8号'
 
- CODE_COLLAPSE_MIN_LINES: 30,//“长代码”阈值
+  // 只有超过该行数的代码块才显示折叠条，默认 20
+  CODE_COLLAPSE_MIN_LINES: 20,
   
   // RSS订阅
   ENABLE_RSS: process.env.NEXT_PUBLIC_ENABLE_RSS || true, // 是否开启RSS订阅功能

--- a/components/PrismMac.js
+++ b/components/PrismMac.js
@@ -1,184 +1,291 @@
+import { useEffect } from 'react'
+import Prism from 'prismjs'
+// 所有语言的prismjs 使用autoloader引入
+// import 'prismjs/plugins/autoloader/prism-autoloader'
+import 'prismjs/plugins/toolbar/prism-toolbar'
+import 'prismjs/plugins/toolbar/prism-toolbar.min.css'
+import 'prismjs/plugins/show-language/prism-show-language'
+import 'prismjs/plugins/copy-to-clipboard/prism-copy-to-clipboard'
+import 'prismjs/plugins/line-numbers/prism-line-numbers'
+import 'prismjs/plugins/line-numbers/prism-line-numbers.css'
+
+// mermaid图
+import { loadExternalResource } from '@/lib/utils'
+import { useRouter } from 'next/navigation'
+import { useGlobal } from '@/lib/global'
+import { siteConfig } from '@/lib/config'
+
 /**
- * @author https://github.com/txs
- * 通用 Mac 风格代码块样式 (NotionNext Universal)
- **/
+ * 代码美化相关
+ * @author https://github.com/txs/
+ * @returns
+ */
+const PrismMac = () => {
+  const router = useRouter()
+  const { isDarkMode } = useGlobal()
+  const codeMacBar = siteConfig('CODE_MAC_BAR')
+  const prismjsAutoLoader = siteConfig('PRISM_JS_AUTO_LOADER')
+  const prismjsPath = siteConfig('PRISM_JS_PATH')
 
-/* 1. Mac 窗口容器样式 */
-.code-toolbar {
-  position: relative;
-  width: 100%;
-  margin: 1rem 0;
-  border-radius: 14px;
-  border: 1px solid rgba(0, 0, 0, 0.1);
-  background: rgba(27, 28, 32, 0.94); /* 浅色模式下默认暗底 */
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.12), 0 18px 44px rgba(0, 0, 0, 0.18);
-  overflow: hidden;
-  transition: box-shadow 0.3s ease, transform 0.3s ease;
+  const prismThemeSwitch = siteConfig('PRISM_THEME_SWITCH')
+  const prismThemeDarkPath = siteConfig('PRISM_THEME_DARK_PATH')
+  const prismThemeLightPath = siteConfig('PRISM_THEME_LIGHT_PATH')
+  const prismThemePrefixPath = siteConfig('PRISM_THEME_PREFIX_PATH')
+
+  const mermaidCDN = siteConfig('MERMAID_CDN')
+  const codeLineNumbers = siteConfig('CODE_LINE_NUMBERS')
+
+  const codeCollapse = siteConfig('CODE_COLLAPSE')
+  const codeCollapseExpandDefault = siteConfig('CODE_COLLAPSE_EXPAND_DEFAULT')
+
+  useEffect(() => {
+    if (codeMacBar) {
+      loadExternalResource('/css/prism-mac-style.css', 'css')
+    }
+    // 加载prism样式
+    loadPrismThemeCSS(
+      isDarkMode,
+      prismThemeSwitch,
+      prismThemeDarkPath,
+      prismThemeLightPath,
+      prismThemePrefixPath
+    )
+    // 折叠代码
+    loadExternalResource(prismjsAutoLoader, 'js').then(url => {
+      if (window?.Prism?.plugins?.autoloader) {
+        window.Prism.plugins.autoloader.languages_path = prismjsPath
+      }
+
+      renderPrismMac(codeLineNumbers)
+      renderMermaid(mermaidCDN)
+      renderCollapseCode(codeCollapse, codeCollapseExpandDefault)
+    })
+  }, [router, isDarkMode])
+
+  return <></>
 }
 
-/* 暗色模式适配 */
-html.dark .code-toolbar {
-  border-color: rgba(255, 255, 255, 0.12);
-  background: rgba(27, 28, 32, 0.72);
-  -webkit-backdrop-filter: saturate(140%) blur(12px);
-  backdrop-filter: saturate(140%) blur(12px);
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.35), 0 18px 44px rgba(0, 0, 0, 0.45);
+/**
+ * 加载Prism主题样式
+ */
+const loadPrismThemeCSS = (
+  isDarkMode,
+  prismThemeSwitch,
+  prismThemeDarkPath,
+  prismThemeLightPath,
+  prismThemePrefixPath
+) => {
+  let PRISM_THEME
+  let PRISM_PREVIOUS
+  if (prismThemeSwitch) {
+    if (isDarkMode) {
+      PRISM_THEME = prismThemeDarkPath
+      PRISM_PREVIOUS = prismThemeLightPath
+    } else {
+      PRISM_THEME = prismThemeLightPath
+      PRISM_PREVIOUS = prismThemeDarkPath
+    }
+    const previousTheme = document.querySelector(
+      `link[href="${PRISM_PREVIOUS}"]`
+    )
+    if (
+      previousTheme &&
+      previousTheme.parentNode &&
+      previousTheme.parentNode.contains(previousTheme)
+    ) {
+      previousTheme.parentNode.removeChild(previousTheme)
+    }
+    loadExternalResource(PRISM_THEME, 'css')
+  } else {
+    loadExternalResource(prismThemePrefixPath, 'css')
+  }
 }
 
-/* 2. Mac 三色点 */
-.pre-mac {
-  position: absolute;
-  left: 12px;
-  top: 11px;
-  z-index: 13;
-  display: flex;
-  gap: 7px;
+/*
+ * 将代码块转为可折叠对象
+ */
+const renderCollapseCode = (codeCollapse, codeCollapseExpandDefault) => {
+  if (!codeCollapse) {
+    return
+  }
+
+  const COLLAPSE_MIN_LINES = Number(siteConfig('CODE_COLLAPSE_MIN_LINES', 18))
+  const codeBlocks = document.querySelectorAll('.code-toolbar')
+
+  for (const codeBlock of codeBlocks) {
+    if (codeBlock.closest('.collapse-wrapper')) {
+      continue
+    }
+
+    const code = codeBlock.querySelector('code')
+    if (!code) {
+      continue
+    }
+
+    const className = code.getAttribute('class') || ''
+    const languageMatch = className.match(/language-([\w-]+)/)
+    const language = languageMatch ? languageMatch[1] : ''
+
+    const text = code.textContent || ''
+    const lineCount = text ? text.split('\n').length : 0
+
+    // 方案 C：仅当代码行数超过阈值时才启用折叠
+    if (lineCount && lineCount < COLLAPSE_MIN_LINES) {
+      continue
+    }
+
+    const collapseWrapper = document.createElement('div')
+    collapseWrapper.className = 'collapse-wrapper w-full py-2'
+
+    const panelWrapper = document.createElement('div')
+    panelWrapper.className = 'collapse-panel-wrapper'
+
+    const header = document.createElement('button')
+    header.type = 'button'
+    header.className = 'collapse-header'
+
+    const label = language
+      ? `${language.toUpperCase()} · ${lineCount} lines`
+      : `${lineCount} lines`
+
+    header.innerHTML = `<span class="collapse-label">${label}</span><svg class="collapse-chevron" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M6.293 6.293a1 1 0 0 1 1.414 0L10 8.586l2.293-2.293a1 1 0 0 1 1.414 1.414l-3 3a1 1 0 0 1-1.414 0l-3-3a1 1 0 0 1 0-1.414z" clip-rule="evenodd"/></svg>`
+
+    const panel = document.createElement('div')
+    panel.className = 'collapse-panel'
+
+    panelWrapper.appendChild(header)
+    panelWrapper.appendChild(panel)
+    collapseWrapper.appendChild(panelWrapper)
+
+    codeBlock.parentNode.insertBefore(collapseWrapper, codeBlock)
+    panel.appendChild(codeBlock)
+
+    function setExpanded(expanded) {
+      panelWrapper.classList.toggle('is-expanded', expanded)
+      panel.classList.toggle('is-expanded', expanded)
+      header.setAttribute('aria-expanded', expanded ? 'true' : 'false')
+    }
+
+    header.addEventListener('click', () => {
+      const expanded = panelWrapper.classList.contains('is-expanded')
+      setExpanded(!expanded)
+    })
+
+    setExpanded(Boolean(codeCollapseExpandDefault))
+  }
 }
 
-.pre-mac > span {
-  width: 10px;
-  height: 10px;
-  border-radius: 999px;
+/**
+ * 将mermaid语言 渲染成图片
+ */
+const renderMermaid = mermaidCDN => {
+  const observer = new MutationObserver(mutationsList => {
+    for (const m of mutationsList) {
+      if (m.target.className === 'notion-code language-mermaid') {
+        const chart = m.target.querySelector('code').textContent
+        if (chart && !m.target.querySelector('.mermaid')) {
+          const mermaidChart = document.createElement('pre')
+          mermaidChart.className = 'mermaid'
+          mermaidChart.innerHTML = chart
+          m.target.appendChild(mermaidChart)
+        }
+
+        const mermaidsSvg = document.querySelectorAll('.mermaid')
+        if (mermaidsSvg) {
+          let needLoad = false
+          for (const e of mermaidsSvg) {
+            if (e?.firstChild?.nodeName !== 'svg') {
+              needLoad = true
+            }
+          }
+          if (needLoad) {
+            loadExternalResource(mermaidCDN, 'js').then(url => {
+              setTimeout(() => {
+                const mermaid = window.mermaid
+                mermaid?.contentLoaded()
+              }, 100)
+            })
+          }
+        }
+      }
+    }
+  })
+  if (document.querySelector('#notion-article')) {
+    observer.observe(document.querySelector('#notion-article'), {
+      attributes: true,
+      subtree: true
+    })
+  }
 }
 
-.pre-mac > span:nth-child(1) { background: #ff5f57; }
-.pre-mac > span:nth-child(2) { background: #febc2e; }
-.pre-mac > span:nth-child(3) { background: #28c840; }
+function renderPrismMac(codeLineNumbers) {
+  const container = document?.getElementById('notion-article')
 
-/* 3. Toolbar 工具栏 (复制按钮、语言标签) */
-.code-toolbar > .toolbar {
-  position: absolute;
-  top: 0;
-  right: 0;
-  height: 34px;
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  padding: 0 10px;
-  z-index: 12;
+  // Add line numbers
+  if (codeLineNumbers) {
+    const codeBlocks = container?.getElementsByTagName('pre')
+    if (codeBlocks) {
+      Array.from(codeBlocks).forEach(item => {
+        if (!item.classList.contains('line-numbers')) {
+          item.classList.add('line-numbers')
+          item.style.whiteSpace = 'pre-wrap'
+        }
+      })
+    }
+  }
+  // 重新渲染之前检查所有的多余text
+
+  try {
+    Prism.highlightAll()
+  } catch (err) {
+    console.log('代码渲染', err)
+  }
+
+  const codeToolBars = container?.getElementsByClassName('code-toolbar')
+  // Add pre-mac element for Mac Style UI
+  if (codeToolBars) {
+    Array.from(codeToolBars).forEach(item => {
+      const existPreMac = item.getElementsByClassName('pre-mac')
+      if (existPreMac.length < codeToolBars.length) {
+        const preMac = document.createElement('div')
+        preMac.classList.add('pre-mac')
+        preMac.innerHTML = '<span></span><span></span><span></span>'
+        item?.appendChild(preMac, item)
+      }
+    })
+  }
+
+  // 折叠代码行号bug
+  if (codeLineNumbers) {
+    fixCodeLineStyle()
+  }
 }
 
-.code-toolbar .toolbar-item > button {
-  font-size: 12px !important;
-  line-height: 1 !important;
-  padding: 6px 8px !important;
-  border-radius: 999px !important;
-  border: 1px solid rgba(255, 255, 255, 0.15) !important;
-  background: rgba(255, 255, 255, 0.1) !important;
-  color: rgba(255, 255, 255, 0.82) !important;
-  cursor: pointer;
-  transition: all 0.2s ease;
+/**
+ * 行号样式在首次渲染或被detail折叠后行高判断错误
+ * 在此手动resize计算
+ */
+const fixCodeLineStyle = () => {
+  const observer = new MutationObserver(mutationsList => {
+    for (const m of mutationsList) {
+      if (m.target.nodeName === 'DETAILS') {
+        const preCodes = m.target.querySelectorAll('pre.notion-code')
+        for (const preCode of preCodes) {
+          Prism.plugins.lineNumbers.resize(preCode)
+        }
+      }
+    }
+  })
+  observer.observe(document.querySelector('#notion-article'), {
+    attributes: true,
+    subtree: true
+  })
+  setTimeout(() => {
+    const preCodes = document.querySelectorAll('pre.notion-code')
+    for (const preCode of preCodes) {
+      Prism.plugins.lineNumbers.resize(preCode)
+    }
+  }, 10)
 }
 
-.code-toolbar .toolbar-item > button:hover {
-  background: rgba(255, 255, 255, 0.2) !important;
-  color: #fff !important;
-}
-
-/* 4. 代码正文排版 */
-pre.notion-code {
-  font-size: 0.92em !important;
-  line-height: 1.6 !important;
-  margin: 0 !important;
-  padding: 46px 1.1rem 1rem !important;
-  border-radius: 0 !important;
-  border: none !important;
-  background: transparent !important;
-  color: rgba(255, 255, 255, 0.9) !important;
-  overflow: auto;
-  -webkit-overflow-scrolling: touch;
-}
-
-/* 5. 智能折叠 S1 极简 UI */
-.collapse-wrapper {
-  margin: 1rem 0;
-}
-
-.collapse-panel-wrapper {
-  border-radius: 14px;
-  border: 1px solid rgba(0, 0, 0, 0.08);
-  background: rgba(255, 255, 255, 0.55);
-  -webkit-backdrop-filter: saturate(160%) blur(10px);
-  backdrop-filter: saturate(160%) blur(10px);
-  overflow: hidden;
-  transition: all 0.3s ease;
-}
-
-html.dark .collapse-panel-wrapper {
-  border-color: rgba(255, 255, 255, 0.12);
-  background: rgba(27, 28, 32, 0.6);
-}
-
-.collapse-header {
-  width: 100%;
-  height: 36px;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 0 12px;
-  cursor: pointer;
-  user-select: none;
-  border: none;
-  background: transparent;
-  color: rgba(60, 60, 67, 0.6);
-}
-
-html.dark .collapse-header {
-  color: rgba(235, 235, 245, 0.6);
-}
-
-.collapse-label {
-  font-size: 13px;
-  letter-spacing: 0.02em;
-}
-
-.collapse-chevron {
-  width: 18px;
-  height: 18px;
-  transition: transform 0.3s ease;
-  opacity: 0.8;
-}
-
-.collapse-panel-wrapper.is-expanded .collapse-chevron {
-  transform: rotate(180deg);
-}
-
-.collapse-panel {
-  max-height: 0;
-  overflow: hidden;
-  border-top: 1px solid rgba(0, 0, 0, 0.06);
-  transition: max-height 0.32s ease;
-}
-
-html.dark .collapse-panel {
-  border-top-color: rgba(255, 255, 255, 0.08);
-}
-
-.collapse-panel.is-expanded {
-  max-height: 3000px;
-}
-
-/* 6. Prism 代码高亮补丁 (暗底优化) */
-.code-toolbar .token.comment,
-.code-toolbar .token.prolog,
-.code-toolbar .token.doctype,
-.code-toolbar .token.cdata { color: rgba(235, 235, 245, 0.46); }
-.code-toolbar .token.punctuation { color: rgba(235, 235, 245, 0.6); }
-.code-toolbar .token.property,
-.code-toolbar .token.tag,
-.code-toolbar .token.boolean,
-.code-toolbar .token.number,
-.code-toolbar .token.constant,
-.code-toolbar .token.symbol,
-.code-toolbar .token.deleted { color: #7ee787; }
-.code-toolbar .token.selector,
-.code-toolbar .token.attr-name,
-.code-toolbar .token.string,
-.code-toolbar .token.char,
-.code-toolbar .token.builtin,
-.code-toolbar .token.inserted { color: #a5d6ff; }
-.code-toolbar .token.atrule,
-.code-toolbar .token.attr-value,
-.code-toolbar .token.keyword { color: #ff7ab2; }
-.code-toolbar .token.function,
-.code-toolbar .token.class-name { color: #ffd479; }
+export default PrismMac

--- a/components/PrismMac.js
+++ b/components/PrismMac.js
@@ -109,7 +109,7 @@ const renderCollapseCode = (codeCollapse, codeCollapseExpandDefault) => {
     return
   }
 
-  const COLLAPSE_MIN_LINES = Number(siteConfig('CODE_COLLAPSE_MIN_LINES', 18))
+  const COLLAPSE_MIN_LINES = Number(siteConfig('CODE_COLLAPSE_MIN_LINES', 20))
   const codeBlocks = document.querySelectorAll('.code-toolbar')
 
   for (const codeBlock of codeBlocks) {
@@ -164,6 +164,7 @@ const renderCollapseCode = (codeCollapse, codeCollapseExpandDefault) => {
       panelWrapper.classList.toggle('is-expanded', expanded)
       panel.classList.toggle('is-expanded', expanded)
       header.setAttribute('aria-expanded', expanded ? 'true' : 'false')
+      panel.style.maxHeight = expanded ? `${panel.scrollHeight}px` : '0px'
     }
 
     header.addEventListener('click', () => {

--- a/conf/code.config.js
+++ b/conf/code.config.js
@@ -25,6 +25,8 @@ module.exports = {
   CODE_COLLAPSE: process.env.NEXT_PUBLIC_CODE_COLLAPSE || true, // 是否支持折叠代码框
   CODE_COLLAPSE_EXPAND_DEFAULT:
     process.env.NEXT_PUBLIC_CODE_COLLAPSE_EXPAND_DEFAULT || true, // 折叠代码默认是展开状态
+  CODE_COLLAPSE_MIN_LINES:
+    process.env.NEXT_PUBLIC_CODE_COLLAPSE_MIN_LINES || 20, // 只有超过该行数的代码块才显示折叠条
   // Mermaid 图表CDN
   MERMAID_CDN:
     process.env.NEXT_PUBLIC_MERMAID_CDN ||

--- a/public/css/prism-mac-style.css
+++ b/public/css/prism-mac-style.css
@@ -1,58 +1,184 @@
 /**
  * @author https://github.com/txs
- * 当配置文件 CODE_MAC_BAR 开启时，此样式会被动态引入，将开启代码组件左上角的mac图标
+ * 通用 Mac 风格代码块样式 (NotionNext Universal)
  **/
+
+/* 1. Mac 窗口容器样式 */
 .code-toolbar {
   position: relative;
-  padding-top: 0 !important;
-  padding-bottom: 0 !important;
   width: 100%;
-  border-radius: 0.5rem;
-  margin-bottom: 0.5rem;
+  margin: 1rem 0;
+  border-radius: 14px;
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  background: rgba(27, 28, 32, 0.94); /* 浅色模式下默认暗底 */
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.12), 0 18px 44px rgba(0, 0, 0, 0.18);
+  overflow: hidden;
+  transition: box-shadow 0.3s ease, transform 0.3s ease;
 }
 
-.collapse-wrapper .code-toolbar {
-    margin-bottom: 0;
+/* 暗色模式适配 */
+html.dark .code-toolbar {
+  border-color: rgba(255, 255, 255, 0.12);
+  background: rgba(27, 28, 32, 0.72);
+  -webkit-backdrop-filter: saturate(140%) blur(12px);
+  backdrop-filter: saturate(140%) blur(12px);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.35), 0 18px 44px rgba(0, 0, 0, 0.45);
 }
 
-.toolbar-item{
-  white-space: nowrap;
-}
-
-.toolbar-item > button {
-  margin-top: -0.1rem;
-}
-
-pre[class*='language-'] {
-  margin-top: 0rem !important;
-  // margin-bottom: 0rem !important;
-  padding-top: 1.5rem !important;
-
-}
-
+/* 2. Mac 三色点 */
 .pre-mac {
   position: absolute;
-  left: 0.9rem;
-  top: 0.5rem;
-  z-index: 10;
+  left: 12px;
+  top: 11px;
+  z-index: 13;
+  display: flex;
+  gap: 7px;
 }
 
 .pre-mac > span {
   width: 10px;
   height: 10px;
-  border-radius: 50%;
-  margin-right: 5px;
-  float: left;
+  border-radius: 999px;
 }
 
-.pre-mac > span:nth-child(1) {
-  background: red;
+.pre-mac > span:nth-child(1) { background: #ff5f57; }
+.pre-mac > span:nth-child(2) { background: #febc2e; }
+.pre-mac > span:nth-child(3) { background: #28c840; }
+
+/* 3. Toolbar 工具栏 (复制按钮、语言标签) */
+.code-toolbar > .toolbar {
+  position: absolute;
+  top: 0;
+  right: 0;
+  height: 34px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 0 10px;
+  z-index: 12;
 }
 
-.pre-mac > span:nth-child(2) {
-  background: sandybrown;
+.code-toolbar .toolbar-item > button {
+  font-size: 12px !important;
+  line-height: 1 !important;
+  padding: 6px 8px !important;
+  border-radius: 999px !important;
+  border: 1px solid rgba(255, 255, 255, 0.15) !important;
+  background: rgba(255, 255, 255, 0.1) !important;
+  color: rgba(255, 255, 255, 0.82) !important;
+  cursor: pointer;
+  transition: all 0.2s ease;
 }
 
-.pre-mac > span:nth-child(3) {
-  background: limegreen;
+.code-toolbar .toolbar-item > button:hover {
+  background: rgba(255, 255, 255, 0.2) !important;
+  color: #fff !important;
 }
+
+/* 4. 代码正文排版 */
+pre.notion-code {
+  font-size: 0.92em !important;
+  line-height: 1.6 !important;
+  margin: 0 !important;
+  padding: 46px 1.1rem 1rem !important;
+  border-radius: 0 !important;
+  border: none !important;
+  background: transparent !important;
+  color: rgba(255, 255, 255, 0.9) !important;
+  overflow: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
+/* 5. 智能折叠 S1 极简 UI */
+.collapse-wrapper {
+  margin: 1rem 0;
+}
+
+.collapse-panel-wrapper {
+  border-radius: 14px;
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  background: rgba(255, 255, 255, 0.55);
+  -webkit-backdrop-filter: saturate(160%) blur(10px);
+  backdrop-filter: saturate(160%) blur(10px);
+  overflow: hidden;
+  transition: all 0.3s ease;
+}
+
+html.dark .collapse-panel-wrapper {
+  border-color: rgba(255, 255, 255, 0.12);
+  background: rgba(27, 28, 32, 0.6);
+}
+
+.collapse-header {
+  width: 100%;
+  height: 36px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 12px;
+  cursor: pointer;
+  user-select: none;
+  border: none;
+  background: transparent;
+  color: rgba(60, 60, 67, 0.6);
+}
+
+html.dark .collapse-header {
+  color: rgba(235, 235, 245, 0.6);
+}
+
+.collapse-label {
+  font-size: 13px;
+  letter-spacing: 0.02em;
+}
+
+.collapse-chevron {
+  width: 18px;
+  height: 18px;
+  transition: transform 0.3s ease;
+  opacity: 0.8;
+}
+
+.collapse-panel-wrapper.is-expanded .collapse-chevron {
+  transform: rotate(180deg);
+}
+
+.collapse-panel {
+  max-height: 0;
+  overflow: hidden;
+  border-top: 1px solid rgba(0, 0, 0, 0.06);
+  transition: max-height 0.32s ease;
+}
+
+html.dark .collapse-panel {
+  border-top-color: rgba(255, 255, 255, 0.08);
+}
+
+.collapse-panel.is-expanded {
+  max-height: 3000px;
+}
+
+/* 6. Prism 代码高亮补丁 (暗底优化) */
+.code-toolbar .token.comment,
+.code-toolbar .token.prolog,
+.code-toolbar .token.doctype,
+.code-toolbar .token.cdata { color: rgba(235, 235, 245, 0.46); }
+.code-toolbar .token.punctuation { color: rgba(235, 235, 245, 0.6); }
+.code-toolbar .token.property,
+.code-toolbar .token.tag,
+.code-toolbar .token.boolean,
+.code-toolbar .token.number,
+.code-toolbar .token.constant,
+.code-toolbar .token.symbol,
+.code-toolbar .token.deleted { color: #7ee787; }
+.code-toolbar .token.selector,
+.code-toolbar .token.attr-name,
+.code-toolbar .token.string,
+.code-toolbar .token.char,
+.code-toolbar .token.builtin,
+.code-toolbar .token.inserted { color: #a5d6ff; }
+.code-toolbar .token.atrule,
+.code-toolbar .token.attr-value,
+.code-toolbar .token.keyword { color: #ff7ab2; }
+.code-toolbar .token.function,
+.code-toolbar .token.class-name { color: #ffd479; }

--- a/public/css/prism-mac-style.css
+++ b/public/css/prism-mac-style.css
@@ -155,7 +155,7 @@ html.dark .collapse-panel {
 }
 
 .collapse-panel.is-expanded {
-  max-height: 3000px;
+  max-height: none;
 }
 
 /* 6. Prism 代码高亮补丁 (暗底优化) */


### PR DESCRIPTION

## 已知问题

1. 代码折叠体验不佳（全量折叠/全不折叠）
   - 当前折叠功能只按开关启用，对所有代码块一视同仁  
   - 对于只有几行的短代码片段也显示折叠条，增加视觉噪音  
   - 长文中多处代码折叠会打断阅读节奏

2. 代码块视觉表现不统一
   - 不同主题下代码块样式差异较大  
   - 暗色模式下可读性和对比度不够稳定  
   - Mac 样式代码块仅在部分主题中有实现，难以复用

## 解决方案

1. 基于行数的智能代码折叠（Scheme C）
   - 在 `PrismMac` 中为每个代码块统计行数  
   - 引入配置项 `CODE_COLLAPSE_MIN_LINES`（默认 18 行）  
   - 仅当代码行数 ≥ 阈值时才注入折叠控件  
   - 支持原有 `CODE_COLLAPSE` 开关，保持向后兼容

2. 通用化的 Mac 风代码块与 S1 极简折叠 UI
   - 将 Mac 窗口风代码块和极简折叠条样式沉淀到 `public/css/prism-mac-style.css`  
   - 使用 `.code-toolbar` / `.collapse-*` 作为通用选择器，不依赖具体主题 ID  
   - 通过 `html.dark` 适配全站暗色模式  
   - 为 Prism token 提供一套暗底优化配色，保证代码在暗底上的可读性

## 改动收益

1. 更智能的代码折叠体验
   - 短代码不再显示折叠条，阅读更连贯  
   - 长代码可按需折叠，减少页面占用  
   - 用户可以通过 `CODE_COLLAPSE_MIN_LINES` 自定义阈值

2. 更统一的视觉样式
   - 代码块在不同主题下拥有一致的 Mac 窗口风体验  
   - 折叠条使用极简灰条（S1），在浅/深色模式下都足够克制  
   - Prism token 配色在暗底上对比度更合理，长时间阅读更舒适

3. 更利于维护与扩展
   - 折叠逻辑集中在 `PrismMac`，样式集中在 `prism-mac-style.css`  
   - 各个主题只需关注自己的配色与排版，不必重复实现折叠 UI  
   - 未来如需增加其他折叠方案也可以在此基础上扩展

## 具体改动

1. `components/PrismMac.js`
   - 增加 `CODE_COLLAPSE_MIN_LINES` 配置读取，默认值为 20 
   - 在 `renderCollapseCode` 中统计每个代码块的行数，并只对超过阈值的块注入折叠 UI  
   - 将折叠头部统一改为极简样式：显示语言名与行数，例如 `TS · 42 lines`  
   - 保持向后兼容：`CODE_COLLAPSE` 关闭时完全不影响现有行为

2. `public/css/prism-mac-style.css`
   - 定义通用的 Mac 窗口风代码块样式：
     - `.code-toolbar` 容器  
     - `.pre-mac` 三色点  
     - `pre.notion-code` 代码排版与内边距  
   - 定义通用的折叠 UI 样式：
     - `.collapse-wrapper` / `.collapse-panel-wrapper` / `.collapse-header` / `.collapse-label` / `.collapse-chevron` / `.collapse-panel`  
   - 使用 `html.dark` 为暗色模式增加背景、边框和阴影适配  
   - 为 Prism token 类型提供暗底优化配色

3. （可选）`blog.config.js`
   - 新增 `CODE_COLLAPSE_MIN_LINES` 配置项与注释  
   - 示例：
     ```js
     // 只有超过该行数的代码块才显示折叠条，默认 20
     CODE_COLLAPSE_MIN_LINES: 20,
     ```

## 测试确认

- [x] 本地开发环境测试通过  
- [x] 启用/关闭 `CODE_COLLAPSE` 行为符合预期  
- [x] 不同长度代码块在阈值上下表现正确（短代码不折叠，长代码折叠）  
- [x] 浅色/暗色模式下代码块与折叠条样式正常  
- [x] 多个主题下代码块样式一致，无主题特定依赖  
