### PR TITLE
chore(ci): align Yarn version for Cloudflare builds

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,0 +1,2 @@
+enableImmutableInstalls: false
+nodeLinker: node-modules

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "notion-next",
   "version": "4.9.5.1",
+  "packageManager": "yarn@1.22.22",
   "homepage": "https://github.com/tangly1024/NotionNext.git",
   "license": "MIT",
   "engines": {


### PR DESCRIPTION
## Summary
- pin the project package manager to Yarn 1 to match the existing v1 lockfile
- add Yarn config fallbacks to avoid immutable install failures in Cloudflare builds
- keep `yarn.lock` out of this PR to limit scope to CI/build compatibility

## Test plan
- [x] Confirm branch contains only `package.json` and `.yarnrc.yml` changes
- [ ] Re-run Cloudflare build with `yarn export`
- [ ] Verify install step no longer fails with `YN0028`

Made with [Cursor](https://cursor.com)