### PR TITLE
Fix Notion data source schema parsing and page list merging.

### DIFF
--- a/lib/db/SiteDataApi.js
+++ b/lib/db/SiteDataApi.js
@@ -300,10 +300,13 @@ async function convertNotionToSiteData(
   }
 
   const stepStart4 = Date.now()
-  const collectionId = rawMetadata?.collection_id
+  const collectionMap = pageRecordMap.collection || {}
+  const inferredCollectionId =
+    Object.keys(collectionMap).length === 1 ? Object.keys(collectionMap)[0] : null
+  const collectionId = rawMetadata?.collection_id || inferredCollectionId
   const rawCollection =
-    pageRecordMap.collection?.[collectionId] ||
-    pageRecordMap.collection?.[idToUuid(collectionId)] ||
+    collectionMap?.[collectionId] ||
+    collectionMap?.[idToUuid(collectionId)] ||
     {}
   const collection = normalizeCollection(rawCollection)
   const collectionQuery = pageRecordMap.collection_query

--- a/lib/db/notion/getNotionConfig.js
+++ b/lib/db/notion/getNotionConfig.js
@@ -105,10 +105,15 @@ export function parseConfigFromPage(pageRecordMap, content) {
     return null
   }
 
-  const collectionId = rawMetadata.collection_id
-  const collection = normalizeCollection(
-    pageRecordMap.collection[collectionId].value
-  )
+  const collectionMap = pageRecordMap.collection || {}
+  const inferredCollectionId =
+    Object.keys(collectionMap).length === 1 ? Object.keys(collectionMap)[0] : null
+  const collectionId = rawMetadata?.collection_id || inferredCollectionId
+  const rawCollection =
+    collectionMap?.[collectionId] ||
+    collectionMap?.[collectionId?.replace(/-/g, '')] ||
+    {}
+  const collection = normalizeCollection(rawCollection)
   const schema = normalizeSchema(collection?.schema || {})
 
   const rowPageIds = getAllPageIds(


### PR DESCRIPTION
## 背景
在新版 Notion data source 返回结构下，`collection_id` 可能不会稳定地出现在原有元数据位置。  
这会导致以下链路在部分场景下无法正确读取 collection/schema：
- 站点主数据解析链路
- Config 配置表解析链路
本 PR 只做最小范围补丁，降低回归风险。
## 改动内容
### 1) `lib/db/SiteDataApi.js`
- 增加 `collectionMap` 回退推断逻辑：
  - 当 `pageRecordMap.collection` 仅有一个 key 时，将其作为 `inferredCollectionId`
- `collectionId` 使用：
  - `rawMetadata?.collection_id || inferredCollectionId`
- 从推断后的 map 中读取 collection 再进行 normalize
### 2) `lib/db/notion/getNotionConfig.js`
- 增加同样的 `collectionId` 回退推断逻辑
- 读取 collection 时同时兼容：
  - 带 `-` 的 id
  - 去掉 `-` 的 id
## 为什么是最小补丁
本 PR 有意仅保留 `collection_id` 回退逻辑，  
不包含与本问题无直接关系的改动（例如 sitemap 行为调整），以保证变更边界清晰、审查成本可控。
## 预期效果
- 提升新版 Notion data source 结构兼容性
- 降低因 `collection_id` 不稳定导致的 schema/config 解析失败
- 除 collection 定位回退外，不引入额外行为变化
## 致谢与来源
本次修复思路来自 #3900，并在此基础上做了最小化落地。  
提交中已保留原作者信息。


Add collection_id fallback inference for site data and config parsing when Notion metadata omits stable collection_id in newer data source structures.

(adapted from commit 6109153ecc86373da649cf99e77bf244d88a15c2)

https://github.com/tangly1024/NotionNext/pull/3900

## Background
Newer Notion data source responses may not always provide a stable `collection_id` at the expected metadata location.
When that happens, schema/collection parsing can fail in:
- site data conversion path
- config table parsing path
This PR applies a minimal fallback strategy and keeps scope intentionally small.
## Changes
- `lib/db/SiteDataApi.js`
  - Add `collectionMap` fallback inference:
    - if `pageRecordMap.collection` has exactly one key, infer it as `collectionId`
  - Use `rawMetadata?.collection_id || inferredCollectionId`
  - Read collection from inferred map before normalizing
- `lib/db/notion/getNotionConfig.js`
  - Add the same `collectionId` fallback inference
  - Support both hyphenated and non-hyphenated collection keys when resolving collection entry
## Why minimal
This PR intentionally only includes the `collection_id` fallback logic.
It does **not** include unrelated changes (e.g. sitemap behavior), to reduce regression risk and keep review focused.
## Expected impact
- Better compatibility with newer Notion data source structures
- Reduce cases where schema/config parsing fails due to missing stable `collection_id`
- No intended behavior change outside collection resolution fallback
## Attribution
Adapted from upstream contribution in #3900, while keeping only the minimal safe subset.
Commit author metadata is preserved.



