### PR TITLE
fix(seo): remove invalid inter-var preload

### DIFF
--- a/components/SEO.js
+++ b/components/SEO.js
@@ -207,9 +207,6 @@ const SEO = props => {
       <link rel='dns-prefetch' href='//www.googletagmanager.com' />
       <link rel='preconnect' href='https://fonts.gstatic.com' crossOrigin='anonymous' />
 
-      {/* 预加载关键资源 */}
-      <link rel='preload' href='/fonts/inter-var.woff2' as='font' type='font/woff2' crossOrigin='anonymous' />
-
       {children}
     </Head>
   )


### PR DESCRIPTION
## Summary
- remove the preload tag for `/fonts/inter-var.woff2` from `components/SEO.js`
- this font file is not present in `public/`, so the preload request always returns 404
- removing it eliminates noisy preload/network errors during page load

## Test plan
- [x] Run app locally and open any page
- [x] Verify no request is made to `/fonts/inter-var.woff2`
- [x] Confirm no 404/preload error related to this font appears in browser console/network panel

Made with [Cursor](https://cursor.com)