### PR TITLE
fix(prism,gitbook): stabilize mermaid lifecycle and dark mode palette

### DIFF
--- a/components/PrismMac.js
+++ b/components/PrismMac.js
@@ -66,10 +66,29 @@ const PrismMac = () => {
 }
 
 const getNotionArticle = () => {
-  return (
-    document.querySelector('#article-wrapper #notion-article') ||
-    document.querySelector('#notion-article')
+  const inArticleWrapper = document.querySelector('#article-wrapper #notion-article')
+  if (inArticleWrapper) return inArticleWrapper
+
+  const candidates = Array.from(document.querySelectorAll('#notion-article'))
+  if (candidates.length <= 1) return candidates[0] || null
+
+  // 多主题并存时可能有多个 notion-article，优先选择正文内容更完整的节点
+  const score = el => {
+    const codeCount = el.querySelectorAll('pre.notion-code, .code-toolbar').length
+    const blockCount = el.querySelectorAll('.notion, .notion-page, .notion-text').length
+    return codeCount * 10 + blockCount
+  }
+
+  return candidates.sort((a, b) => score(b) - score(a))[0] || null
+}
+
+const getNotionArticles = () => {
+  const inArticleWrapper = Array.from(
+    document.querySelectorAll('#article-wrapper #notion-article')
   )
+  if (inArticleWrapper.length > 0) return inArticleWrapper
+
+  return Array.from(document.querySelectorAll('#notion-article'))
 }
 
 /**
@@ -168,44 +187,76 @@ const renderCollapseCode = (codeCollapse, codeCollapseExpandDefault) => {
  * 将mermaid语言 渲染成图片
  */
 const renderMermaid = mermaidCDN => {
-  const article = getNotionArticle()
-  if (!article) return
-
-  const observer = new MutationObserver(mutationsList => {
-    for (const m of mutationsList) {
-      if (m.target.className === 'notion-code language-mermaid') {
-        const chart = m.target.querySelector('code').textContent
-        if (chart && !m.target.querySelector('.mermaid')) {
-          const mermaidChart = document.createElement('pre')
-          mermaidChart.className = 'mermaid'
-          mermaidChart.innerHTML = chart
-          m.target.appendChild(mermaidChart)
-        }
-
-        const mermaidsSvg = article.querySelectorAll('.mermaid')
-        if (mermaidsSvg) {
-          let needLoad = false
-          for (const e of mermaidsSvg) {
-            if (e?.firstChild?.nodeName !== 'svg') {
-              needLoad = true
-            }
-          }
-          if (needLoad) {
-            loadExternalResource(mermaidCDN, 'js').then(url => {
-              setTimeout(() => {
-                const mermaid = window.mermaid
-                mermaid?.contentLoaded()
-              }, 100)
-            })
-          }
-        }
+  const processArticle = article => {
+    const mermaidCodeBlocks = article.querySelectorAll(
+      '.notion-code.language-mermaid'
+    )
+    for (const codeBlock of mermaidCodeBlocks) {
+      const chart = codeBlock.querySelector('code')?.textContent
+      if (chart && !codeBlock.querySelector('.mermaid')) {
+        const mermaidChart = document.createElement('pre')
+        mermaidChart.className = 'mermaid'
+        mermaidChart.innerHTML = chart
+        codeBlock.appendChild(mermaidChart)
       }
     }
+
+    const mermaidsSvg = article.querySelectorAll('.mermaid')
+    if (mermaidsSvg.length > 0) {
+      let needLoad = false
+      for (const e of mermaidsSvg) {
+        if (e?.firstChild?.nodeName !== 'svg') {
+          needLoad = true
+          break
+        }
+      }
+      if (needLoad) {
+        loadExternalResource(mermaidCDN, 'js').then(url => {
+          setTimeout(() => {
+            const mermaid = window.mermaid
+            mermaid?.contentLoaded()
+          }, 100)
+        })
+      }
+    }
+  }
+
+  const bindArticleObserver = article => {
+    processArticle(article)
+    const observer = new MutationObserver(() => {
+      processArticle(article)
+    })
+    observer.observe(article, {
+      childList: true,
+      attributes: true,
+      subtree: true
+    })
+  }
+
+  const scanAndBind = () => {
+    const articles = getNotionArticles()
+    for (const article of articles) {
+      if (article.dataset.prismMermaidBound === '1') continue
+      article.dataset.prismMermaidBound = '1'
+      bindArticleObserver(article)
+    }
+  }
+
+  // 立即处理已有内容（主题切换时关键）
+  scanAndBind()
+
+  // 监听后续新增的文章容器
+  if (window.__prismMermaidRootObserver) {
+    window.__prismMermaidRootObserver.disconnect()
+  }
+  const rootObserver = new MutationObserver(() => {
+    scanAndBind()
   })
-  observer.observe(article, {
-    attributes: true,
+  rootObserver.observe(document.body, {
+    childList: true,
     subtree: true
   })
+  window.__prismMermaidRootObserver = rootObserver
 }
 
 function renderPrismMac(codeLineNumbers) {

--- a/themes/gitbook/components/BlogPostCard.js
+++ b/themes/gitbook/components/BlogPostCard.js
@@ -14,7 +14,7 @@ const BlogPostCard = ({ post, className }) => {
       <div
         key={post.id}
         className={`${className} relative py-1.5 cursor-pointer px-1.5 rounded-md hover:bg-gray-50
-                    ${currentSelected ? 'text-green-500 dark:bg-yellow-100 dark:text-yellow-600 font-semibold' : ' dark:hover:bg-yellow-100 dark:hover:text-yellow-600'}`}>
+                    ${currentSelected ? 'text-green-600 bg-green-50/70 dark:bg-black dark:text-green-400 font-semibold' : 'dark:hover:bg-gray-900 dark:hover:text-gray-200'}`}>
         <div className='w-full select-none'>
           {siteConfig('POST_TITLE_ICON') && (
             <NotionIcon icon={post?.pageIcon} />

--- a/themes/gitbook/components/BottomMenuBar.js
+++ b/themes/gitbook/components/BottomMenuBar.js
@@ -20,15 +20,21 @@ export default function BottomMenuBar({ post, className }) {
   }
 
   return (
-    <div className='md:hidden fixed bottom-0 left-0 z-50 w-full h-16 bg-white border-t border-gray-200 dark:bg-gray-700 dark:border-gray-600'>
+    <div
+      className={`md:hidden fixed bottom-0 left-0 z-50 w-full border-t border-gray-200 bg-white dark:border-black dark:bg-hexo-black-gray ${className || ''}`}
+      style={{ paddingBottom: 'env(safe-area-inset-bottom)' }}>
       <div
-        className={`grid h-full max-w-lg  mx-auto font-medium ${showTocButton && 'grid-cols-2'}`}>
+        className={`grid h-16 max-w-lg mx-auto px-3 font-medium ${showTocButton ? 'grid-cols-2 gap-2' : 'grid-cols-1'}`}>
         <button
           type='button'
           onClick={togglePageNavVisible}
-          className='inline-flex flex-col items-center justify-center px-5 border-gray-200 border-x hover:bg-gray-50 dark:hover:bg-gray-800 group dark:border-gray-600'>
-          <i className='fa-book fas w-5 h-5 mb-2 text-gray-500 dark:text-gray-400 group-hover:text-gray-600 dark:group-hover:text-gray-500' />
-          <span className='text-sm text-gray-500 dark:text-gray-400 group-hover:text-gray-600 dark:group-hover:text-gray-500'>
+          className={`inline-flex flex-col items-center justify-center rounded-xl transition-all duration-200 border ${
+            pageNavVisible
+              ? 'border-green-200 bg-green-50 text-green-600 shadow-sm dark:border-gray-700 dark:bg-black dark:text-green-400'
+              : 'border-transparent text-gray-500 hover:bg-gray-50 dark:text-gray-400 dark:hover:bg-gray-900'
+          }`}>
+          <i className='fa-book fas w-5 h-5 mb-1.5' />
+          <span className='text-xs tracking-wide'>
             {locale.COMMON.ARTICLE_LIST}
           </span>
         </button>
@@ -37,9 +43,13 @@ export default function BottomMenuBar({ post, className }) {
           <button
             type='button'
             onClick={toggleToc}
-            className='inline-flex flex-col items-center justify-center px-5 border-gray-200 border-x hover:bg-gray-50 dark:hover:bg-gray-800 group dark:border-gray-600'>
-            <i className='fa-list-ol fas w-5 h-5 mb-2 text-gray-500 dark:text-gray-400 group-hover:text-gray-600 dark:group-hover:text-gray-500' />
-            <span class='text-sm text-gray-500 dark:text-gray-400 group-hover:text-gray-600 dark:group-hover:text-gray-500'>
+            className={`inline-flex flex-col items-center justify-center rounded-xl transition-all duration-200 border ${
+              tocVisible
+                ? 'border-green-200 bg-green-50 text-green-600 shadow-sm dark:border-gray-700 dark:bg-black dark:text-green-400'
+                : 'border-transparent text-gray-500 hover:bg-gray-50 dark:text-gray-400 dark:hover:bg-gray-900'
+            }`}>
+            <i className='fa-list-ol fas w-5 h-5 mb-1.5' />
+            <span className='text-xs tracking-wide'>
               {locale.COMMON.TABLE_OF_CONTENTS}
             </span>
           </button>

--- a/themes/gitbook/components/Catalog.js
+++ b/themes/gitbook/components/Catalog.js
@@ -74,7 +74,7 @@ const Catalog = ({ post }) => {
       <div
         id='toc-wrapper'
         className='toc-wrapper overflow-y-auto my-2 max-h-80 overscroll-none scroll-hidden'>
-        <nav className='h-full text-black'>
+        <nav className='h-full text-gray-700 dark:text-gray-300'>
           {toc?.map(tocItem => {
             const id = uuidToId(tocItem.id)
             return (
@@ -82,7 +82,7 @@ const Catalog = ({ post }) => {
                 key={id}
                 href={`#${id}`}
                 //  notion-table-of-contents-item
-                className={`${activeSection === id && 'border-green-500 text-green-500 font-bold'} border-l pl-4 block hover:text-green-500 border-lduration-300 transform font-light dark:text-gray-300
+                className={`${activeSection === id ? 'border-green-500 text-green-600 dark:border-green-500 dark:text-green-400 font-bold' : 'border-gray-300 dark:border-gray-700'} border-l pl-4 block hover:text-green-500 dark:hover:text-green-400 duration-300 transform font-light
               notion-table-of-contents-item-indent-level-${tocItem.indentLevel} catalog-item `}>
                 <span
                   style={{

--- a/themes/gitbook/components/CatalogDrawerWrapper.js
+++ b/themes/gitbook/components/CatalogDrawerWrapper.js
@@ -32,19 +32,19 @@ const CatalogDrawerWrapper = ({ post, cRef }) => {
             (tocVisible
               ? 'animate__slideInRight '
               : ' -mr-72 animate__slideOutRight') +
-            ' overflow-y-hidden shadow-card w-60 duration-200 fixed right-1 bottom-16 rounded py-2 bg-white dark:bg-hexo-black-gray'
+            ' overflow-y-hidden shadow-card w-60 duration-200 fixed right-2 bottom-20 rounded-xl py-2 bg-white dark:bg-hexo-black-gray dark:border dark:border-black'
           }>
           {post && (
             <>
-              <div className='px-4 pb-2 flex justify-between items-center border-b font-bold'>
+              <div className='px-4 pb-2 flex justify-between items-center border-b border-gray-200 dark:border-black font-bold text-gray-800 dark:text-gray-200'>
                 <span>{locale.COMMON.TABLE_OF_CONTENTS}</span>
                 <i
-                  className='fas fa-times p-1 cursor-pointer'
+                  className='fas fa-times p-1 cursor-pointer text-gray-500 dark:text-gray-400'
                   onClick={() => {
                     changeTocVisible(false)
                   }}></i>
               </div>
-              <div className='dark:text-gray-400 text-gray-600 px-3'>
+              <div className='text-gray-600 dark:text-gray-400 px-3'>
                 <Catalog post={post} />
               </div>
             </>
@@ -56,7 +56,7 @@ const CatalogDrawerWrapper = ({ post, cRef }) => {
         id='right-drawer-background'
         className={
           (tocVisible ? 'block' : 'hidden') +
-          ' fixed top-0 left-0 z-30 w-full h-full'
+          ' fixed top-0 left-0 z-30 w-full h-full bg-black/35 dark:bg-black/60'
         }
         onClick={switchVisible}
       />

--- a/themes/gitbook/components/NavPostItem.js
+++ b/themes/gitbook/components/NavPostItem.js
@@ -52,7 +52,7 @@ const NavPostItem = props => {
         <div
           onMouseEnter={onHoverToggle}
           onClick={toggleOpenSubMenu}
-          className='cursor-pointer relative flex justify-between text-md p-2 hover:bg-gray-50 rounded-md dark:hover:bg-yellow-100 dark:hover:text-yellow-600'
+          className='cursor-pointer relative flex justify-between text-md p-2 rounded-md hover:bg-gray-50 dark:hover:bg-gray-900 dark:hover:text-gray-200'
           key={group?.category}>
           <span className={`${expanded && 'font-semibold'}`}>
             {group?.category}
@@ -67,7 +67,7 @@ const NavPostItem = props => {
         </div>
         <Collapse isOpen={expanded} onHeightChange={props.onHeightChange}>
           {group?.items?.map((post, index) => (
-            <div key={index} className='ml-3 border-l'>
+            <div key={index} className='ml-3 border-l border-gray-200 dark:border-gray-700'>
               <BlogPostCard className='ml-3' post={post} />
             </div>
           ))}

--- a/themes/gitbook/components/PageNavDrawer.js
+++ b/themes/gitbook/components/PageNavDrawer.js
@@ -33,17 +33,17 @@ const PageNavDrawer = props => {
         {/* 侧边菜单 */}
         <div
           className={`${pageNavVisible ? 'animate__slideInLeft ' : '-ml-80 animate__slideOutLeft'} 
-                      overflow-y-hidden shadow-card w-72 duration-200 fixed left-1 bottom-16 rounded py-2 bg-white dark:bg-hexo-black-gray`}>
-          <div className='px-4 pb-2 flex justify-between items-center border-b font-bold'>
+                      overflow-y-hidden shadow-card w-72 duration-200 fixed left-2 bottom-20 rounded-xl py-2 bg-white dark:bg-hexo-black-gray dark:border dark:border-black`}>
+          <div className='px-4 pb-2 flex justify-between items-center border-b border-gray-200 dark:border-black font-bold text-gray-800 dark:text-gray-200'>
             <span>{locale.COMMON.ARTICLE_LIST}</span>
             <i
-              className='fas fa-times p-1 cursor-pointer'
+              className='fas fa-times p-1 cursor-pointer text-gray-500 dark:text-gray-400'
               onClick={() => {
                 changePageNavVisible(false)
               }}></i>
           </div>
           {/* 所有文章列表 */}
-          <div className='dark:text-gray-400 text-gray-600 h-96 overflow-y-scroll p-3'>
+          <div className='text-gray-600 dark:text-gray-400 h-96 overflow-y-scroll p-3'>
             <NavPostList filteredNavPages={filteredNavPages} />
           </div>
         </div>
@@ -52,7 +52,7 @@ const PageNavDrawer = props => {
       {/* 背景蒙版 */}
       <div
         id='left-drawer-background'
-        className={`${pageNavVisible ? 'block' : 'hidden'} fixed top-0 left-0 z-30 w-full h-full`}
+        className={`${pageNavVisible ? 'block' : 'hidden'} fixed top-0 left-0 z-30 w-full h-full bg-black/35 dark:bg-black/60`}
         onClick={switchVisible}
       />
     </>


### PR DESCRIPTION
## Summary
- improve Prism mermaid lifecycle so theme switching triggers immediate processing and observer rebinding without hard refresh
- support multiple `#notion-article` containers on one page, processing each container independently
- align gitbook mobile dark-mode palette for bottom bar, article list drawer, and toc drawer with existing gitbook dark theme colors

## Test plan
- [x] Switch themes and verify mermaid diagrams auto-render without manual refresh
- [x] Verify pages with multiple article containers each get mermaid rendering
- [x] Verify gitbook mobile dark bottom bar and both drawers match existing dark palette and remain readable
- [x] Verify article list / toc toggles still function correctly on mobile

Made with [Cursor](https://cursor.com)