### PR TITLE
fix(fuwari): 修复二级菜单交互并优化归档跳转参数继承

### DIFF
--- a/themes/fuwari/components/ArticleHeader.js
+++ b/themes/fuwari/components/ArticleHeader.js
@@ -1,18 +1,35 @@
 import SmartLink from '@/components/SmartLink'
 import { siteConfig } from '@/lib/config'
+import { useRouter } from 'next/router'
 import CONFIG from '../config'
 
-const getArchiveHref = publishDay => {
-  if (!publishDay) return '/archive'
+const getCurrentSearchQuery = router => {
+  const queryString = router?.asPath?.split('?')[1]?.split('#')[0] || ''
+  const params = new URLSearchParams(queryString)
+  const query = {}
+  params.forEach((value, key) => {
+    query[key] = value
+  })
+  return query
+}
+
+const getArchiveHref = (publishDay, router) => {
+  const query = getCurrentSearchQuery(router)
+  if (!publishDay) return { pathname: '/archive', query }
   const str = String(publishDay)
   const matched = str.match(/^(\d{4})[-/.](\d{1,2})/)
-  if (!matched) return '/archive'
+  if (!matched) return { pathname: '/archive', query }
   const year = matched[1]
   const month = matched[2].padStart(2, '0')
-  return `/archive#archive-${year}-${month}`
+  return {
+    pathname: '/archive',
+    query,
+    hash: `archive-${year}-${month}`
+  }
 }
 
 const ArticleHeader = ({ post }) => {
+  const router = useRouter()
   if (!post) return null
 
   return (
@@ -20,11 +37,11 @@ const ArticleHeader = ({ post }) => {
       <h1 className='text-3xl lg:text-4xl font-bold mb-3 leading-tight'>{post.title}</h1>
       {siteConfig('FUWARI_ARTICLE_META', true, CONFIG) && (
         <div className='text-sm text-[var(--fuwari-muted)] flex flex-wrap items-center gap-2'>
-          <SmartLink href={getArchiveHref(post.publishDay)} className='fuwari-link'>{post.publishDay}</SmartLink>
+          <SmartLink href={getArchiveHref(post.publishDay, router)} className='fuwari-link'>{post.publishDay}</SmartLink>
           {post.lastEditedDay && (
             <>
               <span>·</span>
-              <SmartLink href={getArchiveHref(post.lastEditedDay)} className='fuwari-link'>{post.lastEditedDay}</SmartLink>
+              <SmartLink href={getArchiveHref(post.lastEditedDay, router)} className='fuwari-link'>{post.lastEditedDay}</SmartLink>
             </>
           )}
           {post.category && (

--- a/themes/fuwari/components/MenuList.js
+++ b/themes/fuwari/components/MenuList.js
@@ -1,26 +1,69 @@
 import SmartLink from '@/components/SmartLink'
+import { useState } from 'react'
 import { getFuwariMenuLinks } from './menu'
 
 const MenuList = ({ locale, customNav, customMenu, mobile = false }) => {
+  const [activeId, setActiveId] = useState(null)
   const links = getFuwariMenuLinks({ locale, customNav, customMenu })
   if (!links.length) return null
 
   const displayLinks = mobile ? links.slice(0, 4) : links
 
+  if (mobile) {
+    return (
+      <nav className='flex items-center justify-between text-sm text-[var(--fuwari-muted)]'>
+        {displayLinks.map((link, index) => (
+          <SmartLink
+            key={link.id || `${link.href}-${index}`}
+            href={link.href || '/'}
+            className='px-3 py-1.5 rounded-lg font-semibold hover:bg-[var(--fuwari-bg-soft)]'>
+            {link.name || link.title}
+          </SmartLink>
+        ))}
+      </nav>
+    )
+  }
+
   return (
-    <nav
-      className={
-        mobile
-          ? 'flex items-center justify-between text-sm text-[var(--fuwari-muted)]'
-          : 'hidden md:flex items-center justify-center gap-0.5 text-[13px] text-[var(--fuwari-muted)]'
-      }>
+    <nav className='hidden md:flex items-center justify-center gap-0.5 text-[13px] text-[var(--fuwari-muted)]'>
       {displayLinks.map((link, index) => (
-        <SmartLink
+        <div
           key={link.id || `${link.href}-${index}`}
-          href={link.href}
-          className='px-3 py-1.5 rounded-lg font-semibold hover:bg-[var(--fuwari-bg-soft)]'>
-          {link.name || link.title}
-        </SmartLink>
+          className='relative'
+          onMouseEnter={() => setActiveId(link.id)}
+          onMouseLeave={() => setActiveId(null)}>
+          {!link.subMenus?.length && link.href ? (
+            <SmartLink
+              href={link.href}
+              className='px-3 py-1.5 rounded-lg font-semibold hover:bg-[var(--fuwari-bg-soft)]'>
+              {link.name || link.title}
+            </SmartLink>
+          ) : (
+            <div className='px-3 py-1.5 rounded-lg font-semibold hover:bg-[var(--fuwari-bg-soft)] cursor-default select-none'>
+              {link.name || link.title}
+              {!!link.subMenus?.length && <i className='fas fa-angle-down ml-1 text-xs' />}
+            </div>
+          )}
+
+          {!!link.subMenus?.length && (
+            <ul
+              onMouseEnter={() => setActiveId(link.id)}
+              onMouseLeave={() => setActiveId(null)}
+              className={`${activeId === link.id ? 'visible opacity-100 translate-y-0 pointer-events-auto' : 'invisible opacity-0 -translate-y-1 pointer-events-none'} absolute left-0 top-10 min-w-[10rem] fuwari-card p-1.5 transition-all duration-200 z-40`}>
+              <div className='absolute -top-2 left-0 w-full h-2' />
+              {link.subMenus.map(sub => (
+                <li key={sub.id || sub.href}>
+                  <SmartLink
+                    href={sub.href}
+                    target={sub.target}
+                    className='block px-3 py-1.5 rounded-md hover:bg-[var(--fuwari-bg-soft)] text-[13px] text-[var(--fuwari-text)]'>
+                    {sub.name}
+                  </SmartLink>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
       ))}
     </nav>
   )

--- a/themes/fuwari/components/MobileNav.js
+++ b/themes/fuwari/components/MobileNav.js
@@ -6,6 +6,7 @@ import { getFuwariMenuLinks } from './menu'
 
 const MobileNav = ({ locale, customNav, customMenu }) => {
   const [open, setOpen] = useState(false)
+  const [openSub, setOpenSub] = useState('')
   const panelRef = useRef(null)
   if (!siteConfig('FUWARI_MOBILE_MENU', true, CONFIG)) return null
 
@@ -35,13 +36,44 @@ const MobileNav = ({ locale, customNav, customMenu }) => {
         <div className='fuwari-card absolute right-0 top-11 min-w-[9rem] p-2 z-50'>
           <nav className='flex flex-col text-sm text-[var(--fuwari-muted)]'>
             {links.map((link, index) => (
-              <SmartLink
-                key={link.id || `${link.href}-${index}`}
-                href={link.href}
-                className='px-3 py-2 rounded-lg font-semibold hover:bg-[var(--fuwari-bg-soft)]'
-                onClick={() => setOpen(false)}>
-                {link.name || link.title}
-              </SmartLink>
+              <div key={link.id || `${link.href}-${index}`}>
+                <div className='flex items-center'>
+                  {!link.subMenus?.length && link.href ? (
+                    <SmartLink
+                      href={link.href}
+                      className='flex-1 px-3 py-2 rounded-lg font-semibold hover:bg-[var(--fuwari-bg-soft)]'
+                      onClick={() => setOpen(false)}>
+                      {link.name || link.title}
+                    </SmartLink>
+                  ) : (
+                    <span className='flex-1 px-3 py-2 rounded-lg font-semibold cursor-default select-none'>
+                      {link.name || link.title}
+                    </span>
+                  )}
+                  {!!link.subMenus?.length && (
+                    <button
+                      type='button'
+                      className='px-2 py-2 text-xs'
+                      onClick={() => setOpenSub(prev => (prev === link.id ? '' : link.id))}>
+                      <i className={`fas ${openSub === link.id ? 'fa-angle-up' : 'fa-angle-down'}`} />
+                    </button>
+                  )}
+                </div>
+                {!!link.subMenus?.length && openSub === link.id && (
+                  <div className='pl-3 pb-1'>
+                    {link.subMenus.map(sub => (
+                      <SmartLink
+                        key={sub.id || sub.href}
+                        href={sub.href}
+                        target={sub.target}
+                        className='block px-3 py-1.5 rounded-md text-xs hover:bg-[var(--fuwari-bg-soft)]'
+                        onClick={() => setOpen(false)}>
+                        {sub.name}
+                      </SmartLink>
+                    ))}
+                  </div>
+                )}
+              </div>
             ))}
           </nav>
         </div>

--- a/themes/fuwari/components/PostList.js
+++ b/themes/fuwari/components/PostList.js
@@ -1,19 +1,36 @@
 import SmartLink from '@/components/SmartLink'
 import { siteConfig } from '@/lib/config'
+import { useRouter } from 'next/router'
 import { useState } from 'react'
 import CONFIG from '../config'
 
-const getArchiveHref = publishDay => {
-  if (!publishDay) return '/archive'
+const getCurrentSearchQuery = router => {
+  const queryString = router?.asPath?.split('?')[1]?.split('#')[0] || ''
+  const params = new URLSearchParams(queryString)
+  const query = {}
+  params.forEach((value, key) => {
+    query[key] = value
+  })
+  return query
+}
+
+const getArchiveHref = (publishDay, router) => {
+  const query = getCurrentSearchQuery(router)
+  if (!publishDay) return { pathname: '/archive', query }
   const str = String(publishDay)
   const matched = str.match(/^(\d{4})[-/.](\d{1,2})/)
-  if (!matched) return '/archive'
+  if (!matched) return { pathname: '/archive', query }
   const year = matched[1]
   const month = matched[2].padStart(2, '0')
-  return `/archive#archive-${year}-${month}`
+  return {
+    pathname: '/archive',
+    query,
+    hash: `archive-${year}-${month}`
+  }
 }
 
 const PostCard = ({ post }) => {
+  const router = useRouter()
   const coverSrc =
     post.pageCoverThumbnail ||
     (siteConfig('FUWARI_POST_LIST_COVER_DEFAULT', true, CONFIG) &&
@@ -37,7 +54,7 @@ const PostCard = ({ post }) => {
             </SmartLink>
           </h2>
           <div className='fuwari-meta-row mb-2.5'>
-            <SmartLink href={getArchiveHref(post.publishDay)} className='fuwari-meta-item'>
+            <SmartLink href={getArchiveHref(post.publishDay, router)} className='fuwari-meta-item'>
               <i className='far fa-calendar-alt fuwari-meta-icon' />
               <span className='fuwari-meta-text'>{post.publishDay}</span>
             </SmartLink>

--- a/themes/fuwari/components/menu.js
+++ b/themes/fuwari/components/menu.js
@@ -1,6 +1,34 @@
 import { siteConfig } from '@/lib/config'
 import CONFIG from '../config'
 
+const normalizeSubMenus = subMenus =>
+  (Array.isArray(subMenus) ? subMenus : [])
+    .map((item, index) => {
+      if (!item) return null
+      return {
+        id: item.id || `sub-${index}`,
+        name: item.name || item.title || item.label || '',
+        href: item.href || item.url || '',
+        target: item.target
+      }
+    })
+    .filter(item => item && item.name && item.href)
+
+const normalizeMenu = links =>
+  (Array.isArray(links) ? links : [])
+    .map((link, index) => {
+      if (!link) return null
+      const subMenus = normalizeSubMenus(link.subMenus || link.children)
+      return {
+        ...link,
+        id: link.id || `menu-${index}`,
+        name: link.name || link.title || link.label || '',
+        href: link.href || link.url || '',
+        subMenus
+      }
+    })
+    .filter(link => link && link.show !== false && (link.href || link.subMenus?.length))
+
 export function getFuwariMenuLinks({ locale, customNav, customMenu }) {
   let links = [
     {
@@ -44,6 +72,6 @@ export function getFuwariMenuLinks({ locale, customNav, customMenu }) {
     links = customMenu
   }
 
-  return links.filter(link => link && link.show !== false && link.href)
+  return normalizeMenu(links)
 }
 


### PR DESCRIPTION
## Summary
本 PR 主要修复 fuwari 主题近期两个交互问题：

1. 二级菜单不生效/悬停消失问题
- 统一标准化 `customMenu` 数据结构（兼容 `children` / `subMenus`）
- 桌面端支持 hover 下拉，修复鼠标从父级移动到子菜单时“半路消失”
- 父级菜单若包含子菜单，父级本身改为不可点击（仅作为分组入口）
- 移动端支持子菜单折叠展开

2. 文章发布日期跳归档参数丢失问题
- 日期跳转改为 router 对象式导航（`pathname + query + hash`）
- 继承当前 URL 的 query 参数（例如 `theme` 及其它后续参数）
- 避免手工拼接 URL 导致参数丢失或扩展困难

## Files Changed
- `themes/fuwari/components/menu.js`
- `themes/fuwari/components/MenuList.js`
- `themes/fuwari/components/MobileNav.js`
- `themes/fuwari/components/PostList.js`
- `themes/fuwari/components/ArticleHeader.js`

## Test Plan
- [ ] 桌面端验证二级菜单可展开，鼠标移动到子菜单不会消失
- [ ] 验证“父级含子菜单”时父级不可点击
- [ ] 移动端验证二级菜单可折叠展开
- [ ] 在携带 `?theme=fuwari`（及其他 query）时点击发布日期，跳转归档后参数仍保留
- [ ] 归档锚点定位仍能落到对应年月