### PR TITLE
chore(netlify): 最小化引入 Netlify Next.js 兼容配置

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,2 @@
+[[plugins]]
+  package = "@netlify/plugin-nextjs"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,2 +1,9 @@
+[build]
+  command = "yarn run build"
+  publish = ".next"
+
+[build.environment]
+  NODE_VERSION = "20"
+
 [[plugins]]
   package = "@netlify/plugin-nextjs"

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "@typescript-eslint/eslint-plugin": "^7.18.0",
     "@typescript-eslint/parser": "^7.18.0",
     "@waline/client": "^3.6.0",
+    "@netlify/plugin-nextjs": "^4.36.1",
     "autoprefixer": "^10.4.21",
     "cross-env": "^7.0.3",
     "eslint": "^8.57.1",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "@typescript-eslint/eslint-plugin": "^7.18.0",
     "@typescript-eslint/parser": "^7.18.0",
     "@waline/client": "^3.6.0",
-    "@netlify/plugin-nextjs": "^4.36.1",
+    "@netlify/plugin-nextjs": "^5.15.8",
     "autoprefixer": "^10.4.21",
     "cross-env": "^7.0.3",
     "eslint": "^8.57.1",


### PR DESCRIPTION
## 背景

针对 Netlify 部署场景中 Next.js 适配兼容问题，原始 PR #3808 提供了有效方向，但包含大量与问题无关的个人配置/资源改动，直接合并风险较高。

本 PR 采用“最小改动”策略，仅保留与 Netlify 兼容性直接相关的修复内容，并保留原作者提交信息。

## 改动内容（最小范围）

仅涉及 2 个文件：

1. `netlify.toml`（新增）
   - 增加 Netlify 构建配置
   - 指定构建命令与发布目录
   - 指定 Node 版本为 `20`
   - 启用 `@netlify/plugin-nextjs` 插件

2. `package.json`
   - 在 `devDependencies` 中增加：
     - `@netlify/plugin-nextjs: ^5.15.8`

## 说明

- 本 PR 通过 `cherry-pick -x` 从原贡献分支提取最小提交，保留作者归属和来源追踪。
- 未引入 #3808 中与 Netlify 兼容无关的改动（如主题/配置/资源文件等）。

## 预期收益

- 提升 Netlify 环境下 Next.js 构建与预览稳定性
- 降低“部署成功但预览异常”的兼容问题概率
- 在保证修复效果的同时，最大程度降低回归风险

## 关联

- 原始参考 PR：#3808