### PR TITLE
feat: 新增全局置顶标签排序（仅重排置顶子集，按最近更新时间倒序）

### DIFF
--- a/__tests__/lib/utils/sortPinnedPostsByLatestUpdate.test.js
+++ b/__tests__/lib/utils/sortPinnedPostsByLatestUpdate.test.js
@@ -1,0 +1,56 @@
+import { sortPinnedPostsByLatestUpdate } from '@/lib/utils/pinnedPosts'
+
+describe('sortPinnedPostsByLatestUpdate', () => {
+  it('returns original array when topTag is falsy', () => {
+    const posts = [
+      { id: 'a', tags: ['top'], lastEditedDate: '2024-01-01' }
+    ]
+    const res = sortPinnedPostsByLatestUpdate(posts, '')
+    expect(res).toBe(posts)
+  })
+
+  it('does not change non-pinned indices; only reorders pinned subset by lastEditedDate desc', () => {
+    const posts = [
+      { id: 'A', tags: ['x'], lastEditedDate: '2024-01-01' },
+      { id: 'P1', tags: ['top'], lastEditedDate: '2024-01-02' },
+      { id: 'B', tags: ['x'], lastEditedDate: '2024-02-01' },
+      { id: 'P2', tags: ['top'], lastEditedDate: '2024-03-01' },
+      { id: 'C', tags: ['x'], lastEditedDate: '2024-01-03' }
+    ]
+
+    const res = sortPinnedPostsByLatestUpdate(posts, 'top')
+    const ids = res.map(p => p.id)
+
+    // pinned slots are indices [1,3]; after sort, newer pinned should appear at index 1
+    expect(ids).toEqual(['A', 'P2', 'B', 'P1', 'C'])
+    // verify normal posts keep their original indices
+    expect(res[2].id).toBe('B')
+    expect(res[4].id).toBe('C')
+  })
+
+  it('keeps pinned relative order when lastEditedDate is equal (stable)', () => {
+    const posts = [
+      { id: 'A', tags: ['x'], lastEditedDate: '2024-01-01' },
+      { id: 'P1', tags: ['top'], lastEditedDate: '2024-01-02' },
+      { id: 'B', tags: ['x'], lastEditedDate: '2024-02-01' },
+      { id: 'P2', tags: ['top'], lastEditedDate: '2024-01-02' },
+      { id: 'C', tags: ['x'], lastEditedDate: '2024-01-03' }
+    ]
+
+    const res = sortPinnedPostsByLatestUpdate(posts, 'top')
+    const ids = res.map(p => p.id)
+    // stable: P1 stays before P2 in the pinned slots [1,3]
+    expect(ids).toEqual(['A', 'P1', 'B', 'P2', 'C'])
+  })
+
+  it('returns original array when pinned count <= 1', () => {
+    const posts = [
+      { id: 'A', tags: ['x'], lastEditedDate: '2024-01-01' },
+      { id: 'P1', tags: ['top'], lastEditedDate: '2024-01-02' },
+      { id: 'B', tags: ['x'], lastEditedDate: '2024-02-01' }
+    ]
+    const res = sortPinnedPostsByLatestUpdate(posts, 'top')
+    expect(res).toBe(posts)
+  })
+})
+

--- a/blog.config.js
+++ b/blog.config.js
@@ -42,6 +42,7 @@ const BLOG = {
   ...require('./conf/ad.config'), // 广告营收插件
   ...require('./conf/plugin.config'), // 其他第三方插件 algolia全文索引
   ...require('./conf/performance.config'), // 性能优化配置
+  ...require('./conf/top-tag.config'), // 置顶文章全局配置
 
   // 高级用法
   ...require('./conf/layout-map.config'), // 路由与布局映射自定义，例如自定义特定路由的页面布局

--- a/conf/top-tag.config.js
+++ b/conf/top-tag.config.js
@@ -1,0 +1,15 @@
+/**
+ * 全局置顶配置
+ *
+ * 使用方式：
+ * - 在 Notion 的 Config 页填写 `TOP_TAG`（同名覆盖）
+ * - 或在环境变量中设置 `NEXT_PUBLIC_TOP_TAG` / `TOP_TAG`
+ *
+ * 开启后：
+ * - 仅当存在多个置顶文章时，才按最近更新时间倒序排序置顶子集
+ * - 其它非置顶文章的相对顺序不变
+ */
+module.exports = {
+  TOP_TAG: process.env.NEXT_PUBLIC_TOP_TAG || process.env.TOP_TAG || ''
+}
+

--- a/lib/db/SiteDataApi.js
+++ b/lib/db/SiteDataApi.js
@@ -26,6 +26,7 @@ import {
 import { fetchPageFromNotion } from './notion/getNotionPost'
 import { processPostData } from '../utils/post'
 import { adapterNotionBlockMap } from '../utils/notion.util'
+import { sortPinnedPostsByLatestUpdate } from '@/lib/utils/pinnedPosts'
 // import pLimit from 'p-limit'
 
 export { getAllTags } from './notion/getAllTags'
@@ -374,13 +375,20 @@ async function convertNotionToSiteData(
   // ── 筛选有效页面、排序 ──
   // const stepStart10 = Date.now()
   let postCount = 0
-  const allPages = collectionData.filter(post => {
+  let allPages = collectionData.filter(post => {
     if (post?.type === 'Post' && post.status === 'Published') postCount++
     return post?.slug && (post?.status === 'Invisible' || post?.status === 'Published')
   })
   const sortBy = siteConfig('POSTS_SORT_BY', null, NOTION_CONFIG)
   if (sortBy === 'date') {
     allPages.sort((a, b) => (b?.publishDate ?? 0) - (a?.publishDate ?? 0))
+  }
+
+  // 全局置顶：仅当开启 TOP_TAG 时，才对置顶子集做“最新更新时间倒序”重排。
+  // 非置顶文章的相对顺序尽量不改变（匹配你确认的 A 行为）。
+  const topTag = siteConfig('TOP_TAG', '', NOTION_CONFIG)
+  if (topTag) {
+    allPages = sortPinnedPostsByLatestUpdate(allPages, topTag)
   }
   // const stepEnd10 = Date.now()
   // console.log(`[${traceId}] ⏱ 筛选 + 排序 allPages 耗时: ${stepEnd10 - stepStart10}ms @ ${new Date().toISOString()}`)

--- a/lib/utils/pinnedPosts.js
+++ b/lib/utils/pinnedPosts.js
@@ -1,0 +1,62 @@
+/**
+ * 全局置顶排序工具（纯函数，无依赖主题/配置，便于测试）
+ *
+ * 规则（与你确认的 A 一致）：
+ * - 开启 topTag（topTag 非空）才生效
+ * - 只重排“置顶文章”子集
+ * - “非置顶文章”的索引位置不变（尽量保持原排序不动）
+ * - 置顶文章按 lastEditedDate（兜底 publishDate）倒序；相同时间保持稳定（原相对顺序）
+ */
+
+function getPostLatestTime(post) {
+  // lastEditedDate：getPageProperties 里基于 notion last_edited_time 生成
+  if (post?.lastEditedDate) {
+    return post.lastEditedDate
+  }
+  // publishDate：兜底保证不会出现 NaN
+  if (post?.publishDate) {
+    return post.publishDate
+  }
+  return 0
+}
+
+export function sortPinnedPostsByLatestUpdate(posts, topTag) {
+  if (!Array.isArray(posts) || !topTag) {
+    return posts
+  }
+
+  const pinnedSlots = []
+  const pinned = []
+  for (let i = 0; i < posts.length; i++) {
+    const p = posts[i]
+    const tags = Array.isArray(p?.tags) ? p.tags : []
+    if (tags.includes(topTag)) {
+      pinnedSlots.push(i)
+      pinned.push({ post: p, idx: i })
+    }
+  }
+
+  if (pinned.length <= 1) {
+    // 0 或 1 个置顶：不改变顺序，避免无谓数组重排
+    return posts
+  }
+
+  pinned.sort((a, b) => {
+    const timeA = new Date(getPostLatestTime(a.post)).getTime()
+    const timeB = new Date(getPostLatestTime(b.post)).getTime()
+    if (timeB !== timeA) {
+      return timeB - timeA
+    }
+    // 稳定：相同时间保持原相对顺序
+    return a.idx - b.idx
+  })
+
+  // 关键：只重排置顶文章“自身在原列表中的索引位置”，不移动非置顶文章索引
+  const result = [...posts]
+  pinnedSlots.sort((a, b) => a - b) // 升序：保证最靠前的置顶槽位会拿到最新的置顶文章
+  for (let i = 0; i < pinned.length; i++) {
+    result[pinnedSlots[i]] = pinned[i].post
+  }
+  return result
+}
+

--- a/pages/category/[category]/index.js
+++ b/pages/category/[category]/index.js
@@ -25,6 +25,7 @@ export async function getStaticProps({ params: { category }, locale }) {
   props.posts = props.posts.filter(
     post => post && post.category && post.category.includes(category)
   )
+
   // 处理文章页数
   props.postCount = props.posts.length
   // 处理分页


### PR DESCRIPTION
## 相关 PR

- [#3548](https://github.com/tangly1024/NotionNext/pull/3548)：社区曾提议「NEXT 主题专用置顶标签」等方案；本 PR 采用**全局 `TOP_TAG` + 数据层一次处理**，不引入主题单独配置，与上述讨论方向一致的可合并部分已由本实现覆盖。
- [#4004](https://github.com/tangly1024/NotionNext/pull/4004)：曾探索在列表页或更强「整段 Post 前移」的补充排序；经讨论后**不再推进**，以本 PR 的「最小扰动」策略为准（见下文行为说明）。

---

## 背景

此前「置顶标签」能力分散在主题或页面层时，改动面大，且容易遗漏分页、分类、搜索等路由。

本 PR 将置顶排序**统一下沉到服务端数据层**（`SiteDataApi`），一次处理、全局复用，**适用于所有主题**。

## 目标

- 支持全局配置置顶标签：`TOP_TAG`。
- 当存在**多篇**置顶文章时，**仅对置顶子集**按「最近更新时间」倒序。
- **非置顶文章**保持原有相对顺序（不打乱既有 `POSTS_SORT_BY` 等策略下的顺序）。

## 主要改动

### 全局配置

- 新增 `conf/top-tag.config.js`：配置项 `TOP_TAG`（支持环境变量 `NEXT_PUBLIC_TOP_TAG` / `TOP_TAG`）。
- 在 `blog.config.js` 中合并该子配置。

### 纯函数排序

- 新增 `lib/utils/pinnedPosts.js`，提供 `sortPinnedPostsByLatestUpdate(posts, topTag)`：
  - `topTag` 为空时返回原数组；
  - 置顶数量 ≤ 1 时不重排；
  - 置顶子集按 `lastEditedDate`（兜底 `publishDate`）倒序，同时间戳保持稳定顺序；
  - **非置顶文章在原数组中的下标位置不变**。

### 数据层接入

- 在 `lib/db/SiteDataApi.js` 的 `convertNotionToSiteData` 阶段，对 `allPages` 应用上述置顶子集重排，由数据层统一产出顺序，**页面层无需重复逻辑**。

### 测试

- 新增 `__tests__/lib/utils/sortPinnedPostsByLatestUpdate.test.js`，覆盖：`topTag` 为空、多置顶按更新时间倒序、同时间稳定性、置顶数量 ≤ 1 不重排。

## 行为说明（重要）

本 PR 采用 **「最小扰动」** 策略：

- 只重排**命中 `TOP_TAG` 的置顶子集**；非置顶文章相对顺序不变。
- 不改变全局排序的既有语义（例如 `POSTS_SORT_BY`）。

> 说明：该策略**不会**把置顶文从全表很靠后的位置「整体挪到站点第一页列表最前」；若将来需要那种强语义，需另开 issue/PR 讨论，并与本策略的关系写清楚。

## 使用方式

在 Notion Config 或环境变量中设置，例如：

```text
TOP_TAG=top
```

未设置 `TOP_TAG` 时，不启用本功能。

## 验证

- 改动文件通过 ESLint。
- `npx jest __tests__/lib/utils/sortPinnedPostsByLatestUpdate.test.js --runInBand` 通过。
