### PR TITLE
fix(fuwari): 移动端首页文章列表布局与横向溢出

### DIFF
--- a/themes/fuwari/components/PostList.js
+++ b/themes/fuwari/components/PostList.js
@@ -40,9 +40,9 @@ const PostCard = ({ post }) => {
   const showRail = !showCover
 
   return (
-    <article className='fuwari-card fuwari-card-hover p-4 relative'>
+    <article className='fuwari-card fuwari-card-hover p-4 relative w-full max-w-full min-w-0'>
       <div
-        className={`md:grid md:gap-4 md:items-stretch min-h-[178px] ${
+        className={`w-full min-w-0 md:grid md:gap-4 md:items-stretch min-h-[178px] ${
           showRail
             ? 'md:grid-cols-[minmax(0,1fr)_220px_56px]'
             : 'md:grid-cols-[minmax(0,1fr)_220px]'
@@ -119,7 +119,7 @@ const PostCard = ({ post }) => {
 
 const PostList = ({ posts = [] }) => {
   return (
-    <div id='posts-wrapper' className='grid gap-4'>
+    <div id='posts-wrapper' className='grid gap-4 w-full min-w-0 max-w-full'>
       {posts.map(post => (
         <PostCard key={post.id} post={post} />
       ))}

--- a/themes/fuwari/index.js
+++ b/themes/fuwari/index.js
@@ -60,12 +60,12 @@ const LayoutBase = props => {
 
       {showHomeHero && <HeroBanner siteInfo={props.siteInfo} />}
 
-      <main className={`max-w-6xl mx-auto px-3 md:px-4 pb-12 ${showHomeHero ? 'fuwari-main-overlap' : ''}`}>
-        <div className='grid grid-cols-1 lg:grid-cols-[280px_minmax(0,1fr)] gap-4 lg:gap-6 items-start'>
+      <main className={`max-w-6xl mx-auto px-3 md:px-4 pb-12 min-w-0 w-full ${showHomeHero ? 'fuwari-main-overlap' : ''}`}>
+        <div className='grid grid-cols-1 lg:grid-cols-[280px_minmax(0,1fr)] gap-4 lg:gap-6 items-start min-w-0'>
           <div className='hidden lg:block sticky top-4'>
             <SidePanel {...props} />
           </div>
-          <section>
+          <section className='min-w-0 w-full max-w-full'>
             {children}
             <div className='lg:hidden mt-4'>
               <SidePanel {...props} />

--- a/themes/fuwari/style.js
+++ b/themes/fuwari/style.js
@@ -338,6 +338,23 @@ const Style = () => {
       color: #8c9097;
       min-height: 1.5rem;
     }
+    @media (max-width: 1023px) {
+      #theme-fuwari .fuwari-meta-row {
+        flex-wrap: wrap;
+        white-space: normal;
+        overflow: visible;
+      }
+      #theme-fuwari .fuwari-meta-tags {
+        flex-wrap: wrap;
+        white-space: normal;
+        max-width: 100%;
+      }
+      #theme-fuwari .fuwari-post-title,
+      #theme-fuwari .fuwari-post-title a {
+        overflow-wrap: anywhere;
+        word-break: break-word;
+      }
+    }
     #theme-fuwari .fuwari-meta-item {
       display: inline-flex;
       align-items: center;
@@ -549,8 +566,16 @@ const Style = () => {
       background: color-mix(in oklab, var(--fuwari-primary) 10%, var(--fuwari-surface));
       transform: translateX(1px);
     }
+    #theme-fuwari #posts-wrapper {
+      width: 100%;
+      max-width: 100%;
+      min-width: 0;
+    }
     #theme-fuwari #posts-wrapper article {
       border-radius: 1.15rem;
+      max-width: 100%;
+      min-width: 0;
+      box-sizing: border-box;
     }
     #theme-fuwari aside > section.fuwari-card {
       border-radius: 1.05rem;


### PR DESCRIPTION
## 问题

移动端（含平板单列布局）下，Fuwari 主题首页文章列表卡片视觉上未居中，易出现一侧留白、另一侧顶出或横向溢出。

## 原因

- `.fuwari-meta-row` 使用 `white-space: nowrap`，日期、分类、标签被强制单行排列，在窄屏下撑大行框最小宽度。
- 布局链上缺少 `min-w-0` / `max-w-full`，网格子项无法按视口正确收缩（flex/grid 默认 `min-width: auto`）。

## 修改

- 在 `max-width: 1023px`（与主题 `lg` 单列布局一致）下：元数据行与标签允许换行；标题链接增加 `overflow-wrap` / `word-break`，避免长字符串撑破布局。
- 为 `#posts-wrapper`、其中 `article`、`main`、内容 `section` 与 `PostList` 卡片链补充 `width` / `min-width` / `max-width` 约束。
- `PostList` 内层网格容器增加 `w-full min-w-0`。

## 验证建议

- 手机或小窗 DevTools 打开首页，确认卡片无横向滚动条、与左右 `padding` 对称。
- 抽一篇带长标题、多标签的文章检查换行与自然排版。