### PR TITLE
chore: backfill missed local dev cache and fuwari UX updates

### DIFF
--- a/conf/dev.config.js
+++ b/conf/dev.config.js
@@ -11,10 +11,13 @@ module.exports = {
   // Redis 缓存数据库地址
   REDIS_URL: process.env.REDIS_URL || '',
 
+  // 未设置 ENABLE_CACHE 时：build/export 默认开启；next dev 下 NODE_ENV=development 也默认开启，便于本地命中 file+memory 缓存。
+  // 若不想用缓存，请在 .env.local 中设置 ENABLE_CACHE=false（字符串即可）。
   ENABLE_CACHE:
     process.env.ENABLE_CACHE ||
     process.env.npm_lifecycle_event === 'build' ||
-    process.env.npm_lifecycle_event === 'export', // 在打包过程中默认开启缓存，开发或运行时开启此功能意义不大。
+    process.env.npm_lifecycle_event === 'export' ||
+    process.env.NODE_ENV === 'development',
   isProd: process.env.VERCEL_ENV === 'production' || process.env.EXPORT, // distinguish between development and production environment (ref: https://vercel.com/docs/environment-variables#system-environment-variables)
   BUNDLE_ANALYZER: process.env.ANALYZE === 'true' || false, // 是否展示编译依赖内容与大小
   VERSION: (() => {

--- a/lib/cache/cache_manager.js
+++ b/lib/cache/cache_manager.js
@@ -21,6 +21,25 @@ const enableLocalCache = isBuildPhase || !BLOG.isProd
 const hasRedis = !!BLOG.REDIS_URL
 const inflightMap = new Map()
 
+/** 与 dev.config 中 ENABLE_CACHE 的多种写法兼容（boolean / JSON 字符串 / 'true'|'false'） */
+function cacheReadsEnabled(force) {
+  if (force) return true
+  const v = BLOG.ENABLE_CACHE
+  if (v === true) return true
+  if (v === false) return false
+  if (typeof v === 'string') {
+    const s = v.trim()
+    if (s === '' || s === 'false' || s === '0') return false
+    if (s === 'true' || s === '1') return true
+    try {
+      return Boolean(JSON.parse(s))
+    } catch {
+      return true
+    }
+  }
+  return Boolean(v)
+}
+
 function cacheLog(action, key, extra = '') {
   const type = getCacheType()
   console.log(
@@ -122,7 +141,7 @@ export async function setDataToCache(key, data, customCacheTime) {
 }
 
 export async function getDataFromCache(key, force) {
-  if (!JSON.parse(BLOG.ENABLE_CACHE) && !force) return null
+  if (!cacheReadsEnabled(force)) return null
 
   cacheStats.total++
   const chain = getCacheChain()

--- a/next.config.js
+++ b/next.config.js
@@ -32,6 +32,17 @@ const locales = (function () {
   return langs
 })()
 
+// next dev 启动时提示：开发环境默认读/写 Notion 缓存（见 conf/dev.config.js 中 ENABLE_CACHE）
+;(function printDevCacheHint() {
+  if (process.env.npm_lifecycle_event !== 'dev') return
+  console.log(
+    '\n[NotionNext] 开发环境默认开启 Notion 数据缓存（ENABLE_CACHE），便于本地调试提速。'
+  )
+  console.log(
+    '若需关闭缓存、每次请求都从 Notion 获取实时数据：请复制仓库根目录的 .env.example 创建 .env.local，并配置 ENABLE_CACHE=false\n'
+  )
+})()
+
 // 编译前执行
 // eslint-disable-next-line no-unused-vars
 const preBuild = (function () {

--- a/themes/fuwari/components/AnalyticsCard.js
+++ b/themes/fuwari/components/AnalyticsCard.js
@@ -1,12 +1,15 @@
+import SmartLink from '@/components/SmartLink'
 import { siteConfig } from '@/lib/config'
 import { useGlobal } from '@/lib/global'
 import CONFIG from '../config'
 
-const Item = ({ label, value }) => (
-  <div className='fuwari-card fuwari-analytics-item p-3 text-center min-w-0'>
-    <div className='text-lg font-semibold leading-none'>{value}</div>
+const Item = ({ label, value, href }) => (
+  <SmartLink
+    href={href}
+    className='fuwari-card fuwari-analytics-item fuwari-analytics-link p-3 text-center min-w-0 block no-underline text-inherit hover:opacity-95 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--fuwari-primary)]'>
+    <div className='text-lg font-semibold leading-none text-[var(--fuwari-text)]'>{value}</div>
     <div className='fuwari-analytics-label mt-1'>{label}</div>
-  </div>
+  </SmartLink>
 )
 
 const AnalyticsCard = ({ postCount = 0, categoryOptions = [], tagOptions = [] }) => {
@@ -28,9 +31,9 @@ const AnalyticsCard = ({ postCount = 0, categoryOptions = [], tagOptions = [] })
         {title}
       </h3>
       <div className='grid grid-cols-3 gap-2'>
-        <Item label={postsLabel} value={postCount || 0} />
-        <Item label={categoryLabel} value={categoryOptions?.length || 0} />
-        <Item label={tagsLabel} value={tagOptions?.length || 0} />
+        <Item label={postsLabel} value={postCount || 0} href='/archive' />
+        <Item label={categoryLabel} value={categoryOptions?.length || 0} href='/category' />
+        <Item label={tagsLabel} value={tagOptions?.length || 0} href='/tag' />
       </div>
     </section>
   )

--- a/themes/fuwari/components/ArticleCopyright.js
+++ b/themes/fuwari/components/ArticleCopyright.js
@@ -39,12 +39,15 @@ const ArticleCopyright = ({ post }) => {
 
   if (!siteConfig('FUWARI_ARTICLE_COPYRIGHT', true, CONFIG) || !post) return null
 
+  const authorName = (siteConfig('AUTHOR') || '').trim() || siteConfig('TITLE')
+  const profileHref = siteConfig('FUWARI_PROFILE_PATH', '/about', CONFIG)
+
   return (
     <section className='mt-6 fuwari-card p-4 text-sm text-[var(--fuwari-muted)] leading-7'>
       <div>
         <span className='font-semibold mr-2'>{locale?.COMMON?.AUTHOR || '作者'}:</span>
-        <SmartLink href='/about' className='fuwari-link'>
-          {siteConfig('AUTHOR') || siteConfig('TITLE')}
+        <SmartLink href={profileHref} className='fuwari-link'>
+          {authorName}
         </SmartLink>
       </div>
       <div className='mt-1'>

--- a/themes/fuwari/components/RightFloatArea.js
+++ b/themes/fuwari/components/RightFloatArea.js
@@ -2,12 +2,13 @@ import { useEffect, useState } from 'react'
 import { siteConfig } from '@/lib/config'
 import { useGlobal } from '@/lib/global'
 import CONFIG from '../config'
+import { isCommentServiceConfigured } from '../utils/commentEnabled'
 import Toc from './Toc'
 
 const RightFloatArea = ({ post }) => {
   const [visible, setVisible] = useState(false)
   const [showTocDrawer, setShowTocDrawer] = useState(false)
-  const { isDarkMode, toggleDarkMode } = useGlobal()
+  const { isDarkMode, toggleDarkMode, locale } = useGlobal()
   const hasToc = Boolean(post?.toc && post.toc.length > 1)
 
   useEffect(() => {
@@ -51,9 +52,13 @@ const RightFloatArea = ({ post }) => {
             <i className='fas fa-list-ul' />
           </button>
         )}
-        {post && siteConfig('FUWARI_WIDGET_TO_COMMENT', true, CONFIG) && (
+        {post &&
+          siteConfig('FUWARI_WIDGET_TO_COMMENT', true, CONFIG) &&
+          isCommentServiceConfigured() && (
           <button
+            type='button'
             className='fuwari-float-btn'
+            aria-label={locale?.COMMON?.COMMENTS || 'Comments'}
             onClick={() => document.getElementById('comment')?.scrollIntoView({ behavior: 'smooth' })}>
             <i className='far fa-comment-dots' />
           </button>

--- a/themes/fuwari/config.js
+++ b/themes/fuwari/config.js
@@ -127,7 +127,7 @@ const CONFIG = {
   FUWARI_ARTICLE_SHARE: true,
   /** 文末版权信息块 */
   FUWARI_ARTICLE_COPYRIGHT: true,
-  /** 评论区域 */
+  /** 文末评论区（需在 `blog.config.js` 配置任一种评论服务，如 COMMENT_GISCUS_REPO / COMMENT_TWIKOO_ENV_ID 等，否则不渲染） */
   FUWARI_ARTICLE_COMMENT: true,
   /** 文末上一篇 / 下一篇 */
   FUWARI_ARTICLE_ADJACENT: true

--- a/themes/fuwari/index.js
+++ b/themes/fuwari/index.js
@@ -1,6 +1,5 @@
 'use client'
 
-import Comment from '@/components/Comment'
 import replaceSearchResult from '@/components/Mark'
 import NotionPage from '@/components/NotionPage'
 import ShareBar from '@/components/ShareBar'
@@ -25,6 +24,9 @@ import RightFloatArea from './components/RightFloatArea'
 import SidePanel from './components/SidePanel'
 import CONFIG from './config'
 import { Style } from './style'
+import { isCommentServiceConfigured } from './utils/commentEnabled'
+
+const Comment = dynamic(() => import('@/components/Comment'), { ssr: false })
 
 const AlgoliaSearchModal = dynamic(
   () => import('@/components/AlgoliaSearchModal'),
@@ -109,6 +111,8 @@ const LayoutSlug = props => {
   const locale = getLocale()
   const { post, lock, validPassword, prev, next } = props
   if (!post) return null
+  const showComments =
+    siteConfig('FUWARI_ARTICLE_COMMENT', true, CONFIG) && isCommentServiceConfigured()
   return (
     <>
       {lock ? (
@@ -122,7 +126,15 @@ const LayoutSlug = props => {
           </div>
           <ArticleCopyright post={post} />
           <ArticleAdjacent prev={prev} next={next} />
-          {siteConfig('FUWARI_ARTICLE_COMMENT', true, CONFIG) && <Comment frontMatter={post} />}
+          {showComments && (
+            <section className='mt-8 pt-6 border-t border-[var(--fuwari-border)]' aria-label={locale?.COMMON?.COMMENTS || 'Comments'}>
+              <h2 className='text-base font-semibold mb-4 text-[var(--fuwari-text)] flex items-center gap-2'>
+                <i className='far fa-comments text-[var(--fuwari-muted)]' aria-hidden='true' />
+                {locale?.COMMON?.COMMENTS || 'Comments'}
+              </h2>
+              <Comment frontMatter={post} className='fuwari-comment !mt-0' />
+            </section>
+          )}
         </article>
       )}
     </>

--- a/themes/fuwari/utils/commentEnabled.js
+++ b/themes/fuwari/utils/commentEnabled.js
@@ -1,0 +1,19 @@
+import { siteConfig } from '@/lib/config'
+
+/**
+ * 是否与 `components/Comment.js` 中实际会渲染的评论源一致。
+ * 未配置任何服务时不在主题中占位，避免空白「评论区」。
+ */
+export function isCommentServiceConfigured() {
+  return Boolean(
+    siteConfig('COMMENT_ARTALK_SERVER') ||
+      siteConfig('COMMENT_TWIKOO_ENV_ID') ||
+      siteConfig('COMMENT_WALINE_SERVER_URL') ||
+      siteConfig('COMMENT_VALINE_APP_ID') ||
+      siteConfig('COMMENT_GISCUS_REPO') ||
+      siteConfig('COMMENT_CUSDIS_APP_ID') ||
+      siteConfig('COMMENT_UTTERRANCES_REPO') ||
+      siteConfig('COMMENT_GITALK_CLIENT_ID') ||
+      siteConfig('COMMENT_WEBMENTION_ENABLE')
+  )
+}


### PR DESCRIPTION
## Summary
- backfill the previously missed local dev and fuwari UX improvements that were committed on `feat/theme-fuwari` but not included in the follow-up PRs
- enable cache by default in local dev, add startup hint logs in Next config, and make cache reads robust for multiple `ENABLE_CACHE` value formats
- include fuwari follow-up UX refinements: clickable analytics cards, configurable copyright profile link, and render comments only when a comment provider is configured

## Included files
- `conf/dev.config.js`
- `lib/cache/cache_manager.js`
- `next.config.js`
- `themes/fuwari/components/AnalyticsCard.js`
- `themes/fuwari/components/ArticleCopyright.js`
- `themes/fuwari/components/RightFloatArea.js`
- `themes/fuwari/config.js`
- `themes/fuwari/index.js`
- `themes/fuwari/utils/commentEnabled.js`

## Test plan
- [x] Confirm local `next dev` prints cache behavior hint
- [x] Verify cache read logic handles `ENABLE_CACHE` values like `true/false/1/0` and JSON strings
- [x] Verify fuwari analytics cards route correctly
- [x] Verify comment section only renders when a comment provider is configured

Made with [Cursor](https://cursor.com)