### PR TITLE
Fix TOC parsing for newer Notion heading types.

### DIFF
--- a/lib/db/notion/getPageTableOfContents.js
+++ b/lib/db/notion/getPageTableOfContents.js
@@ -3,8 +3,13 @@ import { getTextContent } from 'notion-utils'
 const indentLevels = {
   header: 0,
   sub_header: 1,
-  sub_sub_header: 2
+  sub_sub_header: 2,
+  heading_1: 0,
+  heading_2: 1,
+  heading_3: 2
 }
+
+const unknownHeadingStats = new Map()
 
 /**
  * @see https://github.com/NotionX/react-notion-x/blob/master/packages/notion-utils/src/get-page-table-of-contents.ts
@@ -12,8 +17,12 @@ const indentLevels = {
  * H1, H2, and H3 elements.
  */
 export const getPageTableOfContents = (page, recordMap) => {
+  const pageId = page?.id
+  if (process.env.NODE_ENV !== 'production' && pageId) {
+    unknownHeadingStats.set(pageId, 0)
+  }
   const contents = page.content ?? []
-  const toc = getBlockHeader(contents, recordMap)
+  const toc = getBlockHeader(contents, recordMap, [], pageId)
   const indentLevelStack = [
     {
       actual: -1,
@@ -25,11 +34,18 @@ export const getPageTableOfContents = (page, recordMap) => {
   // This is a little tricky, but the key is that when increasing indent levels,
   // they should never jump more than one at a time.
   for (const tocItem of toc) {
-    const { indentLevel } = tocItem
-    const actual = indentLevel
+    const actual = Number.isInteger(tocItem.indentLevel) ? tocItem.indentLevel : 0
 
     do {
       const prevIndent = indentLevelStack[indentLevelStack.length - 1]
+      if (!prevIndent) {
+        tocItem.indentLevel = 0
+        indentLevelStack.push({
+          actual,
+          effective: 0
+        })
+        break
+      }
       const { actual: prevActual, effective: prevEffective } = prevIndent
 
       if (actual > prevActual) {
@@ -49,13 +65,21 @@ export const getPageTableOfContents = (page, recordMap) => {
     } while (true)
   }
 
+  if (process.env.NODE_ENV !== 'production' && pageId) {
+    const unknownCount = unknownHeadingStats.get(pageId) || 0
+    if (unknownCount > 0) {
+      console.warn('[TOC] unknown heading summary', { pageId, unknownCount })
+    }
+    unknownHeadingStats.delete(pageId)
+  }
+
   return toc
 }
 
 /**
  * 重写获取目录方法
  */
-function getBlockHeader(contents, recordMap, toc) {
+function getBlockHeader(contents, recordMap, toc, pageId) {
   if (!toc) {
     toc = []
   }
@@ -69,27 +93,55 @@ function getBlockHeader(contents, recordMap, toc) {
       continue
     }
     const { type } = block
+    const isHeading =
+      typeof type === 'string' &&
+      (type.indexOf('header') >= 0 || /^heading_[123]$/.test(type))
+
     if (block.content?.length > 0) {
-      getBlockHeader(block.content, recordMap, toc)
+      getBlockHeader(block.content, recordMap, toc, pageId)
     } else {
-      if (type.indexOf('header') >= 0) {
+      if (isHeading) {
         const existed = toc.find(e => e.id === blockId)
+        const indentLevel = indentLevels[type]
+        if (!Number.isInteger(indentLevel)) {
+          // Emit debug signal only in development for quick reproduction.
+          if (process.env.NODE_ENV !== 'production') {
+            if (pageId) {
+              unknownHeadingStats.set(
+                pageId,
+                (unknownHeadingStats.get(pageId) || 0) + 1
+              )
+            }
+            console.warn('[TOC] unknown heading type', {
+              pageId,
+              blockId,
+              type,
+              title: getTextContent(block.properties?.title),
+              parentId: block.parent_id
+            })
+          }
+          continue
+        }
         if (!existed) {
           toc.push({
             id: blockId,
             type,
             text: getTextContent(block.properties?.title),
-            indentLevel: indentLevels[type]
+            indentLevel
           })
         }
-      } else if (type === 'transclusion_reference') {
+      } else if (
+        type === 'transclusion_reference' &&
+        block.format?.transclusion_reference_pointer?.id
+      ) {
         getBlockHeader(
           [block.format.transclusion_reference_pointer.id],
           recordMap,
-          toc
+          toc,
+          pageId
         )
       } else if (type === 'transclusion_container') {
-          getBlockHeader(block.content, recordMap, toc)
+        getBlockHeader(block.content, recordMap, toc, pageId)
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "notion-next",
-  "version": "4.9.4.2",
+  "version": "4.9.4.3",
   "homepage": "https://github.com/tangly1024/NotionNext.git",
   "license": "MIT",
   "engines": {


### PR DESCRIPTION
Prevent invalid heading indent data from emptying the indent stack and crashing post rendering, while adding dev-only diagnostics for unknown heading blocks.


受影响的issue

https://github.com/tangly1024/NotionNext/issues/3918
https://github.com/tangly1024/NotionNext/issues/3943
https://github.com/tangly1024/NotionNext/issues/3915