### PR TITLE
fix(fuwari): refine palette behavior, analytics i18n, and hero clarity

### DIFF
--- a/lib/lang/en-US.js
+++ b/lib/lang/en-US.js
@@ -41,6 +41,7 @@ export default {
     COPYRIGHT: 'Copyright',
     AUTHOR: 'Author',
     URL: 'URL',
+    ANALYTICS: 'Analytics',
     NOW: 'NOW',
     RECOMMEND_BADGES: 'Recommend',
     BLOG: 'Blog',

--- a/lib/lang/tr-TR.js
+++ b/lib/lang/tr-TR.js
@@ -23,6 +23,7 @@ export default {
     COPYRIGHT: 'Copyright',
     AUTHOR: 'Yazar',
     URL: 'URL',
+    ANALYTICS: 'İstatistik',
     POSTS: 'Gönderiler',
     ARTICLE: 'Başlık',
     VISITORS: 'Ziyaretçiler',

--- a/themes/fuwari/components/AnalyticsCard.js
+++ b/themes/fuwari/components/AnalyticsCard.js
@@ -1,4 +1,5 @@
 import { siteConfig } from '@/lib/config'
+import { useGlobal } from '@/lib/global'
 import CONFIG from '../config'
 
 const Item = ({ label, value }) => (
@@ -9,17 +10,27 @@ const Item = ({ label, value }) => (
 )
 
 const AnalyticsCard = ({ postCount = 0, categoryOptions = [], tagOptions = [] }) => {
+  const { locale, lang } = useGlobal()
   if (!siteConfig('FUWARI_WIDGET_ANALYTICS', true, CONFIG)) return null
+
+  // zh-* 的 COMMON.POSTS 多为「篇文章」，不适合单独作统计标签，改用「文章」
+  const postsLabel = /^zh-(CN|TW|HK)$/i.test(lang || '')
+    ? locale?.COMMON?.ARTICLE || '文章'
+    : locale?.COMMON?.POSTS || locale?.COMMON?.ARTICLE || 'Posts'
+
+  const title = locale?.COMMON?.ANALYTICS || 'Analytics'
+  const categoryLabel = locale?.COMMON?.CATEGORY || 'Categories'
+  const tagsLabel = locale?.COMMON?.TAGS || 'Tags'
 
   return (
     <section>
       <h3 className='text-sm font-semibold mb-2 tracking-wide uppercase text-[var(--fuwari-muted)] px-1'>
-        Analytics
+        {title}
       </h3>
       <div className='grid grid-cols-3 gap-2'>
-        <Item label='Posts' value={postCount || 0} />
-        <Item label='Categories' value={categoryOptions?.length || 0} />
-        <Item label='Tags' value={tagOptions?.length || 0} />
+        <Item label={postsLabel} value={postCount || 0} />
+        <Item label={categoryLabel} value={categoryOptions?.length || 0} />
+        <Item label={tagsLabel} value={tagOptions?.length || 0} />
       </div>
     </section>
   )

--- a/themes/fuwari/components/Header.js
+++ b/themes/fuwari/components/Header.js
@@ -24,6 +24,7 @@ const Header = ({ locale, customNav, customMenu, searchModal }) => {
   useEffect(() => {
     const onClickOutside = e => {
       if (!showPalette) return
+      if (e.target.closest?.('[data-fuwari-palette-trigger]')) return
       if (panelRef.current && !panelRef.current.contains(e.target)) {
         setShowPalette(false)
       }
@@ -34,7 +35,7 @@ const Header = ({ locale, customNav, customMenu, searchModal }) => {
 
   return (
     <header className='max-w-6xl mx-auto px-4 pt-0 pb-3 sticky top-0 z-40'>
-      <div className='fuwari-card fuwari-navbar px-4 py-2.5 flex items-center justify-between md:grid md:grid-cols-[1fr_auto_1fr]'>
+      <div className='fuwari-card fuwari-navbar relative px-4 py-2.5 flex items-center justify-between md:grid md:grid-cols-[1fr_auto_1fr]'>
         <SmartLink href='/' className='text-[1.35rem] md:text-[1.45rem] font-bold fuwari-title-gradient text-left'>
           {siteConfig('TITLE')}
         </SmartLink>
@@ -46,6 +47,7 @@ const Header = ({ locale, customNav, customMenu, searchModal }) => {
           {!paletteFixed && (
             <button
               type='button'
+              data-fuwari-palette-trigger
               onClick={() => setShowPalette(v => !v)}
               className='fuwari-tool-btn'>
               <i className='fas fa-palette' />
@@ -54,11 +56,6 @@ const Header = ({ locale, customNav, customMenu, searchModal }) => {
           <button type='button' onClick={toggleDarkMode} className='fuwari-tool-btn'>
             {isDarkMode ? '☀' : '☾'}
           </button>
-          {showPalette && !paletteFixed && (
-            <div ref={panelRef} className='fuwari-card absolute right-0 top-12 p-0 w-80 z-50'>
-              <ThemeColorSwitch />
-            </div>
-          )}
         </div>
         <div className='md:hidden flex items-center justify-end gap-2 relative'>
           <button type='button' onClick={handleSearch} className='fuwari-tool-btn'>
@@ -67,6 +64,7 @@ const Header = ({ locale, customNav, customMenu, searchModal }) => {
           {!paletteFixed && (
             <button
               type='button'
+              data-fuwari-palette-trigger
               onClick={() => setShowPalette(v => !v)}
               className='fuwari-tool-btn'>
               <i className='fas fa-palette' />
@@ -76,12 +74,14 @@ const Header = ({ locale, customNav, customMenu, searchModal }) => {
             {isDarkMode ? '☀' : '☾'}
           </button>
           <MobileNav locale={locale} customNav={customNav} customMenu={customMenu} />
-          {showPalette && !paletteFixed && (
-            <div ref={panelRef} className='fuwari-card absolute right-0 top-12 p-0 w-72 z-50'>
-              <ThemeColorSwitch />
-            </div>
-          )}
         </div>
+        {showPalette && !paletteFixed && (
+          <div
+            ref={panelRef}
+            className='fuwari-card absolute right-3 md:right-4 top-12 p-0 w-[min(20rem,calc(100vw-2rem))] md:w-80 z-50'>
+            <ThemeColorSwitch />
+          </div>
+        )}
       </div>
     </header>
   )

--- a/themes/fuwari/config.js
+++ b/themes/fuwari/config.js
@@ -1,62 +1,136 @@
 /**
- * Fuwari 主题配置
+ * Fuwari 主题专用配置
+ *
+ * 与 NotionNext 的 `blog.config.js` 合并后生效；可在博客配置里覆盖任意项。
+ * 布尔项：true 显示/启用，false 隐藏/关闭。
  */
+
 const CONFIG = {
+  // ---------------------------------------------------------------------------
+  // 导航（桌面顶栏 + 受 FUWARI_MOBILE_MENU 影响的移动菜单项）
+  // ---------------------------------------------------------------------------
+  /** 显示「首页」 */
   FUWARI_MENU_INDEX: true,
-  FUWARI_MENU_CATEGORY: true,
-  FUWARI_MENU_TAG: true,
+  /** 显示「归档」 */
   FUWARI_MENU_ARCHIVE: true,
+  /** 显示「分类」 */
+  FUWARI_MENU_CATEGORY: true,
+  /** 显示「标签」 */
+  FUWARI_MENU_TAG: true,
+  /** 显示「搜索」（Algolia 或站内搜索由全局配置决定） */
   FUWARI_MENU_SEARCH: true,
 
+  // ---------------------------------------------------------------------------
+  // 首页文章列表卡片
+  // ---------------------------------------------------------------------------
+  /** 是否显示右侧封面图区域 */
   FUWARI_POST_LIST_COVER: true,
+  /** 无文章封面时，是否用站点横幅图（HOME_BANNER_IMAGE）作默认图 */
   FUWARI_POST_LIST_COVER_DEFAULT: true,
+  /** 封面悬停轻微放大 */
   FUWARI_POST_LIST_COVER_HOVER_ENLARGE: true,
+  /** 显示摘要（有 summary 时） */
   FUWARI_POST_LIST_SUMMARY: true,
+  /** 卡片内显示标签 */
   FUWARI_POST_LIST_TAG: true,
 
+  // ---------------------------------------------------------------------------
+  // 移动端
+  // ---------------------------------------------------------------------------
+  /** 右侧汉堡菜单（含导航项）；关闭后小屏仅保留顶栏图标 */
   FUWARI_MOBILE_MENU: true,
-  FUWARI_HOME_INTRO_TITLE: 'Latest Articles',
-  FUWARI_HOME_INTRO_SUBTITLE: 'Journal',
+
+  // ---------------------------------------------------------------------------
+  // 首页 Hero 大图区（封面来自站点信息或下方图片配置）
+  // ---------------------------------------------------------------------------
+  /** 是否渲染 Hero 区块（无图时仍占位，可按需关） */
   FUWARI_HERO_ENABLE: true,
-  FUWARI_HERO_BADGE: 'From Notion Database',
+  /** 自定义背景图 URL；留空则用 Notion 站点封面或 HOME_BANNER_IMAGE */
   FUWARI_HERO_BG_IMAGE: '',
+  /** 右下角署名文案；留空不显示 */
   FUWARI_HERO_CREDIT_TEXT: '',
+  /** 署名链接 */
   FUWARI_HERO_CREDIT_LINK: '',
 
+  // ---------------------------------------------------------------------------
+  // 侧栏（SidePanel）小部件
+  // ---------------------------------------------------------------------------
+  /** 公告（有公告数据时） */
   FUWARI_WIDGET_NOTICE: true,
+  /** 最新文章列表 */
   FUWARI_WIDGET_LATEST_POSTS: true,
+  /** 分类云/列表 */
   FUWARI_WIDGET_CATEGORY_LIST: true,
+  /** 标签云/列表 */
   FUWARI_WIDGET_TAG_LIST: true,
+  /** 侧栏头像/昵称下的「个人页」链接路径 */
   FUWARI_PROFILE_PATH: '/about',
+  /** 联系/社群入口卡片 */
   FUWARI_WIDGET_CONTACT: true,
-  FUWARI_CONTACT_TITLE: 'Contact',
-  FUWARI_CONTACT_DESCRIPTION: 'Join the community and discuss ideas.',
-  FUWARI_CONTACT_URL: 'https://docs.tangly1024.com/article/how-to-question',
-  FUWARI_CONTACT_TEXT: 'Get in touch',
-  FUWARI_CONTACT_FLIP_CARD: true,
-  FUWARI_CONTACT_BACK_TITLE: 'Keep in touch',
-  FUWARI_CONTACT_BACK_DESCRIPTION: 'Share your ideas, collaboration, and feedback anytime.',
-  FUWARI_CONTACT_BACK_TEXT: 'Open Contact',
+  /** 侧栏广告位总开关 */
   FUWARI_WIDGET_AD: false,
+  /** 侧栏广告位内：是否渲染 WWAds */
   FUWARI_WIDGET_WWADS: true,
+  /** 侧栏广告位内：是否渲染 AdSense 槽位 */
   FUWARI_WIDGET_ADSENSE: false,
+  /** 插件注入区域卡片 */
   FUWARI_WIDGET_PLUGIN_AREA: true,
+  /** 访问量等统计卡片 */
   FUWARI_WIDGET_ANALYTICS: true,
+  /** 顶栏调色板内的色相滑块等；false 时展开调色板无控件 */
   FUWARI_WIDGET_THEME_COLOR_SWITCHER: true,
-  FUWARI_THEME_COLOR_HUE: 52, // 0~360, default brand hue
-  FUWARI_THEME_COLOR_FIXED: false, // true = hide palette picker for visitors
+  /** 默认品牌色相 0–360 */
+  FUWARI_THEME_COLOR_HUE: 52,
+  /** true：隐藏顶栏调色盘按钮，无法在站内改色相 */
+  FUWARI_THEME_COLOR_FIXED: false,
+  /** 文章页右侧浮动区：跳转评论区按钮 */
   FUWARI_WIDGET_TO_COMMENT: true,
+  /** 文章页右侧浮动区：深色模式切换 */
   FUWARI_WIDGET_DARK_MODE: true,
+  /** 文章页目录：桌面在侧栏；小屏为浮动按钮抽屉（RightFloatArea） */
   FUWARI_ARTICLE_TOC: true,
+
+  // ---------------------------------------------------------------------------
+  // 联系卡片（侧栏，可翻转）
+  // ---------------------------------------------------------------------------
+  /** 正面标题 */
+  FUWARI_CONTACT_TITLE: '联系我们',
+  /** 正面说明文案 */
+  FUWARI_CONTACT_DESCRIPTION: '加入社群，碰撞思维',
+  /** 跳转 URL（外链或站内路径） */
+  FUWARI_CONTACT_URL: 'https://docs.tangly1024.com/article/chat-community',
+  /** 正面行动文案（如「联系我们 →」） */
+  FUWARI_CONTACT_TEXT: '联系我们',
+  /** 是否使用正反面翻转卡片 */
+  FUWARI_CONTACT_FLIP_CARD: true,
+  /** 背面标题 */
+  FUWARI_CONTACT_BACK_TITLE: '保持联系',
+  /** 背面说明 */
+  FUWARI_CONTACT_BACK_DESCRIPTION: '分享你的想法，合作，以及反馈.',
+  /** 背面行动文案 */
+  FUWARI_CONTACT_BACK_TEXT: '打开联系',
+
+  // ---------------------------------------------------------------------------
+  // 全站动效（按需开启，可能影响性能）
+  // ---------------------------------------------------------------------------
+  /** Lenis 平滑滚动 */
   FUWARI_EFFECT_LENIS: false,
+  /** 自定义光标圆点 */
   FUWARI_EFFECT_CURSOR_DOT: false,
 
+  // ---------------------------------------------------------------------------
+  // 文章页
+  // ---------------------------------------------------------------------------
+  /** 文首：日期、分类、标签等元信息 */
   FUWARI_ARTICLE_META: true,
+  /** 分享条 */
   FUWARI_ARTICLE_SHARE: true,
+  /** 文末版权信息块 */
   FUWARI_ARTICLE_COPYRIGHT: true,
+  /** 评论区域 */
   FUWARI_ARTICLE_COMMENT: true,
+  /** 文末上一篇 / 下一篇 */
   FUWARI_ARTICLE_ADJACENT: true
 }
 
 export default CONFIG
-

--- a/themes/fuwari/style.js
+++ b/themes/fuwari/style.js
@@ -243,13 +243,18 @@ const Style = () => {
       inset: 0;
       background-size: cover;
       background-position: center;
-      transform: scale(1.03);
+      transform: scale(1.01);
       filter: saturate(1.05);
     }
     #theme-fuwari .fuwari-hero-mask {
       position: absolute;
       inset: 0;
-      background: linear-gradient(120deg, rgba(15, 23, 42, 0.66), rgba(15, 23, 42, 0.3));
+      background: linear-gradient(
+        120deg,
+        rgba(15, 23, 42, 0.32) 0%,
+        rgba(15, 23, 42, 0.14) 55%,
+        rgba(15, 23, 42, 0.04) 100%
+      );
       z-index: 1;
     }
     #theme-fuwari .fuwari-hero-btn {


### PR DESCRIPTION
## Summary
- fix desktop palette closing issue by consolidating to a single popover and improving outside-click handling
- localize sidebar analytics labels via existing multi-language dictionaries with better Chinese label fallback
- reduce hero haze by lightening the overlay gradient and lowering background scale to improve visual clarity

## Test plan
- [x] Open palette on desktop and click inside to select colors without auto-closing
- [x] Verify analytics card labels in zh-CN and en-US (and fallback behavior)
- [x] Check hero background on desktop/mobile for reduced haze and improved sharpness