### PR TITLE
英雄区副文章数量

### DIFF
--- a/themes/magzine/components/Hero.js
+++ b/themes/magzine/components/Hero.js
@@ -8,33 +8,31 @@ import PostItemCardWide from './PostItemCardWide'
  * @param {*} param0
  * @returns
  */
-const Hero = ({ posts }) => {
-  // 获取置顶文章与次要文章
-  const postTop = posts[0]
-  const post1 = posts[1]
-  const post2 = posts[2]
-  return (
-    <>
-      <div className='w-full mx-auto max-w-screen-3xl xl:flex justify-between gap-10'>
-        {/* 左侧一篇主要置顶文章 */}
-        <div className='basis-1/2 mb-6 px-2 lg:px-5'>
-          <PostItemCardTop post={postTop} />
-        </div>
-        {/* 右侧 */}
-        <div className='basis-1/2 flex flex-col gap-y-4'>
-          {/* 首屏宣传小Banner */}
-          <BannerItem />
+const Hero = ({ topPosts = [], subPosts = [] }) => {
+  const postTop = topPosts[0]
 
-          {/* 两篇次要文章 */}
-          <div className='py-4 px-2 lg:px-0 flex flex-col gap-y-6'>
-            <hr />
-            <PostItemCardWide post={post1} />
-            <hr />
-            <PostItemCardWide post={post2} />
-          </div>
+  return (
+    <div className='w-full mx-auto max-w-screen-3xl xl:flex justify-between gap-10'>
+      
+      {/* 左侧主文章 */}
+      <div className='basis-1/2 mb-6 px-2 lg:px-5'>
+        {postTop && <PostItemCardTop post={postTop} />}
+      </div>
+
+      {/* 右侧 */}
+      <div className='basis-1/2 flex flex-col gap-y-4'>
+        <BannerItem />
+
+        <div className='py-4 px-2 lg:px-0 flex flex-col gap-y-6'>
+          {subPosts.map((post, index) => (
+            <div key={post.id || index}>
+              <hr />
+              <PostItemCardWide post={post} />
+            </div>
+          ))}
         </div>
       </div>
-    </>
+    </div>
   )
 }
 export default Hero

--- a/themes/magzine/config.js
+++ b/themes/magzine/config.js
@@ -12,6 +12,8 @@ const CONFIG = {
     '借助NotionNext，获得助您开创、经营和扩展业务所需的全部工具和帮助。',
   MAGZINE_HOME_TIPS: 'AI时代来临，这是属于超级个体的狂欢盛宴！',
 
+  MAGZINE_HERO_SUB_POST_COUNT: 2, // 首屏英雄区次要文章数量，通常2篇，如果关闭Banner，推荐改为3篇
+
   // 首页底部推荐文章标签, 例如 [推荐] , 最多六篇文章; 若留空白''，则推荐最近更新文章
   MAGZINE_RECOMMEND_POST_TAG: '推荐',
   MAGZINE_RECOMMEND_POST_COUNT: 6,

--- a/themes/magzine/index.js
+++ b/themes/magzine/index.js
@@ -101,13 +101,29 @@ const LayoutBase = props => {
  */
 const LayoutIndex = props => {
   const { posts } = props
-  // 最新文章 从第4个元素开始截取出4个
-  const newPosts = posts.slice(3, 7)
+
+   // ===== 1. Hero区域 =====
+  const heroTopPosts = posts.slice(0, 1)
+  const heroSubPosts = posts.slice(
+    heroTopPosts.length,
+    heroTopPosts.length + siteConfig('MAGZINE_HERO_SUB_POST_COUNT', 2, CONFIG)
+  )
+
+  // ===== 2. 剩余文章 =====
+  const remainingPosts = posts.slice(
+    heroTopPosts.length + heroSubPosts.length
+  )
+
+  // ===== 3. 最新文章 =====
+  const newPosts = remainingPosts.slice(0, siteConfig('MAGZINE_LATEST_POST_COUNT', 4, CONFIG))
 
   return (
     <div className='pt-10 md:pt-18'>
       {/* 首屏宣传区块 */}
-      <Hero posts={posts} />
+     <Hero
+        topPosts={heroTopPosts}
+        subPosts={heroSubPosts}
+      />
 
       {/* 最新文章区块 */}
       <PostSimpleListHorizontal


### PR DESCRIPTION
Magzine主题没有Banner时，可以调整右侧副文章数量，从而确保左右样式齐平


效果预览：

<img width="1605" height="763" alt="84ba44c873212b2d5321633a33011385" src="https://github.com/user-attachments/assets/27fa60d5-d93b-4810-9d52-3e6589dde847" />
