### PR TITLE
Release/4.9.4.2

### DIFF
--- a/lib/build/prefetch.js
+++ b/lib/build/prefetch.js
@@ -1,0 +1,47 @@
+// lib/build/prefetch.js
+import pLimit from 'p-limit'
+import { fetchNotionPageBlocks } from '@/lib/db/notion/getPostBlocks'
+import {
+  getDataFromCache,
+  setDataToCache
+
+} from '@/lib/cache/cache_manager'
+
+/**
+ * 预热所有页面的 block 数据
+ * @param {*} allPages 页面列表
+ * @param {*} concurrency 并发数
+ */
+export async function prefetchAllBlockMaps(allPages, concurrency = 8) {
+  const limit = pLimit(concurrency)
+  let hit = 0, fetched = 0, failed = 0
+
+  console.log(`[Prefetch] 开始预热 ${allPages.length} 个页面 block`)
+  const start = Date.now()
+
+  await Promise.all(
+    allPages.map(page =>
+      limit(async () => {
+        const cacheKey = `page_block_${page.id}`
+        
+        // 已有缓存跳过
+        if (await getDataFromCache(cacheKey)) {
+          hit++
+          return
+        }
+
+        try {
+          const block = await fetchNotionPageBlocks(page.id, 'prefetch')
+          await setDataToCache(cacheKey, block, 1000 * 60 * 60 * 2) // 2小时
+          fetched++
+        } catch (e) {
+          console.warn('[Prefetch Failed]', page.id, e.message)
+          failed++
+        }
+      })
+    )
+  )
+
+  const elapsed = ((Date.now() - start) / 1000).toFixed(1)
+  console.log(`[Prefetch] 完成: 命中缓存=${hit} 新拉取=${fetched} 失败=${failed} 耗时=${elapsed}s`)
+}

--- a/lib/build/prefetch.js
+++ b/lib/build/prefetch.js
@@ -7,6 +7,37 @@ import {
 
 } from '@/lib/cache/cache_manager'
 
+
+// lib/build/prefetch.js 中新增，或单独放 lib/build/buildUtils.js
+
+/**
+ * 获取优先预生成的页面
+ * - 最新5篇（按发布时间倒序）
+ * - 默认排序前5篇（allPages 原始顺序）
+ * - 两者合并去重
+ */
+export function getPriorityPages(allPages) {
+  const published = (allPages ?? []).filter(
+    p => p.type === 'Post' && p.status === 'Published'
+  )
+
+  // 默认排序前5
+  const top5Default = published.slice(0, 5)
+
+  // 按发布时间最新5
+  const top5Latest = [...published]
+    .sort((a, b) => new Date(b.publishDate) - new Date(a.publishDate))
+    .slice(0, 5)
+
+  // 合并去重
+  const seen = new Set()
+  return [...top5Default, ...top5Latest].filter(p => {
+    if (seen.has(p.id)) return false
+    seen.add(p.id)
+    return true
+  })
+}
+
 /**
  * 预热所有页面的 block 数据
  * @param {*} allPages 页面列表

--- a/lib/build/staticPaths.js
+++ b/lib/build/staticPaths.js
@@ -2,6 +2,7 @@
 // lib/build/staticPaths.js
 import { fetchGlobalAllData } from '@/lib/db/notion'
 import { prefetchAllBlockMaps } from '@/lib/build/prefetch'
+import { isExport } from '../utils/buildMode'
 
 let _prefetchDone = false // 模块级标记，同一构建进程只预热一次
 

--- a/lib/build/staticPaths.js
+++ b/lib/build/staticPaths.js
@@ -1,0 +1,42 @@
+
+// lib/build/staticPaths.js
+import { fetchGlobalAllData } from '@/lib/db/notion'
+import { prefetchAllBlockMaps } from '@/lib/build/prefetch'
+
+let _prefetchDone = false // 模块级标记，同一构建进程只预热一次
+
+export async function getStaticPathsBase(filterFn) {
+  if (!isExport()) {
+    return { paths: [], fallback: 'blocking' }
+  }
+
+  const { allPages } = await fetchGlobalAllData({ from: 'static-paths' })
+
+  // 只在第一个调用的路由文件里执行预热
+  if (!_prefetchDone) {
+    _prefetchDone = true
+    // 预热全部，但优先处理最新5篇
+    await prefetchAllBlockMaps(allPages)
+  }
+
+  return {
+    paths: allPages.filter(filterFn).map(pageToParams),
+    fallback: false
+  }
+}
+
+// 把最新5篇单独导出，供各路由文件复用
+export async function getLatestSlugs(allPages, count = 5) {
+  return [...allPages]
+    .filter(p => p.type === 'Post' && p.status === 'Published')
+    .sort((a, b) => new Date(b.publishDate) - new Date(a.publishDate))
+    .slice(0, count)
+}
+
+// 把最新5篇单独导出，供各路由文件复用
+export async function getLatestSlugs(allPages, count = 5) {
+  return [...allPages]
+    .filter(p => p.type === 'Post' && p.status === 'Published')
+    .sort((a, b) => new Date(b.publishDate) - new Date(a.publishDate))
+    .slice(0, count)
+}

--- a/lib/cache/cache_manager.js
+++ b/lib/cache/cache_manager.js
@@ -141,8 +141,8 @@ export async function delCacheData(key) {
 
 function getCacheType() {
   if (hasRedis) return 'redis'
-  if (isVercelEnv()) return 'vercel'
   if (isBuildPhase) return 'file'
+  // if (isVercelEnv()) return 'vercel'
   return 'memory'
 }
 

--- a/lib/db/SiteDataApi.js
+++ b/lib/db/SiteDataApi.js
@@ -26,7 +26,7 @@ import {
 import { fetchPageFromNotion } from './notion/getNotionPost'
 import { processPostData } from '../utils/post'
 import { adapterNotionBlockMap } from '../utils/notion.util'
-import pLimit from 'p-limit'
+// import pLimit from 'p-limit'
 
 export { getAllTags } from './notion/getAllTags'
 export { fetchPageFromNotion as getPost } from './notion/getNotionPost'

--- a/lib/utils/buildMode.js
+++ b/lib/utils/buildMode.js
@@ -1,0 +1,8 @@
+/**
+ * 是否静态导出；或ISR动态站点
+ */
+function isExport() {
+  return process.env.EXPORT === 'true'
+}
+
+module.exports = { isExport }

--- a/lib/utils/pageId.js
+++ b/lib/utils/pageId.js
@@ -41,11 +41,5 @@ function getShortId(uuid) {
   return uuid.substring(14)
 }
 
-/**
- * 是否静态导出；或ISR动态站点
- */
-function isExport() {
-  return process.env.EXPORT === 'true'
-}
 
-module.exports = { extractLangPrefix, extractLangId, getShortId, isExport }
+module.exports = { extractLangPrefix, extractLangId, getShortId }

--- a/lib/utils/pageId.js
+++ b/lib/utils/pageId.js
@@ -6,7 +6,7 @@
  */
 function extractLangPrefix(str) {
   const match = str.match(/^(.+?):/)
-  if (match && match[1]) {
+  if (match?.[1]) {
     return match[1]
   } else {
     return ''
@@ -22,7 +22,7 @@ function extractLangId(str) {
   // 使用正则表达式匹配字符串
   const match = str.match(/:\s*(.+)/)
   // 如果匹配成功，则返回匹配到的内容
-  if (match && match[1]) {
+  if (match?.[1]) {
     return match[1]
   } else {
     // 如果没有匹配到，则返回空字符串或者其他你想要返回的值
@@ -35,10 +35,17 @@ function extractLangId(str) {
  */
 
 function getShortId(uuid) {
-  if (!uuid || uuid.indexOf('-') < 0) {
+  if (!uuid?.includes('-')) {
     return uuid
   }
   return uuid.substring(14)
 }
 
-module.exports = { extractLangPrefix, extractLangId, getShortId }
+/**
+ * 是否静态导出；或ISR动态站点
+ */
+function isExport() {
+  return process.env.EXPORT === 'true'
+}
+
+module.exports = { extractLangPrefix, extractLangId, getShortId, isExport }

--- a/next.config.js
+++ b/next.config.js
@@ -1,8 +1,8 @@
 const { THEME } = require('./blog.config')
-const fs = require('fs')
-const path = require('path')
+const fs = require('node:fs')
+const path = require('node:path')
 const BLOG = require('./blog.config')
-const { extractLangPrefix } = require('./lib/utils/pageId')
+const { extractLangPrefix, isExport } = require('./lib/utils/pageId')
 
 // 打包时是否分析代码
 const withBundleAnalyzer = require('@next/bundle-analyzer')({
@@ -18,8 +18,7 @@ const locales = (function () {
   const langs = [BLOG.LANG]
   if (BLOG.NOTION_PAGE_ID.indexOf(',') > 0) {
     const siteIds = BLOG.NOTION_PAGE_ID.split(',')
-    for (let index = 0; index < siteIds.length; index++) {
-      const siteId = siteIds[index]
+    for (const siteId of siteIds) {
       const prefix = extractLangPrefix(siteId)
       // 如果包含前缀 例如 zh , en 等
       if (prefix) {
@@ -36,8 +35,8 @@ const locales = (function () {
 // eslint-disable-next-line no-unused-vars
 const preBuild = (function () {
   if (
-    !process.env.npm_lifecycle_event === 'export' &&
-    !process.env.npm_lifecycle_event === 'build'
+    process.env.npm_lifecycle_event !== 'export' &&
+    process.env.npm_lifecycle_event !== 'build'
   ) {
     return
   }
@@ -81,7 +80,7 @@ function scanSubdirectories(directory) {
  */
 
 function getOutput() {
-  if (process.env.EXPORT) return 'export'
+  if (isExport()) return 'export'
   if (process.env.NEXT_BUILD_STANDALONE === 'true') return 'standalone'
   return undefined
 }
@@ -163,8 +162,7 @@ const nextConfig = {
       if (BLOG.NOTION_PAGE_ID.indexOf(',') > 0) {
         const siteIds = BLOG.NOTION_PAGE_ID.split(',')
         const langs = []
-        for (let index = 0; index < siteIds.length; index++) {
-          const siteId = siteIds[index]
+        for (const siteId of siteIds) {
           const prefix = extractLangPrefix(siteId)
           // 如果包含前缀 例如 zh , en 等
           if (prefix) {

--- a/next.config.js
+++ b/next.config.js
@@ -2,7 +2,8 @@ const { THEME } = require('./blog.config')
 const fs = require('node:fs')
 const path = require('node:path')
 const BLOG = require('./blog.config')
-const { extractLangPrefix, isExport } = require('./lib/utils/pageId')
+const { extractLangPrefix } = require('./lib/utils/pageId')
+const { isExport } = require('./lib/utils/buildMode')
 
 // 打包时是否分析代码
 const withBundleAnalyzer = require('@next/bundle-analyzer')({

--- a/pages/[prefix]/[slug]/[...suffix].js
+++ b/pages/[prefix]/[slug]/[...suffix].js
@@ -1,10 +1,10 @@
 import BLOG from '@/blog.config'
 import { siteConfig } from '@/lib/config'
 import { fetchGlobalAllData, resolvePostProps } from '@/lib/db/SiteDataApi'
-import { checkSlugHasMorThanTwoSlash, processPostData } from '@/lib/utils/post'
-import { idToUuid } from 'notion-utils'
+import { checkSlugHasMorThanTwoSlash } from '@/lib/utils/post'
 import Slug from '..'
-import { isExport } from '@/lib/utils/pageId'
+import { isExport } from '@/lib/utils/buildMode'
+import { getPriorityPages, prefetchAllBlockMaps } from '@/lib/build/prefetch'
 
 /**
  * 根据notion的slug访问页面
@@ -16,33 +16,44 @@ const PrefixSlug = props => {
   return <Slug {...props} />
 }
 
-/**
- * 编译渲染页面路径
- * @returns
- */
+
 export async function getStaticPaths() {
-
-  // ISR 模式：不预生成，按需渲染
-  if (!isExport()) {
-    return { paths: [], fallback: 'blocking' }
-  }
-
   const from = 'slug-paths'
   const { allPages } = await fetchGlobalAllData({ from })
-  const paths = allPages
-    ?.filter(row => checkSlugHasMorThanTwoSlash(row))
-    .map(row => ({
-      params: {
-        prefix: row.slug.split('/')[0],
-        slug: row.slug.split('/')[1],
-        suffix: row.slug.split('/').slice(2)
-      }
-    }))
 
-    
+  // Export 模式：全量预生成
+  if (isExport()) {
+    await prefetchAllBlockMaps(allPages)
+    return {
+      paths: allPages
+        ?.filter(row => checkSlugHasMorThanTwoSlash(row))
+        .map(row => ({
+          params: {
+            prefix: row.slug.split('/')[0],
+            slug: row.slug.split('/')[1],
+            suffix: row.slug.split('/').slice(2)
+          }
+        })),
+      fallback: false
+    }
+  }
+
+  // ISR 模式：预生成最新10篇（仅三段以上路径格式）
+  const tops = getPriorityPages(allPages)
+
+  await prefetchAllBlockMaps(tops)
+
   return {
-    paths: paths,
-    fallback: true
+    paths: tops
+      .filter(p => checkSlugHasMorThanTwoSlash(p))
+      .map(row => ({
+        params: {
+          prefix: row.slug.split('/')[0],
+          slug: row.slug.split('/')[1],
+          suffix: row.slug.split('/').slice(2)
+        }
+      })),
+    fallback: 'blocking'
   }
 }
 

--- a/pages/[prefix]/[slug]/[...suffix].js
+++ b/pages/[prefix]/[slug]/[...suffix].js
@@ -4,6 +4,7 @@ import { fetchGlobalAllData, resolvePostProps } from '@/lib/db/SiteDataApi'
 import { checkSlugHasMorThanTwoSlash, processPostData } from '@/lib/utils/post'
 import { idToUuid } from 'notion-utils'
 import Slug from '..'
+import { isExport } from '@/lib/utils/pageId'
 
 /**
  * 根据notion的slug访问页面
@@ -20,11 +21,10 @@ const PrefixSlug = props => {
  * @returns
  */
 export async function getStaticPaths() {
-  if (!BLOG.isProd) {
-    return {
-      paths: [],
-      fallback: true
-    }
+
+  // ISR 模式：不预生成，按需渲染
+  if (!isExport()) {
+    return { paths: [], fallback: 'blocking' }
   }
 
   const from = 'slug-paths'
@@ -38,6 +38,8 @@ export async function getStaticPaths() {
         suffix: row.slug.split('/').slice(2)
       }
     }))
+
+    
   return {
     paths: paths,
     fallback: true
@@ -53,6 +55,7 @@ export async function getStaticProps({
   params: { prefix, slug, suffix },
   locale
 }) {
+
   const props = await resolvePostProps({
     prefix,
     slug,
@@ -62,13 +65,14 @@ export async function getStaticProps({
 
   return {
     props,
-    revalidate: process.env.EXPORT
+    revalidate: isExport()
       ? undefined
       : siteConfig(
         'NEXT_REVALIDATE_SECOND',
         BLOG.NEXT_REVALIDATE_SECOND,
         props.NOTION_CONFIG
-      )
+      ),
+    notFound: !props.post
   }
 }
 

--- a/pages/[prefix]/[slug]/index.js
+++ b/pages/[prefix]/[slug]/index.js
@@ -3,6 +3,7 @@ import { siteConfig } from '@/lib/config'
 import { fetchGlobalAllData, resolvePostProps } from '@/lib/db/SiteDataApi'
 import Slug from '..'
 import { checkSlugHasOneSlash } from '@/lib/utils/post'
+import { isExport } from '@/lib/utils/pageId'
 
 /**
  * 根据notion的slug访问页面
@@ -15,11 +16,10 @@ const PrefixSlug = props => {
 }
 
 export async function getStaticPaths() {
-  if (!BLOG.isProd) {
-    return {
-      paths: [],
-      fallback: true
-    }
+
+  // ISR 模式：不预生成，按需渲染
+  if (!isExport()) {
+    return { paths: [], fallback: 'blocking' }
   }
 
   const from = 'slug-paths'
@@ -52,13 +52,14 @@ export async function getStaticProps({ params: { prefix, slug }, locale }) {
 
   return {
     props,
-    revalidate: process.env.EXPORT
+    revalidate: isExport()
       ? undefined
       : siteConfig(
         'NEXT_REVALIDATE_SECOND',
         BLOG.NEXT_REVALIDATE_SECOND,
         props.NOTION_CONFIG
       ),
+    notFound: !props.post
   }
 }
 

--- a/pages/[prefix]/[slug]/index.js
+++ b/pages/[prefix]/[slug]/index.js
@@ -3,7 +3,8 @@ import { siteConfig } from '@/lib/config'
 import { fetchGlobalAllData, resolvePostProps } from '@/lib/db/SiteDataApi'
 import Slug from '..'
 import { checkSlugHasOneSlash } from '@/lib/utils/post'
-import { isExport } from '@/lib/utils/pageId'
+import { isExport } from '@/lib/utils/buildMode'
+import { getPriorityPages, prefetchAllBlockMaps } from '@/lib/build/prefetch'
 
 /**
  * 根据notion的slug访问页面
@@ -16,30 +17,40 @@ const PrefixSlug = props => {
 }
 
 export async function getStaticPaths() {
-
-  // ISR 模式：不预生成，按需渲染
-  if (!isExport()) {
-    return { paths: [], fallback: 'blocking' }
-  }
-
   const from = 'slug-paths'
   const { allPages } = await fetchGlobalAllData({ from })
 
-  // 根据slug中的 / 分割成prefix和slug两个字段 ; 例如 article/test
-  // 最终用户可以通过  [domain]/[prefix]/[slug] 路径访问，即这里的 [domain]/article/test
-  const paths = allPages
-    ?.filter(row => checkSlugHasOneSlash(row))
-    .map(row => ({
-      params: { prefix: row.slug.split('/')[0], slug: row.slug.split('/')[1] }
-    }))
+  // Export 模式：全量预生成
+  if (isExport()) {
+    await prefetchAllBlockMaps(allPages)
+    return {
+      paths: allPages
+        ?.filter(row => checkSlugHasOneSlash(row))
+        .map(row => ({
+          params: {
+            prefix: row.slug.split('/')[0],
+            slug: row.slug.split('/')[1]
+          }
+        })),
+      fallback: false
+    }
+  }
 
-  // 增加一种访问路径 允许通过 [category]/[slug] 访问文章
-  // 例如文章slug 是 test ，然后文章的分类category是 production
-  // 则除了 [domain]/[slug] 以外，还支持分类名访问: [domain]/[category]/[slug]
+  // ISR 模式：预生成最新10篇（仅两段路径格式）
+  const tops = getPriorityPages(allPages)
+
+  await prefetchAllBlockMaps(tops)
 
   return {
-    paths: paths,
-    fallback: true
+    paths: tops
+      .filter(p => checkSlugHasOneSlash(p))
+      .map(row => ({
+        params: {
+          prefix: row.slug.split('/')[0],
+          slug: row.slug.split('/')[1]
+        }
+      })),
+    fallback: 'blocking'
   }
 }
 

--- a/pages/[prefix]/index.js
+++ b/pages/[prefix]/index.js
@@ -11,6 +11,8 @@ import { DynamicLayout } from '@/themes/theme'
 import md5 from 'js-md5'
 import { useRouter } from 'next/router'
 import { useEffect, useState } from 'react'
+import { isExport } from '@/lib/utils/pageId'
+import { prefetchAllBlockMaps } from '@/lib/build/prefetch'
 
 /**
  * 根据notion的slug访问页面
@@ -95,11 +97,10 @@ const Slug = props => {
 }
 
 export async function getStaticPaths() {
-  if (!BLOG.isProd) {
-    return {
-      paths: [],
-      fallback: true
-    }
+
+  // ISR 模式：不预生成，按需渲染
+  if (!isExport()) {
+    return { paths: [], fallback: 'blocking' }
   }
 
   const from = 'slug-paths'
@@ -107,6 +108,10 @@ export async function getStaticPaths() {
   const paths = allPages
     ?.filter(row => checkSlugHasNoSlash(row))
     .map(row => ({ params: { prefix: row.slug } }))
+
+  // 静态导出时预加载所有block
+  await prefetchAllBlockMaps(allPages)
+
   return {
     paths: paths,
     fallback: true
@@ -118,15 +123,17 @@ export async function getStaticProps({ params: { prefix }, locale }) {
     prefix,
     locale,
   })
+
   return {
     props,
-    revalidate: process.env.EXPORT
+    revalidate: isExport()
       ? undefined
       : siteConfig(
         'NEXT_REVALIDATE_SECOND',
         BLOG.NEXT_REVALIDATE_SECOND,
         props.NOTION_CONFIG
-      )
+      ),
+    notFound: !props.post
   }
 }
 

--- a/pages/[prefix]/index.js
+++ b/pages/[prefix]/index.js
@@ -10,9 +10,10 @@ import { checkSlugHasNoSlash } from '@/lib/utils/post'
 import { DynamicLayout } from '@/themes/theme'
 import md5 from 'js-md5'
 import { useRouter } from 'next/router'
+import PropTypes from 'prop-types'
 import { useEffect, useState } from 'react'
-import { isExport } from '@/lib/utils/pageId'
-import { prefetchAllBlockMaps } from '@/lib/build/prefetch'
+import { isExport } from '@/lib/utils/buildMode'
+import { getPriorityPages, prefetchAllBlockMaps } from '@/lib/build/prefetch'
 
 /**
  * 根据notion的slug访问页面
@@ -96,25 +97,44 @@ const Slug = props => {
   )
 }
 
+Slug.propTypes = {
+  post: PropTypes.shape({
+    id: PropTypes.string,
+    slug: PropTypes.string,
+    password: PropTypes.string,
+    content: PropTypes.array,
+    toc: PropTypes.array,
+    blockMap: PropTypes.shape({
+      block: PropTypes.object
+    })
+  }),
+  NOTION_CONFIG: PropTypes.object
+}
+
 export async function getStaticPaths() {
-
-  // ISR 模式：不预生成，按需渲染
-  if (!isExport()) {
-    return { paths: [], fallback: 'blocking' }
-  }
-
   const from = 'slug-paths'
   const { allPages } = await fetchGlobalAllData({ from })
-  const paths = allPages
-    ?.filter(row => checkSlugHasNoSlash(row))
-    .map(row => ({ params: { prefix: row.slug } }))
 
-  // 静态导出时预加载所有block
-  await prefetchAllBlockMaps(allPages)
+  // Export 模式：全量预生成
+  if (isExport()) {
+    await prefetchAllBlockMaps(allPages)
+    return {
+      paths: allPages
+        ?.filter(row => checkSlugHasNoSlash(row))
+        .map(row => ({ params: { prefix: row.slug } })),
+      fallback: false
+    }
+  }
+
+  // ISR 模式：预生成最新10篇，其余按需渲染
+  const tops = getPriorityPages(allPages)
+  await prefetchAllBlockMaps(tops)
 
   return {
-    paths: paths,
-    fallback: true
+    paths: tops
+      .filter(row => checkSlugHasNoSlash(row))
+      .map(row => ({ params: { prefix: row.slug } })),
+    fallback: 'blocking'
   }
 }
 


### PR DESCRIPTION
## feat: 双模式构建策略，解决大规模站点 Vercel 构建超时问题

<img width="1440" height="1568" alt="Image" src="https://github.com/user-attachments/assets/596e8032-2633-46ee-a4e6-703eeeac3d59" />


### 背景

当 Notion 数据库页面数量超过 500+ 时，原有全量 SSG 方案在 Vercel 构建阶段会对每个页面串行调用 Notion API（约 9s/页），导致构建时间超出 Vercel 45 分钟限制而失败。

### 变更内容

引入环境变量 `EXPORT_MODE` 区分两种构建模式，用户可按部署目标自由选择：

**ISR 模式（默认，适用于 Vercel / 自托管 Node）**

- `getStaticPaths` 预生成优先级页面（默认排序前5篇 + 最新发布5篇，去重后约6~8篇），其余页面 `fallback: 'blocking'` 按需渲染
- 构建阶段 Notion API 调用极少，构建耗时从数小时降至 **3 分钟内**
- 优先页面在构建时预热缓存，用户首次访问直接命中静态页面；其余页面首次访问时服务端渲染并缓存，后续同样命中静态缓存
- 适合对构建速度有要求、内容需要定期更新的用户

**Export 模式（适用于 Cloudflare Pages / Nginx / GitHub Pages 等纯静态托管）**

- 在 `getStaticPaths` 阶段并发预拉取所有页面的 Notion block 数据并写入文件缓存
- 随后全量生成静态页面，每页直接读取缓存，单页渲染耗时从 ~9s 降至 **~0.3s**
- `fallback: false`，符合 `next export` 要求
- 适合对实时性无要求、希望节省服务器成本或部署在 CDN 的用户

### 使用方式
```bash
# ISR 模式（默认，无需额外配置）
npm run build
# 或
yarn build

# Export 静态导出模式
EXPORT=true npm run build
# 或使用快捷脚本
yarn export
```

### 性能对比

|  | 原方案 | ISR 模式 | Export 模式 |
|---|---|---|---|
| 构建时间（1200页）| >45min ❌ | <3min ✅ | ~10min ✅ |
| 优先页面首次访问 | <100ms | <100ms（预生成）| <100ms |
| 其余页面首次访问 | <100ms | ~9s（渲染后缓存）| <100ms |
| 适用平台 | Vercel | Vercel / Node | 任意静态托管 |
| 内容更新 | 重新构建 | 自动 revalidate | 重新构建 |

### 相关文件

- `lib/utils/buildMode.js` — `isExport()` 工具函数
- `lib/build/prefetch.js` — `prefetchAllBlockMaps` 并发预热 / `getPriorityPages` 优先页面筛选
- `lib/cache/file_cache.js` — 跨 worker 文件缓存层
- `pages/[prefix]/index.js` 等路由文件 — `getStaticPaths` 双模式分支