### PR TITLE
fix(notion): open external article links in new tabs with same-origin safeguard

### DIFF
--- a/__tests__/components/NotionLink.test.js
+++ b/__tests__/components/NotionLink.test.js
@@ -1,0 +1,66 @@
+import { render, screen } from '@testing-library/react'
+import NotionLink, {
+  shouldOpenNotionLinkInNewTab
+} from '@/components/NotionLink'
+
+describe('NotionLink', () => {
+  it('opens external http links in a new tab', () => {
+    render(<NotionLink href='https://example.com'>Example</NotionLink>)
+
+    const link = screen.getByRole('link', { name: 'Example' })
+    expect(link).toHaveAttribute('href', 'https://example.com')
+    expect(link).toHaveAttribute('target', '_blank')
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer')
+  })
+
+  it('preserves existing rel tokens when forcing a new tab', () => {
+    render(
+      <NotionLink href='https://example.com' rel='nofollow sponsored'>
+        Example
+      </NotionLink>
+    )
+
+    const link = screen.getByRole('link', { name: 'Example' })
+    expect(link).toHaveAttribute('rel', expect.stringContaining('nofollow'))
+    expect(link).toHaveAttribute('rel', expect.stringContaining('sponsored'))
+    expect(link).toHaveAttribute('rel', expect.stringContaining('noopener'))
+    expect(link).toHaveAttribute('rel', expect.stringContaining('noreferrer'))
+  })
+
+  it('keeps mailto links in the current tab by default', () => {
+    render(<NotionLink href='mailto:test@example.com'>Mail</NotionLink>)
+
+    const link = screen.getByRole('link', { name: 'Mail' })
+    expect(link).toHaveAttribute('href', 'mailto:test@example.com')
+    expect(link).not.toHaveAttribute('target')
+    expect(link).not.toHaveAttribute('rel')
+  })
+
+  it('keeps explicit blank targets and adds safe rel tokens', () => {
+    render(
+      <NotionLink href='mailto:test@example.com' target='_blank'>
+        Mail
+      </NotionLink>
+    )
+
+    const link = screen.getByRole('link', { name: 'Mail' })
+    expect(link).toHaveAttribute('target', '_blank')
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer')
+  })
+})
+
+describe('shouldOpenNotionLinkInNewTab', () => {
+  it('returns true for explicit blank targets and http links', () => {
+    expect(
+      shouldOpenNotionLinkInNewTab('mailto:test@example.com', '_blank')
+    ).toBe(true)
+    expect(shouldOpenNotionLinkInNewTab('https://example.com')).toBe(true)
+    expect(shouldOpenNotionLinkInNewTab('http://example.com')).toBe(true)
+  })
+
+  it('returns false for non-http links without an explicit target', () => {
+    expect(shouldOpenNotionLinkInNewTab('/posts/demo')).toBe(false)
+    expect(shouldOpenNotionLinkInNewTab('#section-1')).toBe(false)
+    expect(shouldOpenNotionLinkInNewTab('mailto:test@example.com')).toBe(false)
+  })
+})

--- a/__tests__/components/NotionLink.test.js
+++ b/__tests__/components/NotionLink.test.js
@@ -13,6 +13,16 @@ describe('NotionLink', () => {
     expect(link).toHaveAttribute('rel', 'noopener noreferrer')
   })
 
+  it('keeps same-origin absolute links in current tab', () => {
+    expect(
+      shouldOpenNotionLinkInNewTab(
+        'https://blog.example.com/article/abc',
+        undefined,
+        'https://blog.example.com'
+      )
+    ).toBe(false)
+  })
+
   it('preserves existing rel tokens when forcing a new tab', () => {
     render(
       <NotionLink href='https://example.com' rel='nofollow sponsored'>
@@ -27,7 +37,7 @@ describe('NotionLink', () => {
     expect(link).toHaveAttribute('rel', expect.stringContaining('noreferrer'))
   })
 
-  it('keeps mailto links in the current tab by default', () => {
+  it('keeps mailto links in current tab by default', () => {
     render(<NotionLink href='mailto:test@example.com'>Mail</NotionLink>)
 
     const link = screen.getByRole('link', { name: 'Mail' })
@@ -50,17 +60,36 @@ describe('NotionLink', () => {
 })
 
 describe('shouldOpenNotionLinkInNewTab', () => {
-  it('returns true for explicit blank targets and http links', () => {
+  it('returns true for explicit blank targets and cross-origin http links', () => {
     expect(
       shouldOpenNotionLinkInNewTab('mailto:test@example.com', '_blank')
     ).toBe(true)
-    expect(shouldOpenNotionLinkInNewTab('https://example.com')).toBe(true)
-    expect(shouldOpenNotionLinkInNewTab('http://example.com')).toBe(true)
+    expect(
+      shouldOpenNotionLinkInNewTab(
+        'https://external.example.com',
+        undefined,
+        'https://blog.example.com'
+      )
+    ).toBe(true)
+    expect(
+      shouldOpenNotionLinkInNewTab(
+        'http://external.example.com',
+        undefined,
+        'https://blog.example.com'
+      )
+    ).toBe(true)
   })
 
-  it('returns false for non-http links without an explicit target', () => {
+  it('returns false for non-http links and same-origin http links', () => {
     expect(shouldOpenNotionLinkInNewTab('/posts/demo')).toBe(false)
     expect(shouldOpenNotionLinkInNewTab('#section-1')).toBe(false)
     expect(shouldOpenNotionLinkInNewTab('mailto:test@example.com')).toBe(false)
+    expect(
+      shouldOpenNotionLinkInNewTab(
+        'https://blog.example.com/abc',
+        undefined,
+        'https://blog.example.com'
+      )
+    ).toBe(false)
   })
 })

--- a/components/NotionLink.js
+++ b/components/NotionLink.js
@@ -13,12 +13,35 @@ const mergeRelValues = (...values) => {
   return rel.size > 0 ? Array.from(rel).join(' ') : undefined
 }
 
-export const shouldOpenNotionLinkInNewTab = (href, target) => {
+const isExternalHttpLink = (href, siteOrigin) => {
+  if (typeof href !== 'string' || !EXTERNAL_HTTP_LINK.test(href)) {
+    return false
+  }
+
+  if (!siteOrigin) {
+    return true
+  }
+
+  try {
+    const hrefUrl = new URL(href)
+    return hrefUrl.origin !== siteOrigin
+  } catch {
+    return true
+  }
+}
+
+export const shouldOpenNotionLinkInNewTab = (href, target, siteOrigin) => {
   if (target === '_blank') {
     return true
   }
 
-  return typeof href === 'string' && EXTERNAL_HTTP_LINK.test(href)
+  const fallbackOrigin =
+    siteOrigin ||
+    (typeof window !== 'undefined' && window.location
+      ? window.location.origin
+      : null)
+
+  return isExternalHttpLink(href, fallbackOrigin)
 }
 
 const NotionLink = ({ href, target, rel, ...props }) => {

--- a/components/NotionLink.js
+++ b/components/NotionLink.js
@@ -1,0 +1,36 @@
+const EXTERNAL_HTTP_LINK = /^https?:\/\//i
+
+const mergeRelValues = (...values) => {
+  const rel = new Set()
+
+  values
+    .filter(Boolean)
+    .join(' ')
+    .split(/\s+/)
+    .filter(Boolean)
+    .forEach(token => rel.add(token))
+
+  return rel.size > 0 ? Array.from(rel).join(' ') : undefined
+}
+
+export const shouldOpenNotionLinkInNewTab = (href, target) => {
+  if (target === '_blank') {
+    return true
+  }
+
+  return typeof href === 'string' && EXTERNAL_HTTP_LINK.test(href)
+}
+
+const NotionLink = ({ href, target, rel, ...props }) => {
+  const shouldOpenInNewTab = shouldOpenNotionLinkInNewTab(href, target)
+  const normalizedTarget = shouldOpenInNewTab ? '_blank' : target
+  const normalizedRel = shouldOpenInNewTab
+    ? mergeRelValues(rel, 'noopener noreferrer')
+    : rel
+
+  return (
+    <a {...props} href={href} target={normalizedTarget} rel={normalizedRel} />
+  )
+}
+
+export default NotionLink

--- a/components/NotionPage.js
+++ b/components/NotionPage.js
@@ -123,8 +123,7 @@ const NotionPage = ({ post, className }) => {
   return (
     <div
       id='notion-article'
-      className={`mx-auto overflow-hidden ${className || ''}`}
-    >
+      className={`mx-auto overflow-hidden ${className || ''}`}>
       <NotionRenderer
         recordMap={post?.blockMap}
         mapPageUrl={mapPageUrl}
@@ -145,6 +144,7 @@ const NotionPage = ({ post, className }) => {
     </div>
   )
 }
+
 
 /**
  * 页面的数据库链接禁止跳转，只能查看

--- a/components/NotionPage.js
+++ b/components/NotionPage.js
@@ -1,5 +1,6 @@
 import { siteConfig } from '@/lib/config'
 import { compressImage, mapImgUrl } from '@/lib/db/notion/mapImage'
+import NotionLink from '@/components/NotionLink'
 import { isBrowser, loadExternalResource } from '@/lib/utils'
 import mediumZoom from '@fisch0920/medium-zoom'
 import 'katex/dist/katex.min.css'
@@ -122,7 +123,8 @@ const NotionPage = ({ post, className }) => {
   return (
     <div
       id='notion-article'
-      className={`mx-auto overflow-hidden ${className || ''}`}>
+      className={`mx-auto overflow-hidden ${className || ''}`}
+    >
       <NotionRenderer
         recordMap={post?.blockMap}
         mapPageUrl={mapPageUrl}
@@ -131,6 +133,7 @@ const NotionPage = ({ post, className }) => {
           Code,
           Collection,
           Equation,
+          Link: NotionLink,
           Modal,
           Pdf,
           Tweet
@@ -142,7 +145,6 @@ const NotionPage = ({ post, className }) => {
     </div>
   )
 }
-
 
 /**
  * 页面的数据库链接禁止跳转，只能查看


### PR DESCRIPTION
## Background
This PR addresses article link behavior from Notion-rendered content and consolidates prior contributions while improving compatibility.
It is based on the original fix proposal and keeps author attribution, then adds a follow-up hardening patch.
## What this PR includes
### Commit 1 (attributed to original contributor)
- Cherry-picked original Notion link behavior fix (`-x`) from upstream contribution:
  - route `NotionRenderer` links through `NotionLink`
  - default external `http(s)` links to `_blank`
  - preserve explicit targets and existing `rel` tokens
  - add safe `noopener noreferrer`
  - add focused unit tests
### Commit 2 (compatibility hardening)
- Refines behavior to avoid opening **same-origin absolute URLs** in new tabs by default
- Keeps `_blank` behavior for:
  - explicit `target="_blank"`
  - cross-origin `http(s)` links
- Keeps non-http links (`mailto:`, hash, relative paths) in current tab by default
## Why this is safer
Without same-origin detection, absolute internal links like `https://your-site/...` can be incorrectly forced into new tabs.  
This PR keeps external-link UX while avoiding internal navigation regression.
## Files changed
- `components/NotionLink.js`
- `components/NotionPage.js`
- `__tests__/components/NotionLink.test.js`
## Validation
- `npx jest __tests__/components/NotionLink.test.js --runInBand` ✅ (7/7 passed)
- `npx eslint components/NotionLink.js components/NotionPage.js __tests__/components/NotionLink.test.js` ✅
  - no new errors
  - existing `react-hooks/exhaustive-deps` warnings in `components/NotionPage.js` remain pre-existing
## Related
- Issue: #3670
- Prior duplicate/related PRs: #3852, #3853