### PR TITLE
并发编译优化：基于 #3906 补强 export 阶段 block prefetch 的多 Worker 协调

### DIFF
--- a/lib/build/prefetch.js
+++ b/lib/build/prefetch.js
@@ -1,61 +1,344 @@
-// lib/build/prefetch.js
+import fs from 'fs'
+import path from 'path'
+import { randomUUID } from 'crypto'
 import pLimit from 'p-limit'
 import { fetchNotionPageBlocks } from '@/lib/db/notion/getPostBlocks'
-import {
-  getDataFromCache,
-  setDataToCache
+import { getDataFromCache, setDataToCache } from '@/lib/cache/cache_manager'
+import { getBuildSessionPath } from '@/lib/cache/build_session'
 
-} from '@/lib/cache/cache_manager'
+const PREFETCH_STALE_LOCK_MS = 5 * 60 * 1000
+const PREFETCH_WAIT_TIMEOUT_MS = 15 * 60 * 1000
+const PREFETCH_HEARTBEAT_INTERVAL_MS = 15 * 1000
+const PREFETCH_WAIT_POLL_MS = 200
 
+function getPrefetchDoneFile() {
+  return path.join(getBuildSessionPath('prefetch'), 'block-prefetch.done')
+}
 
-// lib/build/prefetch.js 中新增，或单独放 lib/build/buildUtils.js
+function getPrefetchSkippedFile() {
+  return path.join(getBuildSessionPath('prefetch'), 'block-prefetch.skipped')
+}
+
+function getPrefetchLockFile() {
+  return path.join(getBuildSessionPath('prefetch'), 'block-prefetch.lock')
+}
+
+function hasMarker(file) {
+  try {
+    return fs.existsSync(file)
+  } catch {
+    return false
+  }
+}
+
+function isDone(doneFile) {
+  return hasMarker(doneFile)
+}
+
+function isSkipped(skippedFile) {
+  return hasMarker(skippedFile)
+}
+
+function markDone(doneFile) {
+  fs.mkdirSync(path.dirname(doneFile), { recursive: true })
+  fs.writeFileSync(doneFile, String(process.pid), 'utf8')
+}
+
+function markSkipped(skippedFile, reason) {
+  fs.mkdirSync(path.dirname(skippedFile), { recursive: true })
+  fs.writeFileSync(
+    skippedFile,
+    JSON.stringify({ pid: process.pid, reason, at: Date.now() }),
+    'utf8'
+  )
+}
+
+function clearMarker(file) {
+  try {
+    fs.rmSync(file, { force: true })
+  } catch {}
+}
+
+function createPrefetchLockPayload() {
+  return {
+    token: randomUUID(),
+    pid: process.pid,
+    acquiredAt: Date.now(),
+    heartbeatAt: Date.now()
+  }
+}
+
+function readPrefetchLock(lockFile) {
+  try {
+    if (!fs.existsSync(lockFile)) {
+      return null
+    }
+
+    const raw = fs.readFileSync(lockFile, 'utf8').trim()
+    if (!raw) {
+      return null
+    }
+
+    try {
+      const payload = JSON.parse(raw)
+      if (payload && typeof payload === 'object') {
+        return payload
+      }
+    } catch {}
+
+    const legacyPid = Number(raw)
+    if (Number.isInteger(legacyPid) && legacyPid > 0) {
+      const stat = fs.statSync(lockFile)
+      return {
+        token: null,
+        pid: legacyPid,
+        acquiredAt: stat.mtimeMs,
+        heartbeatAt: stat.mtimeMs
+      }
+    }
+
+    return null
+  } catch (error) {
+    if (error.code === 'ENOENT') {
+      return null
+    }
+    throw error
+  }
+}
+
+function writePrefetchLock(lockFile, payload, flag = 'w') {
+  fs.mkdirSync(path.dirname(lockFile), { recursive: true })
+  fs.writeFileSync(lockFile, JSON.stringify(payload), { flag })
+}
+
+function isProcessAlive(pid) {
+  if (!Number.isInteger(pid) || pid <= 0) {
+    return false
+  }
+
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch (error) {
+    if (error.code === 'EPERM') {
+      return true
+    }
+    if (error.code === 'ESRCH') {
+      return false
+    }
+    return true
+  }
+}
+
+function maybeCleanupPrefetchStaleLock(lockFile, staleLockMs) {
+  try {
+    const stat = fs.statSync(lockFile)
+    const ageMs = Date.now() - stat.mtimeMs
+
+    if (ageMs < staleLockMs) {
+      return false
+    }
+
+    const payload = readPrefetchLock(lockFile)
+    if (!payload) {
+      fs.rmSync(lockFile, { force: true })
+      console.warn(
+        `[Prefetch][pid:${process.pid}] removed malformed stale lock`
+      )
+      return true
+    }
+
+    if (!isProcessAlive(Number(payload.pid))) {
+      fs.rmSync(lockFile, { force: true })
+      console.warn(
+        `[Prefetch][pid:${process.pid}] removed dead-owner lock owner:${payload.pid}`
+      )
+      return true
+    }
+  } catch (error) {
+    if (error.code === 'ENOENT') {
+      return true
+    }
+    console.warn('[Prefetch] failed to inspect lock', error.message)
+  }
+
+  return false
+}
+
+function tryAcquirePrefetchLock(
+  lockFile,
+  staleLockMs = PREFETCH_STALE_LOCK_MS
+) {
+  const payload = createPrefetchLockPayload()
+
+  try {
+    writePrefetchLock(lockFile, payload, 'wx')
+    return { acquired: true, payload }
+  } catch (error) {
+    if (error.code !== 'EEXIST') {
+      throw error
+    }
+
+    const cleaned = maybeCleanupPrefetchStaleLock(lockFile, staleLockMs)
+    return { acquired: false, cleaned }
+  }
+}
+
+function startPrefetchHeartbeat(lockFile, payload) {
+  const timer = setInterval(() => {
+    try {
+      const current = readPrefetchLock(lockFile)
+      if (!current || current.token !== payload.token) {
+        return
+      }
+
+      current.heartbeatAt = Date.now()
+      writePrefetchLock(lockFile, current)
+    } catch (error) {
+      console.warn('[Prefetch] heartbeat failed', error.message)
+    }
+  }, PREFETCH_HEARTBEAT_INTERVAL_MS)
+
+  if (typeof timer.unref === 'function') {
+    timer.unref()
+  }
+
+  return timer
+}
+
+function releasePrefetchLock(lockFile, payload) {
+  try {
+    const current = readPrefetchLock(lockFile)
+    if (!current) {
+      return
+    }
+
+    if (payload?.token && current.token && current.token !== payload.token) {
+      console.warn('[Prefetch] skip release because ownership changed')
+      return
+    }
+
+    fs.unlinkSync(lockFile)
+  } catch (error) {
+    if (error.code !== 'ENOENT') {
+      console.warn('[Prefetch] release failed', error.message)
+    }
+  }
+}
+
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+async function waitForPrefetchTurn(doneFile, skippedFile, lockFile) {
+  const deadline = Date.now() + PREFETCH_WAIT_TIMEOUT_MS
+
+  while (Date.now() < deadline) {
+    if (isDone(doneFile)) {
+      return { done: true }
+    }
+
+    const attempt = tryAcquirePrefetchLock(lockFile)
+    if (attempt.acquired) {
+      return { done: false, payload: attempt.payload }
+    }
+
+    if (attempt.cleaned) {
+      continue
+    }
+
+    if (isSkipped(skippedFile)) {
+      return { skipped: true }
+    }
+
+    await sleep(PREFETCH_WAIT_POLL_MS)
+  }
+
+  console.warn(
+    `[Prefetch][pid:${process.pid}] timed out waiting for shared prefetch, skip warming for this worker`
+  )
+  return { skipped: true }
+}
+
+async function runPrefetchAsLockHolder(
+  allPages,
+  concurrency,
+  doneFile,
+  skippedFile,
+  lockFile,
+  payload
+) {
+  const heartbeat = startPrefetchHeartbeat(lockFile, payload)
+
+  try {
+    if (isDone(doneFile)) {
+      console.log(`[Prefetch][pid:${process.pid}] reuse warmed cache`)
+      return
+    }
+
+    // 当前进程已成为新的持锁者，清理旧的 skipped 标记以允许接手预热。
+    clearMarker(skippedFile)
+
+    try {
+      await doPrefetch(allPages, concurrency)
+    } catch (error) {
+      markSkipped(skippedFile, `owner-error:${process.pid}:${error.message}`)
+      console.warn(
+        `[Prefetch][pid:${process.pid}] prefetch aborted, skip warming for this build`,
+        error.message
+      )
+      return
+    }
+
+    clearMarker(skippedFile)
+    markDone(doneFile)
+    console.log(`[Prefetch][pid:${process.pid}] marked done`)
+  } finally {
+    clearInterval(heartbeat)
+    releasePrefetchLock(lockFile, payload)
+  }
+}
 
 /**
  * 获取优先预生成的页面
- * - 最新5篇（按发布时间倒序）
- * - 默认排序前5篇（allPages 原始顺序）
- * - 两者合并去重
+ * - 默认排序前 5 篇（Notion 拖拽顺序）
+ * - 最新发布 5 篇（按 publishDate 倒序）
+ * - 合并去重，适合 ISR 首批路径
  */
 export function getPriorityPages(allPages) {
   const published = (allPages ?? []).filter(
-    p => p.type === 'Post' && p.status === 'Published'
+    page => page.type === 'Post' && page.status === 'Published'
   )
 
-  // 默认排序前5
   const top5Default = published.slice(0, 5)
-
-  // 按发布时间最新5
   const top5Latest = [...published]
     .sort((a, b) => new Date(b.publishDate) - new Date(a.publishDate))
     .slice(0, 5)
 
-  // 合并去重
   const seen = new Set()
-  return [...top5Default, ...top5Latest].filter(p => {
-    if (seen.has(p.id)) return false
-    seen.add(p.id)
+  return [...top5Default, ...top5Latest].filter(page => {
+    if (seen.has(page.id)) return false
+    seen.add(page.id)
     return true
   })
 }
 
-/**
- * 预热所有页面的 block 数据
- * @param {*} allPages 页面列表
- * @param {*} concurrency 并发数
- */
-export async function prefetchAllBlockMaps(allPages, concurrency = 8) {
+async function doPrefetch(allPages, concurrency = 8) {
   const limit = pLimit(concurrency)
-  let hit = 0, fetched = 0, failed = 0
+  let hit = 0
+  let fetched = 0
+  let failed = 0
 
-  console.log(`[Prefetch] 开始预热 ${allPages.length} 个页面 block`)
+  console.log(
+    `[Prefetch][pid:${process.pid}] start ${allPages.length} page blocks`
+  )
   const start = Date.now()
 
   await Promise.all(
     allPages.map(page =>
       limit(async () => {
         const cacheKey = `page_block_${page.id}`
-        
-        // 已有缓存跳过
+
         if (await getDataFromCache(cacheKey)) {
           hit++
           return
@@ -63,10 +346,13 @@ export async function prefetchAllBlockMaps(allPages, concurrency = 8) {
 
         try {
           const block = await fetchNotionPageBlocks(page.id, 'prefetch')
-          await setDataToCache(cacheKey, block, 1000 * 60 * 60 * 2) // 2小时
+          await setDataToCache(cacheKey, block, 60 * 60 * 2) // 2小时 (单位:秒)
           fetched++
-        } catch (e) {
-          console.warn('[Prefetch Failed]', page.id, e.message)
+        } catch (error) {
+          console.warn(
+            `[Prefetch][pid:${process.pid}] failed page:${page.id}`,
+            error.message
+          )
           failed++
         }
       })
@@ -74,5 +360,75 @@ export async function prefetchAllBlockMaps(allPages, concurrency = 8) {
   )
 
   const elapsed = ((Date.now() - start) / 1000).toFixed(1)
-  console.log(`[Prefetch] 完成: 命中缓存=${hit} 新拉取=${fetched} 失败=${failed} 耗时=${elapsed}s`)
+  console.log(
+    `[Prefetch][pid:${process.pid}] done hit=${hit} fetched=${fetched} failed=${failed} elapsed=${elapsed}s`
+  )
+}
+
+/**
+ * 带跨进程保护的全量预热。
+ * 同一次 build/export 中只允许一个 worker 真正预热。
+ * 其他 worker 优先等待当前构建轮次的 done 标记；
+ * 如果 owner 预热失败，会写入 skipped 标记让后续 worker 跳过本轮共享预热。
+ * 等待超时只跳过当前 worker，不会写入全局 skipped 标记。
+ */
+export async function prefetchAllBlockMaps(allPages, concurrency = 8) {
+  if (!Array.isArray(allPages) || allPages.length === 0) {
+    console.log(`[Prefetch][pid:${process.pid}] skip empty page list`)
+    return
+  }
+
+  const doneFile = getPrefetchDoneFile()
+  const skippedFile = getPrefetchSkippedFile()
+  const lockFile = getPrefetchLockFile()
+  if (isDone(doneFile)) {
+    console.log(`[Prefetch][pid:${process.pid}] reuse warmed cache`)
+    return
+  }
+
+  const attempt = tryAcquirePrefetchLock(lockFile)
+  if (attempt.acquired) {
+    await runPrefetchAsLockHolder(
+      allPages,
+      concurrency,
+      doneFile,
+      skippedFile,
+      lockFile,
+      attempt.payload
+    )
+    return
+  }
+
+  if (isSkipped(skippedFile)) {
+    console.warn(
+      `[Prefetch][pid:${process.pid}] skip shared prefetch for this build`
+    )
+    return
+  }
+
+  console.log(
+    `[Prefetch][pid:${process.pid}] waiting for shared prefetch completion`
+  )
+  const turn = await waitForPrefetchTurn(doneFile, skippedFile, lockFile)
+
+  if (turn.done) {
+    console.log(`[Prefetch][pid:${process.pid}] reuse warmed cache`)
+    return
+  }
+
+  if (turn.skipped) {
+    console.warn(
+      `[Prefetch][pid:${process.pid}] skip shared prefetch for this build`
+    )
+    return
+  }
+
+  await runPrefetchAsLockHolder(
+    allPages,
+    concurrency,
+    doneFile,
+    skippedFile,
+    lockFile,
+    turn.payload
+  )
 }

--- a/lib/cache/build_session.js
+++ b/lib/cache/build_session.js
@@ -1,0 +1,30 @@
+import fs from 'fs'
+import path from 'path'
+
+const NOTION_CACHE_ROOT = path.join(process.cwd(), '.next', 'cache', 'notion')
+const BUILD_SESSION_FILE = path.join(NOTION_CACHE_ROOT, 'build-session.json')
+
+function sanitizeSessionId(sessionId) {
+  return String(sessionId || 'default').replace(/[^a-z0-9_-]/gi, '_')
+}
+
+export function getNotionCacheRoot() {
+  fs.mkdirSync(NOTION_CACHE_ROOT, { recursive: true })
+  return NOTION_CACHE_ROOT
+}
+
+export function getBuildSessionId() {
+  try {
+    const raw = fs.readFileSync(BUILD_SESSION_FILE, 'utf8')
+    const parsed = JSON.parse(raw)
+    if (parsed?.sessionId) {
+      return sanitizeSessionId(parsed.sessionId)
+    }
+  } catch {}
+
+  return sanitizeSessionId(process.env.npm_lifecycle_event || 'runtime')
+}
+
+export function getBuildSessionPath(...parts) {
+  return path.join(getNotionCacheRoot(), 'sessions', getBuildSessionId(), ...parts)
+}

--- a/lib/cache/cache_manager.js
+++ b/lib/cache/cache_manager.js
@@ -2,7 +2,7 @@ import BLOG from '@/blog.config'
 import FileCache from './local_file_cache'
 import MemoryCache from './memory_cache'
 import RedisCache from './redis_cache'
-// import VercelCache from './vercel_cache'
+import { withFileLock } from './file_lock'
 
 const cacheStats = {
   hit: 0,
@@ -10,23 +10,16 @@ const cacheStats = {
   set: 0,
   error: 0,
   total: 0,
-  perStore: {} // { redis: {hit, set}, memory: {...} }
+  perStore: {}
 }
 
 const isBuildPhase =
   process.env.npm_lifecycle_event === 'build' ||
   process.env.npm_lifecycle_event === 'export'
 
-const enableLocalCache = isBuildPhase || !BLOG['isProd']
+const enableLocalCache = isBuildPhase || !BLOG.isProd
 const hasRedis = !!BLOG.REDIS_URL
-
 const inflightMap = new Map()
-
-const pid = process.pid
-
-function isVercelEnv() {
-  return !!process.env.VERCEL
-}
 
 function cacheLog(action, key, extra = '') {
   const type = getCacheType()
@@ -47,23 +40,51 @@ export async function getOrSetDataWithCustomCache(
 ) {
   const dataFromCache = await getDataFromCache(key)
   if (dataFromCache) {
-    // cacheLog('HIT', key)
     return dataFromCache
   }
 
   if (inflightMap.has(key)) {
-    // cacheLog('INFLIGHT-WAIT', key)
     return inflightMap.get(key)
   }
- 
-  cacheLog('MISS', key, '缓存未命中，发起真实请求')
+
+  cacheLog('MISS', key, 'cache miss, fetch from source')
+
+  if (isBuildPhase) {
+    const promise = withFileLock(
+      key,
+      async () => {
+        const doubleCheck = await getDataFromCache(key)
+        if (doubleCheck) {
+          cacheLog('DOUBLE-CHECK-HIT', key, 'lock holder found cached value')
+          return doubleCheck
+        }
+
+        const data = await getDataFunction(...getDataArgs)
+        if (data) {
+          await setDataToCache(key, data, customCacheTime)
+          cacheLog('SET', key, 'cache stored by lock holder')
+        }
+
+        return data || null
+      },
+      () => getDataFromCache(key)
+    ).catch(err => {
+      cacheLog('ERROR', key, err.message)
+      throw err
+    })
+
+    inflightMap.set(key, promise)
+    promise.finally(() => inflightMap.delete(key))
+    return promise
+  }
 
   const promise = getDataFunction(...getDataArgs)
     .then(async data => {
       if (data) {
         await setDataToCache(key, data, customCacheTime)
-        cacheLog('SET', key, '写入缓存成功')
+        cacheLog('SET', key, 'cache stored')
       }
+
       inflightMap.delete(key)
       return data || null
     })
@@ -85,17 +106,15 @@ export async function setDataToCache(key, data, customCacheTime) {
   for (const { name, api } of chain) {
     try {
       await api.setCache(key, data, customCacheTime)
-      // cacheLog('SET', key, `to:${name}`)
 
-       cacheStats.set++
+      cacheStats.set++
       cacheStats.perStore[name] = cacheStats.perStore[name] || { hit: 0, set: 0 }
       cacheStats.perStore[name].set++
 
       return
     } catch (e) {
       console.warn(`[Cache] ${name} set failed key:${key}`, e.message)
-            cacheStats.error++
-
+      cacheStats.error++
     }
   }
 
@@ -105,6 +124,7 @@ export async function setDataToCache(key, data, customCacheTime) {
 export async function getDataFromCache(key, force) {
   if (!JSON.parse(BLOG.ENABLE_CACHE) && !force) return null
 
+  cacheStats.total++
   const chain = getCacheChain()
 
   for (const { name, api } of chain) {
@@ -112,8 +132,7 @@ export async function getDataFromCache(key, force) {
       const data = await api.getCache(key)
 
       if (data && JSON.stringify(data) !== '[]') {
-        // cacheLog('HIT', key, `from:${name}`)
-         cacheStats.hit++
+        cacheStats.hit++
         cacheStats.perStore[name] = cacheStats.perStore[name] || { hit: 0, set: 0 }
         cacheStats.perStore[name].hit++
         return data
@@ -123,6 +142,7 @@ export async function getDataFromCache(key, force) {
       console.warn(`[Cache] ${name} get failed key:${key}`, e.message)
     }
   }
+
   cacheStats.miss++
   return null
 }
@@ -142,7 +162,6 @@ export async function delCacheData(key) {
 function getCacheType() {
   if (hasRedis) return 'redis'
   if (isBuildPhase) return 'file'
-  // if (isVercelEnv()) return 'vercel'
   return 'memory'
 }
 
@@ -152,10 +171,6 @@ export function getApi() {
   switch (type) {
     case 'redis':
       return RedisCache
-    // case 'vercel':
-    // VercelCache 目前不稳定（有大小限制），先注释掉
-    //   return VercelCache
-    // 文件速度和内存消耗存疑
     case 'file':
       return FileCache
     default:
@@ -170,15 +185,10 @@ function getCacheChain() {
     chain.push({ name: 'redis', api: RedisCache })
   }
 
-  // if (isVercelEnv()) {
-  //   chain.push({ name: 'vercel', api: VercelCache })
-  // }
-
-  if (isBuildPhase || !BLOG.isProd) {
+  if (enableLocalCache) {
     chain.push({ name: 'file', api: FileCache })
   }
 
-  // 永远兜底
   chain.push({ name: 'memory', api: MemoryCache })
 
   return chain
@@ -190,12 +200,12 @@ function printCacheSummary() {
     : 0
 
   console.log('\n[Cache Summary]')
-  console.log('Strategy:', getCacheChain().map(c => c.name).join(' → '))
+  console.log('Strategy:', getCacheChain().map(c => c.name).join(' -> '))
   console.log(
     `Stats: HIT ${hitRate}% | MISS ${cacheStats.miss} | ERROR ${cacheStats.error} | total ${cacheStats.total}`
   )
-
   console.log('[Per Store]')
+
   Object.entries(cacheStats.perStore).forEach(([name, stat]) => {
     console.log(`  ${name}: hit=${stat.hit || 0}, set=${stat.set || 0}`)
   })
@@ -203,7 +213,6 @@ function printCacheSummary() {
   console.log('----------------------------------\n')
 }
 
-// Node 进程结束时触发
 if (typeof process !== 'undefined') {
   process.on('exit', printCacheSummary)
 }

--- a/lib/cache/file_lock.js
+++ b/lib/cache/file_lock.js
@@ -1,0 +1,285 @@
+import fs from 'fs'
+import path from 'path'
+import { randomUUID } from 'crypto'
+import { getBuildSessionPath } from './build_session'
+
+const LOCK_MISS = Symbol('lock_miss')
+const DEFAULT_TIMEOUT_MS = 30000
+const DEFAULT_STALE_LOCK_MS = 120000
+const HEARTBEAT_INTERVAL_MS = 15000
+
+function getLockPath(key) {
+  const safeKey = String(key).replace(/[^a-z0-9_-]/gi, '_')
+  return path.join(getBuildSessionPath('locks'), `${safeKey}.lock`)
+}
+
+function createLockPayload() {
+  return {
+    token: randomUUID(),
+    pid: process.pid,
+    acquiredAt: Date.now(),
+    heartbeatAt: Date.now()
+  }
+}
+
+function readLockPayload(lockPath) {
+  try {
+    if (!fs.existsSync(lockPath)) {
+      return null
+    }
+
+    const raw = fs.readFileSync(lockPath, 'utf8').trim()
+    if (!raw) {
+      return null
+    }
+
+    try {
+      const payload = JSON.parse(raw)
+      if (payload && typeof payload === 'object') {
+        return payload
+      }
+    } catch {}
+
+    const legacyPid = Number(raw)
+    if (Number.isInteger(legacyPid) && legacyPid > 0) {
+      const stat = fs.statSync(lockPath)
+      return {
+        token: null,
+        pid: legacyPid,
+        acquiredAt: stat.mtimeMs,
+        heartbeatAt: stat.mtimeMs
+      }
+    }
+
+    return null
+  } catch (error) {
+    if (error.code === 'ENOENT') {
+      return null
+    }
+    throw error
+  }
+}
+
+function writeLockPayload(lockPath, payload, flag = 'w') {
+  fs.mkdirSync(path.dirname(lockPath), { recursive: true })
+  fs.writeFileSync(lockPath, JSON.stringify(payload), { flag })
+}
+
+function isProcessAlive(pid) {
+  if (!Number.isInteger(pid) || pid <= 0) {
+    return false
+  }
+
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch (error) {
+    if (error.code === 'EPERM') {
+      return true
+    }
+    if (error.code === 'ESRCH') {
+      return false
+    }
+    return true
+  }
+}
+
+function maybeCleanupStaleLock(lockPath, staleLockMs) {
+  try {
+    const stat = fs.statSync(lockPath)
+    const ageMs = Date.now() - stat.mtimeMs
+
+    if (ageMs < staleLockMs) {
+      return false
+    }
+
+    const payload = readLockPayload(lockPath)
+    if (!payload) {
+      fs.rmSync(lockPath, { force: true })
+      console.warn(`[FileLock][pid:${process.pid}] removed malformed stale lock ${lockPath}`)
+      return true
+    }
+
+    if (!isProcessAlive(Number(payload.pid))) {
+      fs.rmSync(lockPath, { force: true })
+      console.warn(
+        `[FileLock][pid:${process.pid}] removed dead-owner lock key:${path.basename(lockPath)} owner:${payload.pid}`
+      )
+      return true
+    }
+  } catch (error) {
+    if (error.code === 'ENOENT') {
+      // 锁刚好在检查期间被释放，这是正常竞态；返回 true 让外层立即重试抢锁。
+      return true
+    }
+    console.warn(`[FileLock] failed to check stale lock ${lockPath}`, error.message)
+  }
+  return false
+}
+
+function tryAcquire(lockPath, staleLockMs) {
+  const payload = createLockPayload()
+
+  try {
+    writeLockPayload(lockPath, payload, 'wx')
+    return { acquired: true, payload }
+  } catch (error) {
+    if (error.code !== 'EEXIST') {
+      throw error
+    }
+
+    const cleaned = maybeCleanupStaleLock(lockPath, staleLockMs)
+    return { acquired: false, cleaned }
+  }
+}
+
+function startHeartbeat(lockPath, payload) {
+  const timer = setInterval(() => {
+    try {
+      const current = readLockPayload(lockPath)
+      if (!current || current.token !== payload.token) {
+        return
+      }
+
+      current.heartbeatAt = Date.now()
+      writeLockPayload(lockPath, current)
+    } catch (error) {
+      console.warn(
+        `[FileLock][pid:${process.pid}] heartbeat failed key:${path.basename(lockPath)}`,
+        error.message
+      )
+    }
+  }, HEARTBEAT_INTERVAL_MS)
+
+  if (typeof timer.unref === 'function') {
+    timer.unref()
+  }
+
+  return timer
+}
+
+function release(lockPath, payload) {
+  try {
+    const current = readLockPayload(lockPath)
+    if (!current) {
+      return
+    }
+
+    if (payload?.token && current.token && current.token !== payload.token) {
+      console.warn(
+        `[FileLock][pid:${process.pid}] skip release, ownership changed key:${path.basename(lockPath)}`
+      )
+      return
+    }
+
+    fs.unlinkSync(lockPath)
+  } catch (error) {
+    if (error.code !== 'ENOENT') {
+      console.warn(
+        `[FileLock][pid:${process.pid}] release failed key:${path.basename(lockPath)}`,
+        error.message
+      )
+    }
+  }
+}
+
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+async function waitForUnlock(lockPath, readCache, key, timeout) {
+  const start = Date.now()
+
+  while (Date.now() - start < timeout) {
+    const cached = await readCache()
+    if (cached) {
+      console.log(`[FileLock][pid:${process.pid}] wait-hit key:${key}`)
+      return cached
+    }
+
+    if (!fs.existsSync(lockPath)) {
+      return LOCK_MISS
+    }
+
+    await sleep(200)
+  }
+
+  const cached = await readCache()
+  if (cached) {
+    console.log(`[FileLock][pid:${process.pid}] timeout-hit key:${key}`)
+    return cached
+  }
+
+  return LOCK_MISS
+}
+
+function normalizeOptions(timeoutOrOptions) {
+  if (typeof timeoutOrOptions === 'number') {
+    return {
+      timeout: timeoutOrOptions,
+      staleLockMs: DEFAULT_STALE_LOCK_MS
+    }
+  }
+
+  return {
+    timeout: timeoutOrOptions?.timeout ?? DEFAULT_TIMEOUT_MS,
+    staleLockMs: timeoutOrOptions?.staleLockMs ?? DEFAULT_STALE_LOCK_MS
+  }
+}
+
+/**
+ * 尝试获取跨进程文件锁，持锁者执行 fn。
+ * 
+ * 语义说明：
+ * 此函数并非绝对的排他锁（Exclusive Lock）。为了防止分布式构建环境下的死锁，
+ * 它采用了“优先锁，超时可降级”的策略。
+ * 如果等待超过 timeout 仍未获取到锁，它将跳过锁保护，强制无锁执行 fn。
+ * 因此，传入的 fn 应当是幂等的（Idempotent），或者在内部自行实现 double-check 逻辑。
+ */
+export async function withFileLock(
+  key,
+  fn,
+  readCache,
+  timeoutOrOptions = DEFAULT_TIMEOUT_MS
+) {
+  const { timeout, staleLockMs } = normalizeOptions(timeoutOrOptions)
+  const lockPath = getLockPath(key)
+  const absoluteDeadline = Date.now() + timeout
+
+  while (Date.now() < absoluteDeadline) {
+    const attempt = tryAcquire(lockPath, staleLockMs)
+
+    if (attempt.acquired) {
+      const heartbeat = startHeartbeat(lockPath, attempt.payload)
+
+      try {
+        return await fn(attempt.payload)
+      } finally {
+        clearInterval(heartbeat)
+        release(lockPath, attempt.payload)
+      }
+    }
+
+    if (attempt.cleaned) {
+      console.warn(`[FileLock][pid:${process.pid}] retry after stale cleanup key:${key}`)
+      continue
+    }
+
+    console.log(`[FileLock][pid:${process.pid}] waiting key:${key}`)
+
+    // 动态计算剩余的超时时间
+    const remainingTimeout = absoluteDeadline - Date.now()
+    if (remainingTimeout <= 0) break
+
+    const result = await waitForUnlock(lockPath, readCache, key, remainingTimeout)
+    if (result !== LOCK_MISS) {
+      return result
+    }
+
+    console.warn(`[FileLock][pid:${process.pid}] retry lock key:${key}`)
+  }
+
+  // 绝对超时兜底：强制执行 fn，回退到降级并发模式
+  console.warn(`[FileLock][pid:${process.pid}] ABSOLUTE TIMEOUT (${timeout}ms) key:${key}. Bypassing lock as fallback.`)
+  return await fn()
+}

--- a/lib/cache/local_file_cache.js
+++ b/lib/cache/local_file_cache.js
@@ -1,62 +1,83 @@
 import fs from 'fs'
+import path from 'path'
+import { getNotionCacheRoot } from './build_session'
 
-const path = require('path')
-// 文件缓存持续10秒
-const cacheInvalidSeconds = 1000000000 * 1000
-// 文件名
-const jsonFile = path.resolve('./data.json')
+const CACHE_DIR = path.join(getNotionCacheRoot(), 'data')
+
+function ensureCacheDir() {
+  fs.mkdirSync(CACHE_DIR, { recursive: true })
+}
+
+function getCacheFilePath(key) {
+  const fileName = `${Buffer.from(String(key)).toString('base64url')}.json`
+  return path.join(CACHE_DIR, fileName)
+}
+
+function readCacheEntry(cacheFile) {
+  try {
+    if (!fs.existsSync(cacheFile)) {
+      return null
+    }
+
+    const raw = fs.readFileSync(cacheFile, 'utf8')
+    if (!raw) {
+      return null
+    }
+
+    return JSON.parse(raw)
+  } catch (error) {
+    console.error('[FileCache] Failed to read cache entry', cacheFile, error.message)
+    return null
+  }
+}
 
 export function getCache(key) {
-  const exist = fs.existsSync(jsonFile)
-  if (!exist) return null
-  const data = fs.readFileSync(jsonFile)
-  let json = null
-  if (!data) return null
-  try {
-    json = JSON.parse(data)
-  } catch (error) {
-    console.error('读取JSON缓存文件失败', data)
+  const cacheFile = getCacheFilePath(key)
+  const entry = readCacheEntry(cacheFile)
+  if (!entry) return null
+
+  if (entry.expireTime && entry.expireTime <= Date.now()) {
+    try {
+      fs.rmSync(cacheFile, { force: true })
+    } catch {}
     return null
   }
-  // 缓存超过有效期就作废
-  const cacheValidTime = new Date(
-    parseInt(json[key + '_expire_time']) + cacheInvalidSeconds
-  )
-  const currentTime = new Date()
-  if (!cacheValidTime || cacheValidTime < currentTime) {
-    return null
-  }
-  return json[key]
+
+  return entry.value ?? null
 }
 
 /**
- * 并发请求写文件异常； Vercel生产环境不支持写文件。
- * @param key
- * @param data
- * @returns {Promise<null>}
+ * Persist one cache key per file so concurrent workers never overwrite
+ * unrelated cache entries during a shared build.
  */
-export function setCache(key, data) {
-  const exist = fs.existsSync(jsonFile)
-  const json = exist ? JSON.parse(fs.readFileSync(jsonFile)) : {}
-  json[key] = data
-  json[key + '_expire_time'] = new Date().getTime()
-  fs.writeFileSync(jsonFile, JSON.stringify(json))
+export function setCache(key, data, customCacheTime) {
+  ensureCacheDir()
+  const cacheFile = getCacheFilePath(key)
+  const expireTime =
+    Number.isFinite(customCacheTime) && customCacheTime > 0
+      ? Date.now() + customCacheTime * 1000
+      : null
+
+  const payload = {
+    key,
+    expireTime,
+    updatedAt: Date.now(),
+    value: data
+  }
+
+  fs.writeFileSync(cacheFile, JSON.stringify(payload))
 }
 
 export function delCache(key) {
-  const exist = fs.existsSync(jsonFile)
-  const json = exist ? JSON.parse(fs.readFileSync(jsonFile)) : {}
-  delete json.key
-  json[key + '_expire_time'] = new Date().getTime()
-  fs.writeFileSync(jsonFile, JSON.stringify(json))
+  const cacheFile = getCacheFilePath(key)
+  fs.rmSync(cacheFile, { force: true })
 }
 
-/**
- * 清理缓存
- */
 export function cleanCache() {
-  const json = {}
-  fs.writeFileSync(jsonFile, JSON.stringify(json))
+  fs.rmSync(CACHE_DIR, { recursive: true, force: true })
+  ensureCacheDir()
 }
 
-export default { getCache, setCache, delCache }
+const LocalFileCache = { getCache, setCache, delCache, cleanCache }
+
+export default LocalFileCache

--- a/next.config.js
+++ b/next.config.js
@@ -42,6 +42,9 @@ const preBuild = (function () {
     return
   }
   // 删除 public/sitemap.xml 文件 ； 否则会和/pages/sitemap.xml.js 冲突。
+  if (process.env.NEXT_PRIVATE_BUILD_WORKER) {
+    return
+  }
   const sitemapPath = path.resolve(__dirname, 'public', 'sitemap.xml')
   if (fs.existsSync(sitemapPath)) {
     fs.unlinkSync(sitemapPath)
@@ -53,6 +56,28 @@ const preBuild = (function () {
     fs.unlinkSync(sitemap2Path)
     console.log('Deleted existing sitemap.xml from root directory')
   }
+
+  const notionCacheRoot = path.resolve(__dirname, '.next', 'cache', 'notion')
+  const prefetchDir = path.join(notionCacheRoot, 'sessions')
+  const sessionFile = path.join(notionCacheRoot, 'build-session.json')
+  const sessionId = `${process.env.npm_lifecycle_event}-${Date.now()}-${process.pid}`
+
+  fs.rmSync(prefetchDir, { recursive: true, force: true })
+  fs.mkdirSync(notionCacheRoot, { recursive: true })
+  fs.writeFileSync(
+    sessionFile,
+    JSON.stringify(
+      {
+        sessionId,
+        createdAt: new Date().toISOString(),
+        lifecycle: process.env.npm_lifecycle_event,
+        pid: process.pid
+      },
+      null,
+      2
+    )
+  )
+  console.log('Prepared Notion build session', sessionId)
 })()
 
 /**
@@ -278,6 +303,14 @@ const nextConfig = {
 
     if (!isServer) {
       console.log('[默认主题]', path.resolve(__dirname, 'themes', THEME))
+      config.resolve.fallback = {
+        ...config.resolve.fallback,
+        fs: false,
+        net: false,
+        tls: false,
+        dns: false,
+        path: false
+      }
     }
     config.resolve.alias['@theme-components'] = path.resolve(
       __dirname,

--- a/pages/[prefix]/[slug]/[...suffix].js
+++ b/pages/[prefix]/[slug]/[...suffix].js
@@ -41,8 +41,6 @@ export async function getStaticPaths() {
   // ISR 模式：预生成最新10篇（仅三段以上路径格式）
   const tops = getPriorityPages(allPages)
 
-  await prefetchAllBlockMaps(tops)
-
   return {
     paths: tops
       .filter(p => checkSlugHasMorThanTwoSlash(p))

--- a/pages/[prefix]/[slug]/index.js
+++ b/pages/[prefix]/[slug]/index.js
@@ -39,8 +39,6 @@ export async function getStaticPaths() {
   // ISR 模式：预生成最新10篇（仅两段路径格式）
   const tops = getPriorityPages(allPages)
 
-  await prefetchAllBlockMaps(tops)
-
   return {
     paths: tops
       .filter(p => checkSlugHasOneSlash(p))

--- a/pages/[prefix]/index.js
+++ b/pages/[prefix]/index.js
@@ -128,7 +128,6 @@ export async function getStaticPaths() {
 
   // ISR 模式：预生成最新10篇，其余按需渲染
   const tops = getPriorityPages(allPages)
-  await prefetchAllBlockMaps(tops)
 
   return {
     paths: tops


### PR DESCRIPTION
# fix: 基于 #3906 补强 export 多 Worker 并发构建下的 block 预热协调逻辑

## 关联 Issue / Related Issue

- Issue: https://github.com/tangly1024/NotionNext/issues/3905
- 原始修复 PR: https://github.com/tangly1024/NotionNext/pull/3906

本 PR 不是重新实现另一套方案，而是基于 `#3906` 的修复思路继续补强，重点解决在 Cloudflare Pages 多 Worker 构建环境下，`prefetch_all_blocks` 仍可能因等待超时而退化为重复全量预热的问题。

This PR is a follow-up enhancement to `#3906`, not a replacement of its overall direction. It focuses on a remaining issue observed in real Cloudflare Pages multi-worker builds, where `prefetch_all_blocks` could still fall back into duplicated full prefetch execution after timeout.

---

## 问题根因 / Root Cause

在 `#3906` 之后，构建阶段已经具备：

1. `cache_manager` 层的跨进程 per-key 去重能力
2. export 阶段共享预热入口的收敛

但在 Cloudflare Pages 的多 Worker 场景下，仍存在一个更上层的协调问题：

- `prefetch_all_blocks` 是构建级全量任务，执行时间明显长于单个 block 请求
- 如果等待方在固定超时后直接继续执行预热，就会重新出现多个 Worker 同时做全量 prefetch
- 如果等待逻辑改成硬失败，又可能在 Notion 慢响应场景下直接让整轮构建失败

After `#3906`, the build already had:

1. cross-process per-key deduplication in `cache_manager`
2. a more consolidated prefetch entry path during export

However, in real Cloudflare Pages multi-worker builds, one more coordination issue remained:

- `prefetch_all_blocks` is a build-wide task and can take much longer than a single block fetch
- if waiting workers time out and also start prefetching, duplicated full prefetch returns
- if waiting workers fail hard instead, the whole build becomes fragile under slow Notion responses

换句话说，`#3906` 解决了“同一个 block key 的跨 Worker 重复请求”，但“全量共享预热任务本身如何在多个 Worker 之间协调”还可以进一步收紧。

In other words, `#3906` solved cross-worker duplication for individual block keys, but the build-wide shared prefetch task itself still needed stricter worker coordination.

---

## 本次改动 / Changes

### 1. 引入构建会话隔离

新增 `lib/cache/build_session.js`，将本轮构建使用的缓存、锁和预热标记放入独立 session 目录，避免不同 build/export 之间互相污染。

Added `lib/cache/build_session.js` to isolate cache, lock, and prefetch marker files per build session, preventing cross-build contamination.

### 2. 将本地文件缓存改为 per-key 单文件结构

`lib/cache/local_file_cache.js` 从单一 `data.json` 改为“每个 key 一个文件”，避免多个 Worker 在同一构建中写同一缓存文件时互相覆盖无关条目。

Refactored `lib/cache/local_file_cache.js` from a single shared `data.json` into one file per cache key, so concurrent workers no longer overwrite unrelated entries in the same cache file.

### 3. 增加构建阶段跨进程 per-key 文件锁

新增 `lib/cache/file_lock.js`，并在 `lib/cache/cache_manager.js` 的 build/export 阶段接入：

- 同一 key 只允许一个 Worker 发起真实请求
- 其他 Worker 等待缓存结果
- 持锁后执行 double-check，避免锁内重复写入
- 保留超时降级能力，防止死锁导致整个构建永久卡住

Added `lib/cache/file_lock.js` and wired it into `lib/cache/cache_manager.js` for build/export mode:

- only one worker fetches a given cache key from source
- other workers wait for cache reuse
- a double-check is performed after lock acquisition
- timeout fallback is preserved to avoid permanent deadlocks

### 4. 将 `prefetch_all_blocks` 从通用文件锁中拆出，改为专用协调逻辑

`lib/build/prefetch.js` 不再直接依赖通用 `withFileLock()` 处理全量预热，而是为共享 prefetch 单独维护：

- `lock` 标记：表示当前 Worker 正在执行共享预热
- `done` 标记：表示本轮构建共享预热已完成
- `skipped` 标记：表示持锁 Worker 预热异常，后续 Worker 可跳过本轮共享预热
- heartbeat：用于持续刷新持锁状态
- stale lock cleanup：用于 owner 异常退出后的补位恢复

`lib/build/prefetch.js` no longer treats full prefetch as a generic lock-protected function. Instead it now has a dedicated coordination flow with:

- `lock` marker: one worker owns the shared prefetch
- `done` marker: shared prefetch completed for this build
- `skipped` marker: owner prefetch failed, later workers may skip shared warmup
- heartbeat refresh for active ownership
- stale-lock cleanup for owner crash recovery

### 5. 调整等待方语义，避免“超时后重复全量预热”

这是本 PR 相比 `#3906` 最关键的补强点：

- 共享预热等待超时后，等待方只跳过当前 Worker，不会重新启动一轮全量 prefetch
- 这样避免了 Cloudflare Pages 下多个 Worker 在超时后再次执行全量预热
- 同时等待超时不会硬失败，从而避免把构建直接打断

This is the main enhancement beyond `#3906`:

- if a worker times out while waiting for shared prefetch, it only skips warmup for itself
- it does not start a second full prefetch run
- this prevents duplicated full prefetch in Cloudflare Pages multi-worker builds
- and it avoids turning temporary slowness into a hard build failure

### 6. 保留补位恢复路径，避免 owner 异常后“永久跳过”

本 PR 还处理了一个细节语义问题：

- `skipped` 不再意味着“本轮 build 永久禁止接手预热”
- 如果原 owner 失活，后续 Worker 在清理 stale lock 后仍然可以成功接手共享预热
- 从而保留恢复能力，而不是将共享预热永久压死

This PR also preserves takeover recovery:

- `skipped` no longer permanently blocks later takeover
- if the original owner dies, a later worker can clean the stale lock and still take over the shared prefetch
- this keeps the system recoverable instead of permanently disabling warmup for the build

### 7. 收敛 ISR 路径下的重复预热触发

`pages/[prefix]/index.js`、`pages/[prefix]/[slug]/index.js`、`pages/[prefix]/[slug]/[...suffix].js` 中，ISR 路径不再对 `tops` 重复调用 `prefetchAllBlockMaps()`，减少不必要的扫描和日志噪音。

Removed repeated `prefetchAllBlockMaps(tops)` calls from ISR path generation, reducing unnecessary scanning and log noise.

### 8. 补充客户端 fallback，避免 Node 原生模块打入浏览器 bundle

`next.config.js` 中补充客户端 `resolve.fallback`，避免 `fs`、`net`、`tls`、`dns`、`path` 等 Node 模块在浏览器侧被错误打包。

Added client-side `resolve.fallback` in `next.config.js` to avoid bundling Node-only modules into the browser build.

---

## 预期效果 / Expected Impact

| 项目 | `#3906` 后 | 本 PR 后 |
|---|---|---|
| 单个 block key 的跨 Worker 去重 | 已支持 | 保持 |
| 全量 prefetch 仅执行一次 | 理论上支持，但在 CF 多 Worker 下可能超时退化 | 在 CF 多 Worker 下实际验证通过 |
| 等待超时后的行为 | 可能重新触发全量预热或需要更强兜底 | 仅跳过当前 Worker，不重复全量预热 |
| owner 异常后的恢复能力 | 有限 | 支持 stale-lock 补位接手 |
| 构建稳定性 | 较好 | 更稳 |

---

## 验证情况 / Validation

已在 Cloudflare Pages 多 Worker 环境中实际部署验证。

Validated in real Cloudflare Pages multi-worker deployment.

验证结果包括：

- 只有一个 Worker 执行 `prefetch_all_blocks`
- 其他 Worker 只等待共享结果
- 不再出现多个 Worker 因等待超时而重新执行全量 prefetch
- 构建最终成功完成并成功部署

Observed results:

- only one worker performs the shared full prefetch
- other workers wait and reuse the result
- duplicated full prefetch after timeout no longer occurs
- the build completes and deploys successfully

---

## 兼容性 / Compatibility

本 PR 不改变运行时页面渲染逻辑，主要影响 build/export 阶段的缓存与预热协作机制。

This PR does not change runtime page rendering logic. It mainly tightens cache and warmup coordination during build/export.

---

## 备注 / Notes

如果维护上希望保持修复链路清晰，可以将本 PR 视为：

- `#3905` 的补充修复
- 或 `#3906` 的 follow-up enhancement

这个 PR 是对 `#3906` 在真实 Cloudflare Pages 多 Worker 环境中的补强与验证。