### PR TITLE
chore(gitignore): ignore local .tmp workspace directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,4 @@ package-lock.json
 # yarn.lock
 
 .notion-api-lock
+.tmp/


### PR DESCRIPTION
## Summary
- add `.tmp/` to `.gitignore` so local scratch workspace artifacts are not tracked
- keep the change isolated in a dedicated housekeeping branch after the previous PR merge

## Test plan
- [x] Confirm `.tmp/` no longer appears in `git status`
- [x] Verify no source files are changed in this PR besides `.gitignore`

Made with [Cursor](https://cursor.com)