### PR TITLE
fix(fuwari): 优化移动端顶栏布局并新增目录悬浮抽屉

### DIFF
--- a/themes/fuwari/components/Header.js
+++ b/themes/fuwari/components/Header.js
@@ -34,8 +34,8 @@ const Header = ({ locale, customNav, customMenu, searchModal }) => {
 
   return (
     <header className='max-w-6xl mx-auto px-4 pt-0 pb-3 sticky top-0 z-40'>
-      <div className='fuwari-card fuwari-navbar px-4 py-2.5 grid grid-cols-[1fr_auto_1fr] items-center'>
-        <SmartLink href='/' className='text-[1.45rem] font-bold fuwari-title-gradient'>
+      <div className='fuwari-card fuwari-navbar px-4 py-2.5 flex items-center justify-between md:grid md:grid-cols-[1fr_auto_1fr]'>
+        <SmartLink href='/' className='text-[1.35rem] md:text-[1.45rem] font-bold fuwari-title-gradient text-left'>
           {siteConfig('TITLE')}
         </SmartLink>
         <MenuList locale={locale} customNav={customNav} customMenu={customMenu} />
@@ -60,14 +60,27 @@ const Header = ({ locale, customNav, customMenu, searchModal }) => {
             </div>
           )}
         </div>
-        <div className='md:hidden flex items-center justify-end gap-2'>
+        <div className='md:hidden flex items-center justify-end gap-2 relative'>
           <button type='button' onClick={handleSearch} className='fuwari-tool-btn'>
             <i className='fas fa-search' />
           </button>
+          {!paletteFixed && (
+            <button
+              type='button'
+              onClick={() => setShowPalette(v => !v)}
+              className='fuwari-tool-btn'>
+              <i className='fas fa-palette' />
+            </button>
+          )}
           <button type='button' onClick={toggleDarkMode} className='fuwari-tool-btn'>
             {isDarkMode ? '☀' : '☾'}
           </button>
           <MobileNav locale={locale} customNav={customNav} customMenu={customMenu} />
+          {showPalette && !paletteFixed && (
+            <div ref={panelRef} className='fuwari-card absolute right-0 top-12 p-0 w-72 z-50'>
+              <ThemeColorSwitch />
+            </div>
+          )}
         </div>
       </div>
     </header>

--- a/themes/fuwari/components/RightFloatArea.js
+++ b/themes/fuwari/components/RightFloatArea.js
@@ -2,10 +2,13 @@ import { useEffect, useState } from 'react'
 import { siteConfig } from '@/lib/config'
 import { useGlobal } from '@/lib/global'
 import CONFIG from '../config'
+import Toc from './Toc'
 
 const RightFloatArea = ({ post }) => {
   const [visible, setVisible] = useState(false)
+  const [showTocDrawer, setShowTocDrawer] = useState(false)
   const { isDarkMode, toggleDarkMode } = useGlobal()
+  const hasToc = Boolean(post?.toc && post.toc.length > 1)
 
   useEffect(() => {
     const onScroll = () => setVisible(window.scrollY > 180)
@@ -17,23 +20,51 @@ const RightFloatArea = ({ post }) => {
   if (!visible) return null
 
   return (
-    <div className='fuwari-float-wrap fixed z-30 flex flex-col gap-2'>
-      <button className='fuwari-float-btn' onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}>
-        <i className='fas fa-angle-up' />
-      </button>
-      {post && siteConfig('FUWARI_WIDGET_TO_COMMENT', true, CONFIG) && (
-        <button
-          className='fuwari-float-btn'
-          onClick={() => document.getElementById('comment')?.scrollIntoView({ behavior: 'smooth' })}>
-          <i className='far fa-comment-dots' />
-        </button>
+    <>
+      {showTocDrawer && hasToc && (
+        <div className='fuwari-toc-mobile lg:hidden'>
+          <div className='fuwari-toc-mask' onClick={() => setShowTocDrawer(false)} />
+          <section className='fuwari-card fuwari-toc-panel p-4'>
+            <div className='flex items-center justify-between mb-2'>
+              <h3 className='text-sm font-semibold tracking-wide uppercase text-[var(--fuwari-muted)]'>
+                目录
+              </h3>
+              <button
+                type='button'
+                className='fuwari-tool-btn'
+                onClick={() => setShowTocDrawer(false)}>
+                <i className='fas fa-times' />
+              </button>
+            </div>
+            <Toc toc={post.toc} />
+          </section>
+        </div>
       )}
-      {siteConfig('FUWARI_WIDGET_DARK_MODE', true, CONFIG) && (
-        <button className='fuwari-float-btn' onClick={toggleDarkMode}>
-          {isDarkMode ? '☀' : '☾'}
+      <div className='fuwari-float-wrap fixed z-30 flex flex-col gap-2'>
+        <button className='fuwari-float-btn' onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}>
+          <i className='fas fa-angle-up' />
         </button>
-      )}
-    </div>
+        {hasToc && (
+          <button
+            className='fuwari-float-btn lg:hidden'
+            onClick={() => setShowTocDrawer(true)}>
+            <i className='fas fa-list-ul' />
+          </button>
+        )}
+        {post && siteConfig('FUWARI_WIDGET_TO_COMMENT', true, CONFIG) && (
+          <button
+            className='fuwari-float-btn'
+            onClick={() => document.getElementById('comment')?.scrollIntoView({ behavior: 'smooth' })}>
+            <i className='far fa-comment-dots' />
+          </button>
+        )}
+        {siteConfig('FUWARI_WIDGET_DARK_MODE', true, CONFIG) && (
+          <button className='fuwari-float-btn' onClick={toggleDarkMode}>
+            {isDarkMode ? '☀' : '☾'}
+          </button>
+        )}
+      </div>
+    </>
   )
 }
 

--- a/themes/fuwari/style.js
+++ b/themes/fuwari/style.js
@@ -427,6 +427,25 @@ const Style = () => {
       right: max(1rem, calc((100vw - 72rem) / 2 - 2.8rem));
       bottom: 1.15rem;
     }
+    #theme-fuwari .fuwari-toc-mobile {
+      position: fixed;
+      inset: 0;
+      z-index: 60;
+    }
+    #theme-fuwari .fuwari-toc-mask {
+      position: absolute;
+      inset: 0;
+      background: rgba(15, 23, 42, .32);
+      backdrop-filter: blur(1.5px);
+    }
+    #theme-fuwari .fuwari-toc-panel {
+      position: absolute;
+      right: .8rem;
+      bottom: 4.35rem;
+      width: min(21rem, calc(100vw - 1.6rem));
+      max-height: 58vh;
+      overflow: hidden;
+    }
     @media (max-width: 1280px) {
       #theme-fuwari .fuwari-float-wrap {
         right: 1.05rem;


### PR DESCRIPTION
## Summary
本 PR 仅包含最近两次提交的移动端优化：

1. 移动端顶栏布局优化
- Logo 文本左对齐
- 功能按钮组（搜索/选色/明暗/菜单）右对齐
- 当 `FUWARI_THEME_COLOR_FIXED=false` 时，在移动端显示选色按钮

2. 移动端目录交互增强
- 在文章页且存在 TOC 时，显示目录悬浮按钮
- 点击按钮弹出目录抽屉
- 支持点击遮罩或关闭按钮收起抽屉
- 桌面端目录行为保持不变

## Files Changed
- `themes/fuwari/components/Header.js`
- `themes/fuwari/components/RightFloatArea.js`
- `themes/fuwari/style.js`

## Test Plan
- [ ] 移动端打开首页，确认 Logo 左对齐、功能按钮右对齐
- [ ] 移动端确认选色按钮按配置显示（`FUWARI_THEME_COLOR_FIXED=false` 可见）
- [ ] 打开有目录的文章页，确认右下目录悬浮按钮出现
- [ ] 点击目录按钮可弹出目录抽屉，点击遮罩/关闭按钮可收起
- [ ] 桌面端目录与顶栏行为无回归