### PR TITLE
security: updated form-data to ^4.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,6 +73,9 @@
     "react-tweet-embed": "~2.0.0"
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "^6.1.4",
+    "@testing-library/react": "^14.1.2",
+    "@testing-library/user-event": "^14.5.1",
     "@types/node": "22.15.3",
     "@types/react": "18.3.10",
     "@typescript-eslint/eslint-plugin": "^7.18.0",
@@ -88,21 +91,19 @@
     "eslint-plugin-prettier": "^5.5.1",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^4.6.2",
+    "jest": "^29.7.0",
+    "jest-environment-jsdom": "^29.7.0",
+    "jest-junit": "^16.0.0",
     "next-sitemap": "^1.9.12",
     "postcss": "^8.5.6",
     "prettier": "^3.6.2",
     "tailwindcss": "^3.4.17",
     "typescript": "5.6.2",
-    "webpack-bundle-analyzer": "^4.5.0",
-    "@testing-library/jest-dom": "^6.1.4",
-    "@testing-library/react": "^14.1.2",
-    "@testing-library/user-event": "^14.5.1",
-    "jest": "^29.7.0",
-    "jest-environment-jsdom": "^29.7.0",
-    "jest-junit": "^16.0.0"
+    "webpack-bundle-analyzer": "^4.5.0"
   },
   "resolutions": {
-    "axios": ">=0.21.1"
+    "axios": ">=0.21.1",
+    "form-data": "^4.0.4"
   },
   "bugs": {
     "url": "https://github.com/tangly/NotionNext/issues",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3167,13 +3167,15 @@ foreground-child@^3.1.0:
     cross-spawn "^7.0.0"
     signal-exit "^4.0.1"
 
-form-data@^4.0.0:
-  version "4.0.1"
-  resolved "https://registry.npmmirror.com/form-data/-/form-data-4.0.1.tgz"
-  integrity sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==
+form-data@^4.0.0, form-data@^4.0.4:
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.5.tgz#b49e48858045ff4cbf6b03e1805cebcad3679053"
+  integrity sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==
   dependencies:
     asynckit "^0.4.0"
     combined-stream "^1.0.8"
+    es-set-tostringtag "^2.1.0"
+    hasown "^2.0.2"
     mime-types "^2.1.12"
 
 fraction.js@^4.3.7:


### PR DESCRIPTION
已知问题

  1. form-data 依赖版本为 4.0.1，存在已知安全漏洞 CVE-2025-7783

  解决方案

  1. 在 resolutions 中将 form-data 固定为 ^4.0.4，强制升级至 4.0.5
    - 同时整理了 devDependencies 的字母排序

  改动收益

  1. 修复 form-data 安全漏洞
    - 升级后版本包含 es-set-tostringtag 和 hasown 等额外安全依赖
    - 不影响现有功能

  具体改动

  1. package.json
    - resolutions 中新增 "form-data": "^4.0.4"
    - 整理 devDependencies 为字母排序
  2. yarn.lock
    - form-data 从 4.0.1 升级至 4.0.5

  测试确认

  - 本地开发环境测试通过
  - 生产环境构建测试通过
  - 依赖安全扫描通过

  ---
  Known Issues

  1. form-data dependency at version 4.0.1 has a known security vulnerability CVE-2025-7783

  Solution

  1. Pin form-data to ^4.0.4 in resolutions, forcing upgrade to 4.0.5
    - Also sorted devDependencies alphabetically

  Benefits

  1. Fixes form-data security vulnerability
    - Updated version includes additional security hardening via es-set-tostringtag and hasown
    - No functional impact

  Changes

  1. package.json
    - Added "form-data": "^4.0.4" to resolutions
    - Sorted devDependencies alphabetically
  2. yarn.lock
    - form-data upgraded from 4.0.1 to 4.0.5

  Testing

  - Local dev environment tested
  - Production build tested
  - Dependency security scan passed