### PR TITLE
security: pin form-data resolution to ^4.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,8 @@
     "webpack-bundle-analyzer": "^4.5.0"
   },
   "resolutions": {
-    "axios": ">=0.21.1"
+    "axios": ">=0.21.1",
+    "form-data": "^4.0.4"
   },
   "bugs": {
     "url": "https://github.com/tangly/NotionNext/issues",


### PR DESCRIPTION
# 基于此PR最小改动提交
https://github.com/tangly1024/NotionNext/pull/3873


## Background
This PR applies the security intent from #3873 with a minimal, low-risk merge strategy.
The repository should keep a guardrail to avoid `form-data` regressing into vulnerable ranges (CVE-2025-7783 context), while avoiding unrelated package churn in the same change.
## What changed
- Updated `package.json` `resolutions`:
  - Added `"form-data": "^4.0.4"`
## Why this is minimal
This PR intentionally does **not** include unrelated changes from #3873 (e.g. `devDependencies` reordering), to keep review scope small and reduce merge/conflict risk.
## Impact
- Keeps dependency resolution constrained away from vulnerable `form-data` versions.
- No runtime behavior change expected.
- No feature logic touched.
## Attribution
This change follows the original contribution direction from #3873 and preserves original author attribution in commit metadata.
Related PR:
- #3873