### PR TITLE
feat(hexo): add Essay content type

### DIFF
--- a/conf/notion.config.js
+++ b/conf/notion.config.js
@@ -5,7 +5,7 @@
  */
 module.exports = {
   // Notion数据库索引，取notion的第几个视图作为站点数据和排序依据
-  NOTION_INDEX: process.env.NEXT_PUBLIC_NOTION_INDEX || 0,  // 默认取Notion数据库中的第1个视图
+  NOTION_INDEX: process.env.NEXT_PUBLIC_NOTION_INDEX || 0, // 默认取Notion数据库中的第1个视图
   // 由于计算机是从0开始计数、而非从1开始。因此如果要取第二个视图，可以传1，取第三个视图传2，以此类推,取数据库的最后一个视图可以传-1。
 
   // 自定义配置notion数据库字段名
@@ -13,6 +13,7 @@ module.exports = {
     password: process.env.NEXT_PUBLIC_NOTION_PROPERTY_PASSWORD || 'password',
     type: process.env.NEXT_PUBLIC_NOTION_PROPERTY_TYPE || 'type', // 文章类型，
     type_post: process.env.NEXT_PUBLIC_NOTION_PROPERTY_TYPE_POST || 'Post', // 当type文章类型与此值相同时，为博文。
+    type_essay: process.env.NEXT_PUBLIC_NOTION_PROPERTY_TYPE_ESSAY || 'Essay', // 当type文章类型与此值相同时，为随笔。
     type_page: process.env.NEXT_PUBLIC_NOTION_PROPERTY_TYPE_PAGE || 'Page', // 当type文章类型与此值相同时，为单页。
     type_notice:
       process.env.NEXT_PUBLIC_NOTION_PROPERTY_TYPE_NOTICE || 'Notice', // 当type文章类型与此值相同时，为公告。

--- a/lib/db/SiteDataApi.js
+++ b/lib/db/SiteDataApi.js
@@ -7,13 +7,22 @@ import { getConfigMapFromConfigPage } from '@/lib/db/notion/getNotionConfig'
 import getPageProperties, {
   adjustPageProperties
 } from '@/lib/db/notion/getPageProperties'
-import { fetchInBatches, fetchNotionPageBlocks, formatNotionBlock } from '@/lib/db/notion/getPostBlocks'
+import {
+  fetchInBatches,
+  fetchNotionPageBlocks,
+  formatNotionBlock
+} from '@/lib/db/notion/getPostBlocks'
 import { compressImage, mapImgUrl } from '@/lib/db/notion/mapImage'
 import { deepClone } from '@/lib/utils'
 import { idToUuid } from 'notion-utils'
 import { siteConfig } from '../config'
 import { extractLangId, extractLangPrefix, getShortId } from '../utils/pageId'
-import { normalizeNotionMetadata, normalizeCollection, normalizeSchema, normalizePageBlock } from './notion/normalizeUtil'
+import {
+  normalizeNotionMetadata,
+  normalizeCollection,
+  normalizeSchema,
+  normalizePageBlock
+} from './notion/normalizeUtil'
 
 import { fetchPageFromNotion } from './notion/getNotionPost'
 import { processPostData } from '../utils/post'
@@ -159,13 +168,7 @@ const EmptyData = pageId => {
  * ✅ 兼容 prefix / slug / suffix 任意组合
  * ⚠️ 只能在 getStaticProps / getServerSideProps 使用
  */
-export async function resolvePostProps({
-  prefix,
-  slug,
-  suffix,
-  locale,
-  from,
-}) {
+export async function resolvePostProps({ prefix, slug, suffix, locale, from }) {
   /**
    * 1️⃣ 统一路径片段
    */
@@ -182,12 +185,7 @@ export async function resolvePostProps({
    */
   const lastSegment = segments[segments.length - 1]
 
-  const slugCandidates = new Set([
-    fullSlug,
-    lastSegment,
-    slug,
-    prefix,
-  ])
+  const slugCandidates = new Set([fullSlug, lastSegment, slug, prefix])
 
   // 去掉 falsy
   for (const s of Array.from(slugCandidates)) {
@@ -223,7 +221,11 @@ export async function resolvePostProps({
     try {
       post = await fetchPageFromNotion(lastSegment)
     } catch (e) {
-      console.warn('[resolvePostProps] fetchPageFromNotion failed:', lastSegment, e)
+      console.warn(
+        '[resolvePostProps] fetchPageFromNotion failed:',
+        lastSegment,
+        e
+      )
     }
   }
 
@@ -232,7 +234,6 @@ export async function resolvePostProps({
    */
   if (post && post.id && !post?.blockMap) {
     try {
-
       const rawBlockMap = await fetchNotionPageBlocks(post.id, source)
 
       // Notion修改了数据格式再次做统一兼容
@@ -243,9 +244,12 @@ export async function resolvePostProps({
         ...post.blockMap,
         block: formatNotionBlock(post.blockMap.block)
       }
-
     } catch (e) {
-      console.warn('[resolvePostProps] fetchNotionPageBlocks failed:', post.id, e)
+      console.warn(
+        '[resolvePostProps] fetchNotionPageBlocks failed:',
+        post.id,
+        e
+      )
     }
   }
 
@@ -273,9 +277,16 @@ export async function resolvePostProps({
  * 这里统一对数据格式化
  * @returns {Promise<JSX.Element|null|*>}
  */
-async function convertNotionToSiteData(SITE_DATABASE_PAGE_ID, from, pageRecordMap) {
+async function convertNotionToSiteData(
+  SITE_DATABASE_PAGE_ID,
+  from,
+  pageRecordMap
+) {
   if (!pageRecordMap) {
-    console.error('can`t get Notion Data ; Which id is: ', SITE_DATABASE_PAGE_ID)
+    console.error(
+      'can`t get Notion Data ; Which id is: ',
+      SITE_DATABASE_PAGE_ID
+    )
     return {}
   }
   SITE_DATABASE_PAGE_ID = idToUuid(SITE_DATABASE_PAGE_ID)
@@ -383,7 +394,10 @@ async function convertNotionToSiteData(SITE_DATABASE_PAGE_ID, from, pageRecordMa
 
   // 查找所有的Post和Page
   const allPages = collectionData.filter(post => {
-    if (post?.type === 'Post' && post.status === 'Published') {
+    if (
+      (post?.type === 'Post' || post?.type === 'Essay') &&
+      post.status === 'Published'
+    ) {
       postCount++
     }
 
@@ -675,7 +689,9 @@ function cleanBlock(item) {
  */
 function getLatestPosts({ allPages, from, latestPostCount }) {
   const allPosts = allPages?.filter(
-    page => page.type === 'Post' && page.status === 'Published'
+    page =>
+      (page.type === 'Post' || page.type === 'Essay') &&
+      page.status === 'Published'
   )
 
   const latestPosts = Object.create(allPosts).sort((a, b) => {
@@ -972,7 +988,7 @@ export function getNavPages({ allPages }) {
     return (
       post &&
       post?.slug &&
-      post?.type === 'Post' &&
+      (post?.type === 'Post' || post?.type === 'Essay') &&
       post?.status === 'Published'
     )
   })

--- a/lib/db/notion/getPageProperties.js
+++ b/lib/db/notion/getPageProperties.js
@@ -4,7 +4,12 @@ import formatDate from '../../utils/formatDate'
 // import { createHash } from 'crypto'
 import md5 from 'js-md5'
 import { siteConfig } from '../../config'
-import { convertUrlStartWithOneSlash, getLastSegmentFromUrl, isHttpLink, isMailOrTelLink } from '../../utils'
+import {
+  convertUrlStartWithOneSlash,
+  getLastSegmentFromUrl,
+  isHttpLink,
+  isMailOrTelLink
+} from '../../utils'
 import { extractLangPrefix } from '../../utils/pageId'
 import { mapImgUrl } from './mapImage'
 import notionAPI from '@/lib/db/notion/getNotionAPI'
@@ -147,6 +152,7 @@ function convertToJSON(str) {
 function mapProperties(properties) {
   const typeMap = {
     [BLOG.NOTION_PROPERTY_NAME.type_post]: 'Post',
+    [BLOG.NOTION_PROPERTY_NAME.type_essay]: 'Essay',
     [BLOG.NOTION_PROPERTY_NAME.type_page]: 'Page',
     [BLOG.NOTION_PROPERTY_NAME.type_notice]: 'Notice',
     [BLOG.NOTION_PROPERTY_NAME.type_menu]: 'Menu',
@@ -175,7 +181,7 @@ export function adjustPageProperties(properties, NOTION_CONFIG) {
   // 处理URL
   // 1.按照用户配置的URL_PREFIX 转换一下slug
   // 2.为文章添加一个href字段，存储最终调整的路径
-  if (properties.type === 'Post') {
+  if (properties.type === 'Post' || properties.type === 'Essay') {
     properties.slug = generateCustomizeSlug(properties, NOTION_CONFIG)
     properties.href = properties.slug ?? properties.id
   } else if (properties.type === 'Page') {

--- a/lib/utils/post.js
+++ b/lib/utils/post.js
@@ -23,7 +23,10 @@ export function getRecommendPost(post, allPosts, count = 6) {
   const currentTags = post?.tags || []
   for (let i = 0; i < allPosts.length; i++) {
     const p = allPosts[i]
-    if (p.id === post.id || p.type.indexOf('Post') < 0) {
+    if (
+      p.id === post.id ||
+      (p.type.indexOf('Post') < 0 && p.type.indexOf('Essay') < 0)
+    ) {
       continue
     }
 
@@ -96,7 +99,6 @@ export function checkSlugHasMorThanTwoSlash(row) {
   )
 }
 
-
 /**
  * 获取文章摘要
  * @param props
@@ -136,7 +138,6 @@ async function getPageAISummary(props, pageContentText) {
  * @returns {Promise<void>}
  */
 export async function processPostData(props, from) {
-
   if (props.post?.blockMap?.block) {
     // 目录默认加载
     props.post.content = Object.keys(props.post.blockMap.block).filter(
@@ -157,7 +158,9 @@ export async function processPostData(props, from) {
 
   // 推荐关联文章处理
   const allPosts = props.allPages?.filter(
-    page => page.type === 'Post' && page.status === 'Published'
+    page =>
+      (page.type === 'Post' || page.type === 'Essay') &&
+      page.status === 'Published'
   )
   if (allPosts && allPosts.length > 0) {
     const index = allPosts.indexOf(props.post)

--- a/pages/index.js
+++ b/pages/index.js
@@ -32,7 +32,9 @@ export async function getStaticProps(req) {
     props?.NOTION_CONFIG
   )
   props.posts = props.allPages?.filter(
-    page => page.type === 'Post' && page.status === 'Published'
+    page =>
+      (page.type === 'Post' || page.type === 'Essay') &&
+      page.status === 'Published'
   )
 
   // 处理分页
@@ -52,7 +54,9 @@ export async function getStaticProps(req) {
       if (post.password && post.password !== '') {
         continue
       }
-      post.blockMap = await getPostBlocks(post.id, 'slug', POST_PREVIEW_LINES)
+      // 对于Essay类型，获取更多内容块以展示全文
+      const previewLines = post.type === 'Essay' ? 9999 : POST_PREVIEW_LINES
+      post.blockMap = await getPostBlocks(post.id, 'slug', previewLines)
     }
   }
 

--- a/themes/hexo/components/BlogPostCard.js
+++ b/themes/hexo/components/BlogPostCard.js
@@ -5,8 +5,10 @@ import CONFIG from '../config'
 import { BlogPostCardInfo } from './BlogPostCardInfo'
 
 const BlogPostCard = ({ index, post, showSummary, siteInfo }) => {
+  const isEssay = post?.type === 'Essay'
   const showPreview =
-    siteConfig('HEXO_POST_LIST_PREVIEW', null, CONFIG) && post.blockMap
+    isEssay ||
+    (siteConfig('HEXO_POST_LIST_PREVIEW', null, CONFIG) && post.blockMap)
   if (
     post &&
     !post.pageCoverThumbnail &&
@@ -15,6 +17,7 @@ const BlogPostCard = ({ index, post, showSummary, siteInfo }) => {
     post.pageCoverThumbnail = siteInfo?.pageCover
   }
   const showPageCover =
+    !isEssay &&
     siteConfig('HEXO_POST_LIST_COVER', null, CONFIG) &&
     post?.pageCoverThumbnail &&
     !showPreview
@@ -22,7 +25,8 @@ const BlogPostCard = ({ index, post, showSummary, siteInfo }) => {
 
   return (
     <div
-      className={`${siteConfig('HEXO_POST_LIST_COVER_HOVER_ENLARGE', null, CONFIG) ? ' hover:scale-110 transition-all duration-150' : ''}`}>
+      className={`${siteConfig('HEXO_POST_LIST_COVER_HOVER_ENLARGE', null, CONFIG) ? ' hover:scale-110 transition-all duration-150' : ''}`}
+    >
       <div
         key={post.id}
         data-aos='fade-up'
@@ -32,7 +36,8 @@ const BlogPostCard = ({ index, post, showSummary, siteInfo }) => {
         data-aos-anchor-placement='top-bottom'
         id='blog-post-card'
         className={`group md:h-56 w-full flex justify-between md:flex-row flex-col-reverse ${siteConfig('HEXO_POST_LIST_IMG_CROSSOVER', null, CONFIG) && index % 2 === 1 ? 'md:flex-row-reverse' : ''}
-                    overflow-hidden border dark:border-black rounded-xl bg-white dark:bg-hexo-black-gray`}>
+                    overflow-hidden border dark:border-black rounded-xl bg-white dark:bg-hexo-black-gray`}
+      >
         {/* 文字内容 */}
         <BlogPostCardInfo
           index={index}

--- a/themes/hexo/components/BlogPostCardInfo.js
+++ b/themes/hexo/components/BlogPostCardInfo.js
@@ -19,34 +19,47 @@ export const BlogPostCardInfo = ({
 }) => {
   return (
     <article
-      className={`flex flex-col justify-between lg:p-6 p-4  ${showPageCover && !showPreview ? 'md:w-7/12 w-full md:max-h-60' : 'w-full'}`}>
+      className={`flex flex-col justify-between lg:p-6 p-4  ${showPageCover && !showPreview ? 'md:w-7/12 w-full md:max-h-60' : 'w-full'}`}
+    >
       <div>
         <header>
-          <h2>
-            {/* 标题 */}
-            <SmartLink
-              href={post?.href}
-              passHref
-              className={`line-clamp-2 replace cursor-pointer text-2xl ${
-                showPreview ? 'text-center' : ''
-              } leading-tight font-normal text-gray-600 dark:text-gray-100 hover:text-indigo-700 dark:hover:text-indigo-400`}>
-              {siteConfig('POST_TITLE_ICON') && (
-                <NotionIcon icon={post.pageIcon} />
-              )}
-              <span className='menu-link '>{post.title}</span>
-            </SmartLink>
-          </h2>
+          {post.type !== 'Essay' && (
+            <h2>
+              {/* 标题 */}
+              <SmartLink
+                href={post?.href}
+                passHref
+                className={`line-clamp-2 replace cursor-pointer text-2xl ${
+                  showPreview ? 'text-center' : ''
+                } leading-tight font-normal text-gray-600 dark:text-gray-100 hover:text-indigo-700 dark:hover:text-indigo-400`}
+              >
+                {siteConfig('POST_TITLE_ICON') && (
+                  <NotionIcon icon={post.pageIcon} />
+                )}
+                <span className='menu-link '>{post.title}</span>
+              </SmartLink>
+            </h2>
+          )}
+
+          {/* 随笔特殊标识 */}
+          {post.type === 'Essay' && (
+            <div className='text-4xl text-gray-300 dark:text-gray-600 font-serif leading-none mb-2'>
+              “
+            </div>
+          )}
 
           {/* 分类 */}
           {post?.category && (
             <div
               className={`flex mt-2 items-center ${
                 showPreview ? 'justify-center' : 'justify-start'
-              } flex-wrap dark:text-gray-500 text-gray-400 `}>
+              } flex-wrap dark:text-gray-500 text-gray-400 `}
+            >
               <SmartLink
                 href={`/category/${post.category}`}
                 passHref
-                className='cursor-pointer font-light text-sm menu-link hover:text-indigo-700 dark:hover:text-indigo-400 transform'>
+                className='cursor-pointer font-light text-sm menu-link hover:text-indigo-700 dark:hover:text-indigo-400 transform'
+              >
                 <i className='mr-1 far fa-folder' />
                 {post.category}
               </SmartLink>
@@ -77,7 +90,7 @@ export const BlogPostCardInfo = ({
 
         {/* 预览 */}
         {showPreview && (
-          <div className='overflow-ellipsis truncate'>
+          <div className='overflow-ellipsis'>
             <NotionPage post={post} />
           </div>
         )}
@@ -90,7 +103,8 @@ export const BlogPostCardInfo = ({
           <SmartLink
             href={`/archive#${formatDateFmt(post?.publishDate, 'yyyy-MM')}`}
             passHref
-            className='font-light menu-link cursor-pointer text-sm leading-4 mr-3'>
+            className='font-light menu-link cursor-pointer text-sm leading-4 mr-3'
+          >
             <i className='far fa-calendar-alt mr-1' />
             {post?.publishDay || post.lastEditedDay}
           </SmartLink>


### PR DESCRIPTION
## Summary
Added a new content type "Essay" (随笔) for the Hexo theme.

- **Config**: Added `type_essay` mapping.
- **Backend**: Supported fetching and filtering "Essay" type.
- **Hexo Theme**: 
    - Essays display full content on the homepage (no truncation).
    - Essays have no cover image.
    - Essays are distinguished by a quote icon (`“`).
    - Essays do not show title links in the list view.

This allows for more fragmented, micro-blogging style content to be mixed with regular posts.