### PR TITLE
fix(fuwari): stabilize contact card flip and prism scoping

### DIFF
--- a/themes/fuwari/components/SocialButton.js
+++ b/themes/fuwari/components/SocialButton.js
@@ -1,6 +1,9 @@
 import { siteConfig } from '@/lib/config'
+import { handleEmailClick } from '@/lib/plugins/mailEncrypt'
+import { useRef } from 'react'
 
 const SocialButton = () => {
+  const emailIcon = useRef(null)
   const enableRSS = siteConfig('ENABLE_RSS')
   const links = [
     { key: 'CONTACT_TWITTER', icon: 'fab fa-twitter', label: 'Twitter' },
@@ -35,14 +38,20 @@ const SocialButton = () => {
   return (
     <div className='flex items-center justify-center gap-2 flex-wrap'>
       {finalLinks.map(item => {
-        const href = item.isMail ? `mailto:${item.href}` : item.href
+        const href = item.isMail ? undefined : item.href
         return (
           <a
             key={item.key}
             href={href}
+            onClick={
+              item.isMail
+                ? e => handleEmailClick(e, emailIcon, item.href)
+                : undefined
+            }
             target={item.isMail ? undefined : '_blank'}
             rel={item.isMail ? undefined : 'noopener noreferrer'}
             aria-label={item.label}
+            ref={item.isMail ? emailIcon : undefined}
             className='fuwari-social-btn'>
             <i className={item.icon} />
           </a>


### PR DESCRIPTION
## Summary
- scope Prism/Mermaid article queries to `#article-wrapper #notion-article` first to avoid duplicated `notion-article` nodes hijacking rendering
- stabilize `FlipCard` 3D rendering for back-face readability across themes
- refine fuwari contact card content structure with distinct front/back copy and shorter defaults, removing extra hint/list noise

## Test plan
- [x] On fuwari article page with sidebar Notion content, verify mermaid parsing uses article body container
- [x] Hover contact card and confirm back-side text is readable (not mirrored bleed-through)
- [x] Verify front/back contact copy is concise and different
- [x] Confirm click action still opens configured contact URL

Made with [Cursor](https://cursor.com)