### PR TITLE
增强 TechGrow 兼容性：替代OpenWrite公众号解锁方案

### DIFF
--- a/blog.config.js
+++ b/blog.config.js
@@ -58,6 +58,56 @@ const BLOG = {
   // 文章列表相关设置
   CAN_COPY: process.env.NEXT_PUBLIC_CAN_COPY || true, // 是否允许复制页面内容 默认允许，如果设置为false、则全栈禁止复制内容。
 
+  // 公众号导流插件（TechGrow）
+  TECH_GROW_BLOG_ID:
+    process.env.NEXT_PUBLIC_TECH_GROW_BLOG_ID ||
+    process.env.TECH_GROW_BLOG_ID ||
+    '',
+  TECH_GROW_NAME:
+    process.env.NEXT_PUBLIC_TECH_GROW_NAME ||
+    process.env.TECH_GROW_NAME ||
+    '',
+  TECH_GROW_QRCODE:
+    process.env.NEXT_PUBLIC_TECH_GROW_QRCODE ||
+    process.env.TECH_GROW_QRCODE ||
+    '',
+  TECH_GROW_KEYWORD:
+    process.env.NEXT_PUBLIC_TECH_GROW_KEYWORD ||
+    process.env.TECH_GROW_KEYWORD ||
+    '',
+  TECH_GROW_BTN_TEXT:
+    process.env.NEXT_PUBLIC_TECH_GROW_BTN_TEXT ||
+    process.env.TECH_GROW_BTN_TEXT ||
+    '原创不易，完成人机检测，阅读全文',
+  TECH_GROW_VALIDITY_DURATION:
+    process.env.NEXT_PUBLIC_TECH_GROW_VALIDITY_DURATION ||
+    process.env.TECH_GROW_VALIDITY_DURATION ||
+    1,
+  TECH_GROW_WHITE_LIST:
+    process.env.NEXT_PUBLIC_TECH_GROW_WHITE_LIST ||
+    process.env.TECH_GROW_WHITE_LIST ||
+    '',
+  TECH_GROW_YELLOW_LIST:
+    process.env.NEXT_PUBLIC_TECH_GROW_YELLOW_LIST ||
+    process.env.TECH_GROW_YELLOW_LIST ||
+    '',
+  TECH_GROW_JS_URL:
+    process.env.NEXT_PUBLIC_TECH_GROW_JS_URL ||
+    process.env.TECH_GROW_JS_URL ||
+    'https://qiniu.techgrow.cn/readmore/dist/readmore.js',
+  TECH_GROW_CSS_URL:
+    process.env.NEXT_PUBLIC_TECH_GROW_CSS_URL ||
+    process.env.TECH_GROW_CSS_URL ||
+    'https://qiniu.techgrow.cn/readmore/dist/hexo.css',
+  TECH_GROW_CAPTCHA_URL:
+    process.env.NEXT_PUBLIC_TECH_GROW_CAPTCHA_URL ||
+    process.env.TECH_GROW_CAPTCHA_URL ||
+    'https://open.techgrow.cn/#/readmore/captcha/generate?blogId=',
+  TECH_GROW_BASE_URL:
+    process.env.NEXT_PUBLIC_TECH_GROW_BASE_URL ||
+    process.env.TECH_GROW_BASE_URL ||
+    '',
+
   // 侧栏布局 是否反转(左变右,右变左) 已支持主题: hexo next medium fukasawa example
   LAYOUT_SIDEBAR_REVERSE:
     process.env.NEXT_PUBLIC_LAYOUT_SIDEBAR_REVERSE || false,

--- a/blog.config.js
+++ b/blog.config.js
@@ -59,6 +59,19 @@ const BLOG = {
   CAN_COPY: process.env.NEXT_PUBLIC_CAN_COPY || true, // 是否允许复制页面内容 默认允许，如果设置为false、则全栈禁止复制内容。
 
   // 公众号导流插件（TechGrow）
+  // 可在 Notion 的 Config 页面用“同名键”覆盖这里的值（Config 优先级更高）。
+  // 建议在 Config 页面至少配置以下四项：
+  // - TECH_GROW_BLOG_ID: TechGrow 后台的 blogId
+  // - TECH_GROW_NAME: 公众号名称
+  // - TECH_GROW_QRCODE: 公众号二维码图片地址
+  // - TECH_GROW_KEYWORD: 公众号回复关键词
+  // 常用可选项：
+  // - TECH_GROW_ARTICLE_CONTENT_ID: 需要被锁定的正文容器 id（默认 notion-article）
+  // - TECH_GROW_BTN_TEXT: 引导按钮文案
+  // - TECH_GROW_VALIDITY_DURATION: 验证通过后的有效时长（小时）
+  // 名单规则：
+  // - TECH_GROW_WHITE_LIST: 白名单（这些路径直接放行）
+  // - TECH_GROW_YELLOW_LIST: 黄名单（仅这些路径启用拦截，优先级高于白名单）
   TECH_GROW_BLOG_ID:
     process.env.NEXT_PUBLIC_TECH_GROW_BLOG_ID ||
     process.env.TECH_GROW_BLOG_ID ||

--- a/blog.config.js
+++ b/blog.config.js
@@ -58,68 +58,7 @@ const BLOG = {
   // 文章列表相关设置
   CAN_COPY: process.env.NEXT_PUBLIC_CAN_COPY || true, // 是否允许复制页面内容 默认允许，如果设置为false、则全栈禁止复制内容。
 
-  // 公众号导流插件（TechGrow）
-  // 可在 Notion 的 Config 页面用“同名键”覆盖这里的值（Config 优先级更高）。
-  // 建议在 Config 页面至少配置以下四项：
-  // - TECH_GROW_BLOG_ID: TechGrow 后台的 blogId
-  // - TECH_GROW_NAME: 公众号名称
-  // - TECH_GROW_QRCODE: 公众号二维码图片地址
-  // - TECH_GROW_KEYWORD: 公众号回复关键词
-  // 常用可选项：
-  // - TECH_GROW_ARTICLE_CONTENT_ID: 需要被锁定的正文容器 id（默认 notion-article）
-  // - TECH_GROW_BTN_TEXT: 引导按钮文案
-  // - TECH_GROW_VALIDITY_DURATION: 验证通过后的有效时长（小时）
-  // 名单规则：
-  // - TECH_GROW_WHITE_LIST: 白名单（这些路径直接放行）
-  // - TECH_GROW_YELLOW_LIST: 黄名单（仅这些路径启用拦截，优先级高于白名单）
-  TECH_GROW_BLOG_ID:
-    process.env.NEXT_PUBLIC_TECH_GROW_BLOG_ID ||
-    process.env.TECH_GROW_BLOG_ID ||
-    '',
-  TECH_GROW_NAME:
-    process.env.NEXT_PUBLIC_TECH_GROW_NAME ||
-    process.env.TECH_GROW_NAME ||
-    '',
-  TECH_GROW_QRCODE:
-    process.env.NEXT_PUBLIC_TECH_GROW_QRCODE ||
-    process.env.TECH_GROW_QRCODE ||
-    '',
-  TECH_GROW_KEYWORD:
-    process.env.NEXT_PUBLIC_TECH_GROW_KEYWORD ||
-    process.env.TECH_GROW_KEYWORD ||
-    '',
-  TECH_GROW_BTN_TEXT:
-    process.env.NEXT_PUBLIC_TECH_GROW_BTN_TEXT ||
-    process.env.TECH_GROW_BTN_TEXT ||
-    '原创不易，完成人机检测，阅读全文',
-  TECH_GROW_VALIDITY_DURATION:
-    process.env.NEXT_PUBLIC_TECH_GROW_VALIDITY_DURATION ||
-    process.env.TECH_GROW_VALIDITY_DURATION ||
-    1,
-  TECH_GROW_WHITE_LIST:
-    process.env.NEXT_PUBLIC_TECH_GROW_WHITE_LIST ||
-    process.env.TECH_GROW_WHITE_LIST ||
-    '',
-  TECH_GROW_YELLOW_LIST:
-    process.env.NEXT_PUBLIC_TECH_GROW_YELLOW_LIST ||
-    process.env.TECH_GROW_YELLOW_LIST ||
-    '',
-  TECH_GROW_JS_URL:
-    process.env.NEXT_PUBLIC_TECH_GROW_JS_URL ||
-    process.env.TECH_GROW_JS_URL ||
-    'https://qiniu.techgrow.cn/readmore/dist/readmore.js',
-  TECH_GROW_CSS_URL:
-    process.env.NEXT_PUBLIC_TECH_GROW_CSS_URL ||
-    process.env.TECH_GROW_CSS_URL ||
-    'https://qiniu.techgrow.cn/readmore/dist/hexo.css',
-  TECH_GROW_CAPTCHA_URL:
-    process.env.NEXT_PUBLIC_TECH_GROW_CAPTCHA_URL ||
-    process.env.TECH_GROW_CAPTCHA_URL ||
-    'https://open.techgrow.cn/#/readmore/captcha/generate?blogId=',
-  TECH_GROW_BASE_URL:
-    process.env.NEXT_PUBLIC_TECH_GROW_BASE_URL ||
-    process.env.TECH_GROW_BASE_URL ||
-    '',
+  ...require('./conf/techgrow.config'), // 公众号导流插件（TechGrow）
 
   // 侧栏布局 是否反转(左变右,右变左) 已支持主题: hexo next medium fukasawa example
   LAYOUT_SIDEBAR_REVERSE:

--- a/components/TechGrow.js
+++ b/components/TechGrow.js
@@ -93,7 +93,9 @@ const installReadmoreNetworkProbe = debug => {
 
   const XHR = window.XMLHttpRequest
   if (XHR?.prototype?.open && XHR?.prototype?.send) {
+    // eslint-disable-next-line @typescript-eslint/unbound-method
     const originalOpen = XHR.prototype.open
+    // eslint-disable-next-line @typescript-eslint/unbound-method
     const originalSend = XHR.prototype.send
 
     XHR.prototype.open = function(method, url, ...rest) {

--- a/components/TechGrow.js
+++ b/components/TechGrow.js
@@ -6,8 +6,6 @@ import { useEffect } from 'react'
 
 const DEFAULT_TECH_GROW_JS = 'https://qiniu.techgrow.cn/readmore/dist/readmore.js'
 const DEFAULT_TECH_GROW_CSS = 'https://qiniu.techgrow.cn/readmore/dist/hexo.css'
-const DEFAULT_TECH_GROW_CAPTCHA_URL =
-  'https://open.techgrow.cn/#/readmore/captcha/generate?blogId='
 
 const hasValue = value => value !== undefined && value !== null && value !== ''
 
@@ -19,27 +17,6 @@ const getFirstConfig = (keys, defaultVal = null) => {
     }
   }
   return defaultVal
-}
-
-const resolveCaptchaGenerateUrl = (url, blogId) => {
-  if (!url) {
-    return ''
-  }
-
-  if (!blogId) {
-    return url
-  }
-
-  if (url.includes('{blogId}')) {
-    return url.replace('{blogId}', blogId)
-  }
-
-  if (url.includes('blogId=')) {
-    return url.replace(/blogId=([^&]*)/, `blogId=${blogId}`)
-  }
-
-  const separator = url.includes('?') ? '&' : '?'
-  return `${url}${separator}blogId=${blogId}`
 }
 
 const getReadmoreWrapper = () =>
@@ -61,6 +38,137 @@ const normalizePreviewHeight = height => {
     return null
   }
   return /^\d+$/.test(raw) ? `${raw}px` : raw
+}
+
+const isReadmoreRelatedUrl = url =>
+  typeof url === 'string' &&
+  /(techgrow|readmore|open\.techgrow\.cn|qiniu\.techgrow\.cn)/i.test(url)
+
+const installReadmoreNetworkProbe = debug => {
+  if (!debug || typeof window === 'undefined') {
+    return
+  }
+  if (window.__TECH_GROW_NETWORK_PROBE_INSTALLED__) {
+    return
+  }
+  window.__TECH_GROW_NETWORK_PROBE_INSTALLED__ = true
+
+  if (typeof window.fetch === 'function') {
+    const originalFetch = window.fetch.bind(window)
+    window.fetch = async (...args) => {
+      let url = ''
+      let method = 'GET'
+      try {
+        const input = args[0]
+        const init = args[1]
+        url = typeof input === 'string' ? input : input?.url || ''
+        method =
+          init?.method ||
+          (typeof input !== 'string' && input?.method) ||
+          'GET'
+      } catch {}
+
+      const related = isReadmoreRelatedUrl(url)
+      const start = Date.now()
+      if (related) {
+        console.log(`[TechGrow][fetch][req] ${method} ${url}`)
+      }
+
+      try {
+        const response = await originalFetch(...args)
+        if (related) {
+          console.log(
+            `[TechGrow][fetch][res] ${response.status} ${response.url || url} ${Date.now() - start}ms`
+          )
+        }
+        return response
+      } catch (error) {
+        if (related) {
+          console.error(`[TechGrow][fetch][err] ${url}`, error)
+        }
+        throw error
+      }
+    }
+  }
+
+  const XHR = window.XMLHttpRequest
+  if (XHR?.prototype?.open && XHR?.prototype?.send) {
+    const originalOpen = XHR.prototype.open
+    const originalSend = XHR.prototype.send
+
+    XHR.prototype.open = function(method, url, ...rest) {
+      this.__techGrowDebugMeta = {
+        method: method || 'GET',
+        url: String(url || '')
+      }
+      return originalOpen.call(this, method, url, ...rest)
+    }
+
+    XHR.prototype.send = function(body) {
+      const meta = this.__techGrowDebugMeta || { method: 'GET', url: '' }
+      const related = isReadmoreRelatedUrl(meta.url)
+      const start = Date.now()
+
+      if (related) {
+        console.log(`[TechGrow][xhr][req] ${meta.method} ${meta.url}`)
+        this.addEventListener('loadend', () => {
+          console.log(
+            `[TechGrow][xhr][res] ${this.status} ${meta.url} ${Date.now() - start}ms`
+          )
+        })
+        this.addEventListener('error', () => {
+          console.error(`[TechGrow][xhr][err] ${meta.url}`)
+        })
+      }
+
+      return originalSend.call(this, body)
+    }
+  }
+}
+
+const installReadmoreAlertProbe = debug => {
+  if (!debug || typeof window === 'undefined') {
+    return
+  }
+  if (window.__TECH_GROW_ALERT_PROBE_INSTALLED__) {
+    return
+  }
+  if (typeof window.alert !== 'function') {
+    return
+  }
+  window.__TECH_GROW_ALERT_PROBE_INSTALLED__ = true
+  const originalAlert = window.alert.bind(window)
+  window.alert = message => {
+    const text = String(message || '')
+    console.warn(`[TechGrow][alert] ${text}`)
+    if (text.includes('验证码无效')) {
+      console.warn('[TechGrow][alert] invalid-captcha triggered')
+    }
+    return originalAlert(message)
+  }
+}
+
+const logReadmoreState = (debug, contentId, stage) => {
+  if (!debug || typeof document === 'undefined') {
+    return
+  }
+  const container = document.getElementById(contentId)
+  const wrapper = getReadmoreWrapper()
+  const containerStyle = container
+    ? window.getComputedStyle(container)
+    : null
+  const wrapperStyle = wrapper ? window.getComputedStyle(wrapper) : null
+  console.log('[TechGrow][state]', stage, {
+    contentId,
+    hasContainer: !!container,
+    hasWrapper: !!wrapper,
+    wrapperParentId: wrapper?.parentElement?.id || '',
+    containerPosition: containerStyle?.position || '',
+    containerHeight: containerStyle?.height || '',
+    containerOverflow: containerStyle?.overflow || '',
+    wrapperDisplay: wrapperStyle?.display || '',
+    wrapperVisibility: wrapperStyle?.visibility || ''
+  })
 }
 /**
  * 公众号导流插件（TechGrow）
@@ -88,15 +196,20 @@ const TechGrow = ({ lock } = {}) => {
   const yellowList = getFirstConfig(['TECH_GROW_YELLOW_LIST'], '')
   const jsUrl = getFirstConfig(['TECH_GROW_JS_URL'], DEFAULT_TECH_GROW_JS)
   const cssUrl = getFirstConfig(['TECH_GROW_CSS_URL'], DEFAULT_TECH_GROW_CSS)
-  const captchaTemplateUrl = getFirstConfig(
-    ['TECH_GROW_CAPTCHA_URL'],
-    DEFAULT_TECH_GROW_CAPTCHA_URL
-  )
-  const captchaGenerateUrl = resolveCaptchaGenerateUrl(captchaTemplateUrl, blogId)
   const baseUrl = getFirstConfig(['TECH_GROW_BASE_URL'], '')
+
+  // 调试开关（默认关闭，避免线上日志噪音与额外探测开销）
+  const debug = getFirstConfig(['TECH_GROW_DEBUG'], false)
+  // 是否允许移动端场景（如果配置不存在则默认允许，避免误拦截）
+  const allowMobile = getFirstConfig(['TECH_GROW_ALLOW_MOBILE'], true)
 
   // 登录信息
   const { isLoaded, isSignedIn } = useGlobal()
+
+  useEffect(() => {
+    installReadmoreNetworkProbe(debug)
+    installReadmoreAlertProbe(debug)
+  }, [debug])
 
   const waitForContentReady = () =>
     new Promise(resolve => {
@@ -123,8 +236,29 @@ const TechGrow = ({ lock } = {}) => {
     try {
       const isReady = await waitForContentReady()
       if (!isReady) {
-        console.warn(`Readmore 未找到内容容器: #${id}`)
+        if (debug) {
+          console.warn(`Readmore 未找到内容容器: #${id}`)
+          logReadmoreState(debug, id, 'content-not-ready')
+        }
         return
+      }
+      if (debug) {
+        console.log('[TechGrow][init]', {
+          id,
+          blogId,
+          name,
+          keyword,
+          height,
+          interval,
+          expires,
+          random,
+          lockToc,
+          tocSelector,
+          allowMobile,
+          jsUrl,
+          cssUrl,
+          hasBaseUrl: !!baseUrl
+        })
       }
       const target = document.getElementById(id)
       if (target) {
@@ -136,8 +270,14 @@ const TechGrow = ({ lock } = {}) => {
       }
       if (cssUrl) {
         await loadExternalResource(cssUrl, 'css')
+        if (debug) {
+          console.log(`[TechGrow][asset] css loaded: ${cssUrl}`)
+        }
       }
       await loadExternalResource(jsUrl, 'js')
+      if (debug) {
+        console.log(`[TechGrow][asset] js loaded: ${jsUrl}`)
+      }
       const ReadmorePlugin = window?.ReadmorePlugin
 
       if (ReadmorePlugin) {
@@ -159,16 +299,14 @@ const TechGrow = ({ lock } = {}) => {
           tocSelector,
           execute: 'yes',
           type: 'hexo',
-          baseUrl,
-          captchaUrl: captchaGenerateUrl,
-          generateCodeUrl: captchaGenerateUrl,
-          codeUrl: captchaGenerateUrl
+          ...(baseUrl ? { baseUrl } : {})
         })
 
         const fixReadmoreWrapperPosition = () => {
           const container = document.getElementById(id)
           const wrapper = getReadmoreWrapper()
           if (!container || !wrapper) {
+            logReadmoreState(debug, id, 'fix-skip-no-wrapper')
             return false
           }
 
@@ -188,6 +326,7 @@ const TechGrow = ({ lock } = {}) => {
             container.style.height = previewHeight
             container.style.overflow = 'hidden'
           }
+          logReadmoreState(debug, id, 'fix-wrapper-positioned')
           return true
         }
 

--- a/components/TechGrow.js
+++ b/components/TechGrow.js
@@ -41,6 +41,10 @@ const resolveCaptchaGenerateUrl = (url, blogId) => {
   const separator = url.includes('?') ? '&' : '?'
   return `${url}${separator}blogId=${blogId}`
 }
+
+const getReadmoreWrapper = () =>
+  document.getElementById('readmore-wrapper') ||
+  document.getElementById('read-more-wrap')
 /**
  * 公众号导流插件（TechGrow）
  * @returns
@@ -103,6 +107,14 @@ const TechGrow = () => {
         console.warn(`Readmore 未找到内容容器: #${id}`)
         return
       }
+      const target = document.getElementById(id)
+      if (target) {
+        const position = window.getComputedStyle(target).position
+        if (!position || position === 'static') {
+          // TechGrow 的 #readmore-wrapper 使用 absolute 定位，父容器需为 relative
+          target.style.position = 'relative'
+        }
+      }
       if (cssUrl) {
         await loadExternalResource(cssUrl, 'css')
       }
@@ -136,11 +148,11 @@ const TechGrow = () => {
 
         // btw初始化后，开始监听read-more-wrap何时消失
         const intervalId = setInterval(() => {
-          const readMoreWrapElement = document.getElementById('read-more-wrap')
+          const readMoreWrapElement = getReadmoreWrapper()
           const articleWrapElement = document.getElementById(id)
 
           if (!readMoreWrapElement && articleWrapElement) {
-            toggleTocItems(false) // 恢复目录项的点击
+            toggleTocItems(false, tocSelector) // 恢复目录项的点击
             // 自动调整文章区域的高度
             articleWrapElement.style.height = 'auto'
             // 停止定时器
@@ -190,7 +202,7 @@ const TechGrow = () => {
       toggleTocItems(true) // 禁止目录项的点击
 
       // 检查是否已加载
-      const readMoreWrap = document.getElementById('read-more-wrap')
+      const readMoreWrap = getReadmoreWrapper()
       if (!readMoreWrap) {
         loadReadmore()
       }

--- a/components/TechGrow.js
+++ b/components/TechGrow.js
@@ -45,6 +45,31 @@ const resolveCaptchaGenerateUrl = (url, blogId) => {
 const getReadmoreWrapper = () =>
   document.getElementById('readmore-wrapper') ||
   document.getElementById('read-more-wrap')
+
+const isReadmoreWrapperInactive = wrapper => {
+  if (!wrapper) {
+    return true
+  }
+  const style = window.getComputedStyle(wrapper)
+  return style.display === 'none' || style.visibility === 'hidden'
+}
+
+const normalizePreviewHeight = height => {
+  if (height === undefined || height === null || height === '') {
+    return null
+  }
+  if (typeof height === 'number') {
+    return `${height}px`
+  }
+  const raw = String(height).trim()
+  if (!raw) {
+    return null
+  }
+  if (raw.toLowerCase() === 'auto') {
+    return null
+  }
+  return /^\d+$/.test(raw) ? `${raw}px` : raw
+}
 /**
  * 公众号导流插件（TechGrow）
  * @returns
@@ -114,6 +139,12 @@ const TechGrow = () => {
           // TechGrow 的 #readmore-wrapper 使用 absolute 定位，父容器需为 relative
           target.style.position = 'relative'
         }
+        const previewHeight = normalizePreviewHeight(height)
+        if (previewHeight) {
+          // NotionNext 兜底：明确正文预览高度，防止按钮跑到页面末尾
+          target.style.height = previewHeight
+          target.style.overflow = 'hidden'
+        }
       }
       if (cssUrl) {
         await loadExternalResource(cssUrl, 'css')
@@ -146,15 +177,46 @@ const TechGrow = () => {
           codeUrl: captchaGenerateUrl
         })
 
+        const fixReadmoreWrapperPosition = () => {
+          const container = document.getElementById(id)
+          const wrapper = getReadmoreWrapper()
+          if (!container || !wrapper) {
+            return false
+          }
+
+          if (wrapper.parentElement !== container) {
+            container.appendChild(wrapper)
+          }
+
+          wrapper.style.position = 'absolute'
+          wrapper.style.left = '0'
+          wrapper.style.right = '0'
+          wrapper.style.bottom = '0'
+          wrapper.style.width = '100%'
+          wrapper.style.zIndex = '9999'
+          return true
+        }
+
+        // 插件在不同模式下创建 wrapper 的时机不同，分批兜底修正
+        ;[0, 150, 400, 900].forEach(delay => {
+          setTimeout(() => {
+            fixReadmoreWrapperPosition()
+          }, delay)
+        })
+
         // btw初始化后，开始监听read-more-wrap何时消失
         const intervalId = setInterval(() => {
           const readMoreWrapElement = getReadmoreWrapper()
           const articleWrapElement = document.getElementById(id)
 
-          if (!readMoreWrapElement && articleWrapElement) {
+          if (
+            isReadmoreWrapperInactive(readMoreWrapElement) &&
+            articleWrapElement
+          ) {
             toggleTocItems(false, tocSelector) // 恢复目录项的点击
             // 自动调整文章区域的高度
             articleWrapElement.style.height = 'auto'
+            articleWrapElement.style.overflow = 'visible'
             // 停止定时器
             clearInterval(intervalId)
           }
@@ -205,6 +267,13 @@ const TechGrow = () => {
       const readMoreWrap = getReadmoreWrapper()
       if (!readMoreWrap) {
         loadReadmore()
+      } else if (isReadmoreWrapperInactive(readMoreWrap)) {
+        toggleTocItems(false, tocSelector)
+        const articleWrapElement = document.getElementById(id)
+        if (articleWrapElement) {
+          articleWrapElement.style.height = 'auto'
+          articleWrapElement.style.overflow = 'visible'
+        }
       }
     }
   }, [isLoaded, router, id])

--- a/components/TechGrow.js
+++ b/components/TechGrow.js
@@ -46,14 +46,6 @@ const getReadmoreWrapper = () =>
   document.getElementById('readmore-wrapper') ||
   document.getElementById('read-more-wrap')
 
-const isReadmoreWrapperInactive = wrapper => {
-  if (!wrapper) {
-    return true
-  }
-  const style = window.getComputedStyle(wrapper)
-  return style.display === 'none' || style.visibility === 'hidden'
-}
-
 const normalizePreviewHeight = height => {
   if (height === undefined || height === null || height === '') {
     return null
@@ -74,7 +66,7 @@ const normalizePreviewHeight = height => {
  * 公众号导流插件（TechGrow）
  * @returns
  */
-const TechGrow = () => {
+const TechGrow = ({ lock } = {}) => {
   const router = useRouter()
   const qrcode = getFirstConfig(['TECH_GROW_QRCODE'], '请配置公众号二维码')
   const blogId = getFirstConfig(['TECH_GROW_BLOG_ID'])
@@ -109,7 +101,9 @@ const TechGrow = () => {
   const waitForContentReady = () =>
     new Promise(resolve => {
       let attempts = 0
-      const maxAttempts = 20
+      // Password 解锁后，内容容器子元素出现可能有延迟；
+      // 这里适当拉长轮询窗口以提升稳定性（避免“解锁后不再触发初始化”）。
+      const maxAttempts = 60
       const timer = setInterval(() => {
         const target = document.getElementById(id)
         if (target && target.childElementCount > 0) {
@@ -138,12 +132,6 @@ const TechGrow = () => {
         if (!position || position === 'static') {
           // TechGrow 的 #readmore-wrapper 使用 absolute 定位，父容器需为 relative
           target.style.position = 'relative'
-        }
-        const previewHeight = normalizePreviewHeight(height)
-        if (previewHeight) {
-          // NotionNext 兜底：明确正文预览高度，防止按钮跑到页面末尾
-          target.style.height = previewHeight
-          target.style.overflow = 'hidden'
         }
       }
       if (cssUrl) {
@@ -194,6 +182,12 @@ const TechGrow = () => {
           wrapper.style.bottom = '0'
           wrapper.style.width = '100%'
           wrapper.style.zIndex = '9999'
+          const previewHeight = normalizePreviewHeight(height)
+          if (previewHeight) {
+            // 只有在 readmore wrapper 已生成时才裁剪正文，避免误解锁
+            container.style.height = previewHeight
+            container.style.overflow = 'hidden'
+          }
           return true
         }
 
@@ -204,26 +198,7 @@ const TechGrow = () => {
           }, delay)
         })
 
-        // btw初始化后，开始监听read-more-wrap何时消失
-        const intervalId = setInterval(() => {
-          const readMoreWrapElement = getReadmoreWrapper()
-          const articleWrapElement = document.getElementById(id)
-
-          if (
-            isReadmoreWrapperInactive(readMoreWrapElement) &&
-            articleWrapElement
-          ) {
-            toggleTocItems(false, tocSelector) // 恢复目录项的点击
-            // 自动调整文章区域的高度
-            articleWrapElement.style.height = 'auto'
-            articleWrapElement.style.overflow = 'visible'
-            // 停止定时器
-            clearInterval(intervalId)
-          }
-        }, 1000) // 每秒检查一次
-
-        // Return cleanup function to clear the interval if the component unmounts
-        return () => clearInterval(intervalId)
+        return undefined
       } else {
         console.warn(`Readmore 插件加载成功但构造器不存在: ${jsUrl}`)
       }
@@ -260,25 +235,21 @@ const TechGrow = () => {
       return
     }
 
+    // 文章密码锁定时，页面内容容器可能暂时为空；
+    // 延后到锁状态解除后再尝试初始化，避免初始化失败后“不会再触发”。
+    if (lock) {
+      return
+    }
+
     if (isBrowser && blogId && !isSignedIn) {
       toggleTocItems(true) // 禁止目录项的点击
-
       // 检查是否已加载
       const readMoreWrap = getReadmoreWrapper()
       if (!readMoreWrap) {
         loadReadmore()
-      } else if (isReadmoreWrapperInactive(readMoreWrap)) {
-        toggleTocItems(false, tocSelector)
-        const articleWrapElement = document.getElementById(id)
-        if (articleWrapElement) {
-          articleWrapElement.style.height = 'auto'
-          articleWrapElement.style.overflow = 'visible'
-        }
       }
     }
-  }, [isLoaded, router, id])
-
-  // 启动一个监听器，当页面上存在#read-more-wrap对象时，所有的 a .catalog-item 对象都禁止点击
+  }, [isLoaded, router, id, lock])
 
   return <></>
 }
@@ -296,7 +267,6 @@ const toggleTocItems = disable => {
     }
   })
 }
-
 /**
  * 检查路径是否在名单中
  * @param {*} path 当前url的字符串
@@ -312,13 +282,32 @@ function isPathInList(path, listStr) {
     .replace(/\?.*$/, '') // 移除查询参数
     .replace(/.*\/([^/]+)(?:\.html)?$/, '$1') // 提取最后部分
 
-  const isInList = listStr.includes(processedPath)
+  // 兼容 config 里常见的多分隔符写法：逗号、换行、空白
+  const tokens = String(listStr)
+    .split(/[,\n\r\s]+/)
+    .map(t => t.trim())
+    .filter(Boolean)
 
-  if (isInList) {
-    // console.log(`当前路径在名单中: ${processedPath}`)
+  if (tokens.includes(processedPath)) {
+    return true
   }
 
-  return isInList
+  // 兼容带通配符（*）的配置：支持前缀/后缀匹配
+  return tokens.some(token => {
+    if (!token.includes('*')) {
+      return false
+    }
+    if (token.startsWith('*') && token.endsWith('*')) {
+      return processedPath.includes(token.slice(1, -1))
+    }
+    if (token.endsWith('*')) {
+      return processedPath.startsWith(token.slice(0, -1))
+    }
+    if (token.startsWith('*')) {
+      return processedPath.endsWith(token.slice(1))
+    }
+    return false
+  })
 }
 
 export default TechGrow

--- a/conf/techgrow.config.js
+++ b/conf/techgrow.config.js
@@ -5,19 +5,22 @@
  *   TECH_GROW_BLOG_ID / TECH_GROW_NAME / TECH_GROW_QRCODE / TECH_GROW_KEYWORD
  */
 module.exports = {
-  // 必填
+  // 必填 TechGrow后台生成的博客ID
   TECH_GROW_BLOG_ID:
     process.env.NEXT_PUBLIC_TECH_GROW_BLOG_ID ||
     process.env.TECH_GROW_BLOG_ID ||
     '',
+  // 必填 公众号名称
   TECH_GROW_NAME:
     process.env.NEXT_PUBLIC_TECH_GROW_NAME ||
     process.env.TECH_GROW_NAME ||
     '',
+  // 必填 公众号二维码
   TECH_GROW_QRCODE:
     process.env.NEXT_PUBLIC_TECH_GROW_QRCODE ||
     process.env.TECH_GROW_QRCODE ||
     '',
+  // 必填 公众号回复关键词
   TECH_GROW_KEYWORD:
     process.env.NEXT_PUBLIC_TECH_GROW_KEYWORD ||
     process.env.TECH_GROW_KEYWORD ||

--- a/conf/techgrow.config.js
+++ b/conf/techgrow.config.js
@@ -1,0 +1,62 @@
+/**
+ * 公众号导流插件（TechGrow）
+ * - 可在 Notion 的 Config 页面用“同名键”覆盖这里的值（Config 优先级更高）
+ * - 建议在 Config 页面至少配置以下四项：
+ *   TECH_GROW_BLOG_ID / TECH_GROW_NAME / TECH_GROW_QRCODE / TECH_GROW_KEYWORD
+ */
+module.exports = {
+  // 必填
+  TECH_GROW_BLOG_ID:
+    process.env.NEXT_PUBLIC_TECH_GROW_BLOG_ID ||
+    process.env.TECH_GROW_BLOG_ID ||
+    '',
+  TECH_GROW_NAME:
+    process.env.NEXT_PUBLIC_TECH_GROW_NAME ||
+    process.env.TECH_GROW_NAME ||
+    '',
+  TECH_GROW_QRCODE:
+    process.env.NEXT_PUBLIC_TECH_GROW_QRCODE ||
+    process.env.TECH_GROW_QRCODE ||
+    '',
+  TECH_GROW_KEYWORD:
+    process.env.NEXT_PUBLIC_TECH_GROW_KEYWORD ||
+    process.env.TECH_GROW_KEYWORD ||
+    '',
+
+  // 常用
+  TECH_GROW_BTN_TEXT:
+    process.env.NEXT_PUBLIC_TECH_GROW_BTN_TEXT ||
+    process.env.TECH_GROW_BTN_TEXT ||
+    '原创不易，完成人机检测，阅读全文',
+  TECH_GROW_VALIDITY_DURATION:
+    process.env.NEXT_PUBLIC_TECH_GROW_VALIDITY_DURATION ||
+    process.env.TECH_GROW_VALIDITY_DURATION ||
+    1,
+  TECH_GROW_WHITE_LIST:
+    process.env.NEXT_PUBLIC_TECH_GROW_WHITE_LIST ||
+    process.env.TECH_GROW_WHITE_LIST ||
+    '',
+  TECH_GROW_YELLOW_LIST:
+    process.env.NEXT_PUBLIC_TECH_GROW_YELLOW_LIST ||
+    process.env.TECH_GROW_YELLOW_LIST ||
+    '',
+
+  // 资源地址
+  TECH_GROW_JS_URL:
+    process.env.NEXT_PUBLIC_TECH_GROW_JS_URL ||
+    process.env.TECH_GROW_JS_URL ||
+    'https://qiniu.techgrow.cn/readmore/dist/readmore.js',
+  TECH_GROW_CSS_URL:
+    process.env.NEXT_PUBLIC_TECH_GROW_CSS_URL ||
+    process.env.TECH_GROW_CSS_URL ||
+    'https://qiniu.techgrow.cn/readmore/dist/hexo.css',
+  TECH_GROW_CAPTCHA_URL:
+    process.env.NEXT_PUBLIC_TECH_GROW_CAPTCHA_URL ||
+    process.env.TECH_GROW_CAPTCHA_URL ||
+    'https://open.techgrow.cn/#/readmore/captcha/generate?blogId=',
+  TECH_GROW_BASE_URL:
+    process.env.NEXT_PUBLIC_TECH_GROW_BASE_URL ||
+    process.env.TECH_GROW_BASE_URL ||
+    ''
+}
+

--- a/pages/[prefix]/index.js
+++ b/pages/[prefix]/index.js
@@ -92,7 +92,7 @@ const Slug = props => {
       {/* 解锁密码提示框 */}
       {post?.password && post?.password !== '' && !lock && <Notification />}
       {/* 导流工具 */}
-      <TechGrow />
+      <TechGrow lock={lock} />
     </>
   )
 }

--- a/pages/[prefix]/index.js
+++ b/pages/[prefix]/index.js
@@ -1,6 +1,6 @@
 import BLOG from '@/blog.config'
 import useNotification from '@/components/Notification'
-import OpenWrite from '@/components/OpenWrite'
+import TechGrow from '@/components/TechGrow'
 import { siteConfig } from '@/lib/config'
 import { fetchGlobalAllData, resolvePostProps } from '@/lib/db/SiteDataApi'
 import { useGlobal } from '@/lib/global'
@@ -92,7 +92,7 @@ const Slug = props => {
       {/* 解锁密码提示框 */}
       {post?.password && post?.password !== '' && !lock && <Notification />}
       {/* 导流工具 */}
-      <OpenWrite />
+      <TechGrow />
     </>
   )
 }


### PR DESCRIPTION
解锁后可重新初始化 Readmore（TechGrow 兼容加密文章）

components/TechGrow.js 增加 lock 入参：当文章处于密码锁定状态时跳过初始化，解锁后会自动再次尝试初始化，避免出现“解锁后不再触发”的情况。
将 waitForContentReady() 的轮询窗口适当延长（密码解锁后 DOM 渲染可能有延迟），提升加载稳定性。
白名单/黄名单改为 token 级精确匹配（避免子串误命中）

TECH_GROW_WHITE_LIST / TECH_GROW_YELLOW_LIST 按 逗号、换行、空白切分为 tokens 做匹配，避免 listStr.includes() 带来的“包含子串误命中”问题。
仍保留 * 通配符兼容能力（用于前缀/后缀匹配）。
挂载层级保持覆盖完整

TechGrow 注入在 pages/[prefix]/index.js 的 Slug 组件中；[prefix]/[slug] 与更深层级页面复用该 Slug，因此不需要额外重复挂载多层路由文件。
配置更易维护：把 TECH_GROW_ 从 blog.config.js 移到子配置*

新增 conf/techgrow.config.js 承载 TECH_GROW_* 配置。
blog.config.js 使用 ...require('./conf/techgrow.config') 引入（key 名称不变，因此 Notion Config 页的同名键覆盖逻辑保持兼容）。
验证方式
在启用 TechGrow 配置的前提下，选择一篇 带 password 的文章：
打开页面应先进入锁定状态，Readmore 初始化行为不会在锁定时触发。
输入正确密码解锁后，确认 Readmore 能正确加载/包裹内容，且黄名单/白名单的拦截逻辑符合配置预期。
验证白/黄名单：
使用会触发“子串误命中”的路径配置对比，确认现在不会再误拦截。
（补充：如果你用 next dev 调试时发现 Readmore 不工作，这是当前组件对开发环境的默认屏蔽逻辑导致的；建议用生产模式启动或开启 debug 配置以调试。)

需要我再把这段内容按你们仓库的 PR 模板（比如必须包含 Test plan/Screenshots 等）调整成完全同款格式吗？