### PR TITLE
页面url转换bug

### DIFF
--- a/lib/db/notion/convertInnerUrl.js
+++ b/lib/db/notion/convertInnerUrl.js
@@ -12,7 +12,7 @@ export const convertInnerUrl = ({ allPages, lang }) => {
   }
   const allAnchorTags = document
     ?.getElementById('notion-article')
-    ?.querySelectorAll('a.notion-link, a.notion-collection-card')
+    ?.querySelectorAll('a.notion-link, a.notion-collection-card, a.notion-page-link')
 
   if (!allAnchorTags) {
     return


### PR DESCRIPTION
识别出页面中的链接，指向Notion数据库中的ID，则自动转换成slug。