### PR TITLE
feat: Fuwari 优化 + 主题动态加载 + 开发体验

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,4 +1,3 @@
-const { THEME } = require('./blog.config')
 const fs = require('node:fs')
 const path = require('node:path')
 const BLOG = require('./blog.config')
@@ -32,13 +31,36 @@ const locales = (function () {
   return langs
 })()
 
-// next dev 启动时提示：开发环境默认读/写 Notion 缓存（见 conf/dev.config.js 中 ENABLE_CACHE）
+// next dev 时配置可能被多个 worker 各自加载一次，globalThis 无法跨进程去重；用独占文件锁只打印一行。
 ;(function printDevCacheHint() {
   if (process.env.npm_lifecycle_event !== 'dev') return
-  if (globalThis.__NOTIONNEXT_DEV_CACHE_HINT_PRINTED__) return
-  globalThis.__NOTIONNEXT_DEV_CACHE_HINT_PRINTED__ = true
-  console.log('\n[NotionNext] Dev cache is ON (ENABLE_CACHE=true).')
-  console.log('[NotionNext] Need realtime data? Set ENABLE_CACHE=false in .env.local\n')
+  const lockFile = path.join(__dirname, '.next', 'dev-cache-hint.lock')
+  const siblingWindowMs = 15_000 // 同一次 dev 内多 worker；间隔超过则视为新会话，删掉旧锁再提示
+  try {
+    fs.mkdirSync(path.dirname(lockFile), { recursive: true })
+    if (fs.existsSync(lockFile)) {
+      const age = Date.now() - fs.statSync(lockFile).mtimeMs
+      if (age < siblingWindowMs) {
+        return
+      }
+      try {
+        fs.unlinkSync(lockFile)
+      } catch (err) {
+        if (err && err.code !== 'ENOENT') return
+      }
+    }
+  } catch (_) {
+    return
+  }
+  try {
+    fs.closeSync(fs.openSync(lockFile, 'wx'))
+  } catch (e) {
+    if (e && e.code === 'EEXIST') return
+    return
+  }
+  console.log(
+    '[NotionNext] Dev cache ON (ENABLE_CACHE=true); live Notion data → ENABLE_CACHE=false in .env.local'
+  )
 })()
 
 // 编译前执行
@@ -317,12 +339,13 @@ const nextConfig = {
 
     if (!isServer) {
       console.log(
-        '[ThemeResolver][webpack-default-only]',
+        '[ThemeResolver][webpack]',
         JSON.stringify({
-          note: 'This is only webpack default theme alias, not final runtime theme.',
+          note:
+            'Layouts load via dynamic import(@/themes/<name>). Theme folder follows runtime NEXT_PUBLIC_THEME / Notion; no compile-time @theme-components alias.',
           envTheme: process.env.NEXT_PUBLIC_THEME || null,
-          configTheme: THEME,
-          resolvedDefaultThemePath: path.resolve(__dirname, 'themes', THEME)
+          configTheme: BLOG.THEME,
+          themeFolderPath: path.resolve(__dirname, 'themes', BLOG.THEME)
         })
       )
       config.resolve.fallback = {
@@ -334,12 +357,6 @@ const nextConfig = {
         path: false
       }
     }
-    config.resolve.alias['@theme-components'] = path.resolve(
-      __dirname,
-      'themes',
-      THEME
-    )
-
     return config
   }
   ,

--- a/themes/fuwari/components/ArticleHeroCover.js
+++ b/themes/fuwari/components/ArticleHeroCover.js
@@ -1,0 +1,22 @@
+/**
+ * 文章卡片内顶部封面（直角矩形 + object-cover）
+ */
+const ArticleHeroCover = ({ coverSrc, title }) => {
+  if (!coverSrc) return null
+
+  return (
+    <div className='fuwari-article-card-cover mb-6 min-w-0 w-full'>
+      <div className='relative h-[200px] w-full overflow-hidden sm:h-[240px] md:h-[260px]'>
+        <img
+          src={coverSrc}
+          alt={title ? `封面：${title}` : ''}
+          className='absolute inset-0 h-full w-full object-cover object-center'
+          loading='eager'
+          decoding='async'
+        />
+      </div>
+    </div>
+  )
+}
+
+export default ArticleHeroCover

--- a/themes/fuwari/components/PostList.js
+++ b/themes/fuwari/components/PostList.js
@@ -31,22 +31,35 @@ const getArchiveHref = (publishDay, router) => {
 
 const PostCard = ({ post }) => {
   const router = useRouter()
+  const coverColPx = Math.min(
+    360,
+    Math.max(200, Number(siteConfig('FUWARI_POST_LIST_COVER_COL_WIDTH', 280, CONFIG)) || 280)
+  )
   const coverSrc =
     post.pageCoverThumbnail ||
-    (siteConfig('FUWARI_POST_LIST_COVER_DEFAULT', true, CONFIG) &&
+    (siteConfig('FUWARI_POST_LIST_COVER_DEFAULT', false, CONFIG) &&
       siteConfig('HOME_BANNER_IMAGE'))
   const [coverFailed, setCoverFailed] = useState(false)
   const showCover = Boolean(coverSrc) && !coverFailed
   const showRail = !showCover
+  const listCoverOn = siteConfig('FUWARI_POST_LIST_COVER', true, CONFIG)
+  const showCoverBlock = listCoverOn && showCover
+
+  const gridTemplateColumns = (() => {
+    if (showCoverBlock) {
+      return `minmax(0, 1fr) ${coverColPx}px`
+    }
+    if (showRail) {
+      return `minmax(0, 1fr) 56px`
+    }
+    return 'minmax(0, 1fr)'
+  })()
 
   return (
     <article className='fuwari-card fuwari-card-hover p-4 relative w-full max-w-full min-w-0'>
       <div
-        className={`w-full min-w-0 md:grid md:gap-4 md:items-stretch min-h-[178px] ${
-          showRail
-            ? 'md:grid-cols-[minmax(0,1fr)_220px_56px]'
-            : 'md:grid-cols-[minmax(0,1fr)_220px]'
-        }`}>
+        className={`fuwari-post-card-grid w-full min-w-0 md:grid md:gap-4 md:items-stretch min-h-[178px]`}
+        style={{ gridTemplateColumns }}>
         <div className='min-w-0 flex-1 md:pr-1'>
           <h2 className='fuwari-post-title text-[2rem] font-bold mb-1.5 leading-tight'>
             <SmartLink href={post.href || `/${post.slug}`} className='hover:opacity-90 transition-opacity'>
@@ -88,23 +101,19 @@ const PostCard = ({ post }) => {
             </p>
           )}
         </div>
-        {siteConfig('FUWARI_POST_LIST_COVER', true, CONFIG) && (
+        {showCoverBlock && (
           <div className='mt-4 md:mt-0'>
-            {showCover ? (
-              <SmartLink href={post.href || `/${post.slug}`}>
-                <div
-                  className={`fuwari-cover-wrap h-full ${siteConfig('FUWARI_POST_LIST_COVER_HOVER_ENLARGE', true, CONFIG) ? 'fuwari-cover-enlarge' : ''}`}>
-                  <img
-                    src={coverSrc}
-                    alt={post.title}
-                    className='w-full h-40 md:h-full object-cover rounded-2xl'
-                    onError={() => setCoverFailed(true)}
-                  />
-                </div>
-              </SmartLink>
-            ) : (
-              <div className='hidden md:block h-full' />
-            )}
+            <SmartLink href={post.href || `/${post.slug}`}>
+              <div
+                className={`fuwari-cover-wrap h-full ${siteConfig('FUWARI_POST_LIST_COVER_HOVER_ENLARGE', true, CONFIG) ? 'fuwari-cover-enlarge' : ''}`}>
+                <img
+                  src={coverSrc}
+                  alt={post.title}
+                  className='w-full aspect-[2/1] max-h-52 md:aspect-auto md:max-h-none md:h-full md:min-h-[168px] object-cover rounded-2xl'
+                  onError={() => setCoverFailed(true)}
+                />
+              </div>
+            </SmartLink>
           </div>
         )}
         {showRail && (

--- a/themes/fuwari/config.js
+++ b/themes/fuwari/config.js
@@ -26,13 +26,15 @@ const CONFIG = {
   /** 是否显示右侧封面图区域 */
   FUWARI_POST_LIST_COVER: true,
   /** 无文章封面时，是否用站点横幅图（HOME_BANNER_IMAGE）作默认图 */
-  FUWARI_POST_LIST_COVER_DEFAULT: true,
+  FUWARI_POST_LIST_COVER_DEFAULT: false,
   /** 封面悬停轻微放大 */
   FUWARI_POST_LIST_COVER_HOVER_ENLARGE: true,
   /** 显示摘要（有 summary 时） */
   FUWARI_POST_LIST_SUMMARY: true,
   /** 卡片内显示标签 */
   FUWARI_POST_LIST_TAG: true,
+  /** 桌面端列表卡片封面列宽度（px），增大则更扁长横向 */
+  FUWARI_POST_LIST_COVER_COL_WIDTH: 280,
 
   // ---------------------------------------------------------------------------
   // 移动端
@@ -123,6 +125,8 @@ const CONFIG = {
   // ---------------------------------------------------------------------------
   // 文章页
   // ---------------------------------------------------------------------------
+  /** 有 Notion 封面时，在详情页文章卡片内顶部展示封面图（object-cover，不占满屏） */
+  FUWARI_ARTICLE_COVER_HERO: false,
   /** 文首：日期、分类、标签等元信息 */
   FUWARI_ARTICLE_META: true,
   /** 分享条 */

--- a/themes/fuwari/index.js
+++ b/themes/fuwari/index.js
@@ -17,6 +17,7 @@ import ArticleHeader from './components/ArticleHeader'
 import ArticleLock from './components/ArticleLock'
 import Footer from './components/Footer'
 import Header from './components/Header'
+import ArticleHeroCover from './components/ArticleHeroCover'
 import HeroBanner from './components/HeroBanner'
 import Pagination from './components/Pagination'
 import PostList from './components/PostList'
@@ -60,7 +61,8 @@ const LayoutBase = props => {
 
       {showHomeHero && <HeroBanner siteInfo={props.siteInfo} />}
 
-      <main className={`max-w-6xl mx-auto px-3 md:px-4 pb-12 min-w-0 w-full ${showHomeHero ? 'fuwari-main-overlap' : ''}`}>
+      <main
+        className={`max-w-6xl mx-auto px-3 md:px-4 pb-12 min-w-0 w-full ${showHomeHero ? 'fuwari-main-overlap' : ''}`}>
         <div className='grid grid-cols-1 lg:grid-cols-[280px_minmax(0,1fr)] gap-4 lg:gap-6 items-start min-w-0'>
           <div className='hidden lg:block sticky top-4'>
             <SidePanel {...props} />
@@ -113,12 +115,18 @@ const LayoutSlug = props => {
   if (!post) return null
   const showComments =
     siteConfig('FUWARI_ARTICLE_COMMENT', true, CONFIG) && isCommentServiceConfigured()
+  const articleCoverSrc =
+    siteConfig('FUWARI_ARTICLE_COVER_HERO', true, CONFIG) &&
+    (post.pageCover || post.pageCoverThumbnail)
   return (
     <>
       {lock ? (
         <ArticleLock validPassword={validPassword} />
       ) : (
-        <article className='fuwari-card p-6'>
+        <article className='fuwari-card p-6 overflow-hidden'>
+          {articleCoverSrc ? (
+            <ArticleHeroCover coverSrc={articleCoverSrc} title={post.title} />
+          ) : null}
           <ArticleHeader post={post} />
           <div id='article-wrapper' className='fuwari-prose'>
             <NotionPage post={post} />

--- a/themes/theme.js
+++ b/themes/theme.js
@@ -1,5 +1,4 @@
 import BLOG, { LAYOUT_MAPPINGS } from '@/blog.config'
-import * as ThemeComponents from '@theme-components'
 import getConfig from 'next/config'
 import dynamic from 'next/dynamic'
 import { useRouter } from 'next/router'
@@ -29,50 +28,39 @@ const scheduleFixThemeDOM = (delay = 120) => {
   }, delay)
 }
 
+async function importThemeConfig(themeFolderName) {
+  try {
+    const mod = await import(`@/themes/${themeFolderName}`)
+    return mod?.THEME_CONFIG ?? null
+  } catch (err) {
+    console.error(`Failed to load theme config "${themeFolderName}":`, err)
+    return null
+  }
+}
+
 /**
- * 获取主题配置
+ * 获取主题配置（始终动态加载，与运行时 BLOG.THEME / URL ?theme 一致；不依赖编译期别名）。
  * @param {string} themeQuery - 主题查询参数（支持多个主题用逗号分隔）
- * @returns {Promise<object>} 主题配置对象
+ * @returns {Promise<object|null>} 主题配置对象
  */
 export const getThemeConfig = async themeQuery => {
   const themeName = normalizeThemeName(themeQuery)
-
-  // 处理主题与默认一致时，直接返回默认配置
-  if (!themeName || themeName === BLOG.THEME) {
-    return ThemeComponents?.THEME_CONFIG
+  let cfg = await importThemeConfig(themeName)
+  if (cfg) {
+    return cfg
   }
-
-  // 如果 themeQuery 存在且不等于默认主题，处理多主题情况
-  try {
-    // 动态导入主题配置
-    const THEME_CONFIG = await import(`@/themes/${themeName}`)
-      .then(m => m.THEME_CONFIG)
-      .catch(err => {
-        console.error(`Failed to load theme ${themeName}:`, err)
-        return null // 主题加载失败时返回 null 或者其他默认值
-      })
-
-    // 如果主题配置加载成功，返回配置
-    if (THEME_CONFIG) {
-      return THEME_CONFIG
-    } else {
-      // 如果加载失败，返回默认主题配置
+  const fallback = normalizeThemeName(BLOG.THEME)
+  if (fallback !== themeName) {
+    cfg = await importThemeConfig(fallback)
+    if (cfg) {
       console.warn(
-        `Loading ${themeName} failed. Falling back to default theme.`
+        `[theme] "${themeName}" config unavailable, using fallback "${fallback}".`
       )
-      return ThemeComponents?.THEME_CONFIG
+      return cfg
     }
-  } catch (error) {
-    // 如果 import 过程中出现异常，返回默认主题配置
-    console.error(
-      `Error loading theme configuration for ${themeName}:`,
-      error
-    )
-    return ThemeComponents?.THEME_CONFIG
   }
-
-  // 如果没有 themeQuery 或 themeQuery 与默认主题相同，返回默认主题配置
-  return ThemeComponents?.THEME_CONFIG
+  console.error('[theme] No theme configuration could be loaded.')
+  return null
 }
 
 /**
@@ -92,22 +80,25 @@ const getCurrentTheme = (router, fallbackTheme) => {
  * @returns
  */
 export const getBaseLayoutByTheme = theme => {
-  const LayoutBase = ThemeComponents['LayoutBase']
   const normalizedTheme = normalizeThemeName(theme)
-  const isDefaultTheme = !normalizedTheme || normalizedTheme === BLOG.THEME
-  if (!isDefaultTheme) {
-    if (baseLayoutCache.has(normalizedTheme)) {
-      return baseLayoutCache.get(normalizedTheme)
-    }
-    const DynamicBaseLayout = dynamic(
-      () => import(`@/themes/${normalizedTheme}`).then(m => m['LayoutBase']),
-      { ssr: true }
-    )
-    baseLayoutCache.set(normalizedTheme, DynamicBaseLayout)
-    return DynamicBaseLayout
+  if (baseLayoutCache.has(normalizedTheme)) {
+    return baseLayoutCache.get(normalizedTheme)
   }
-
-  return LayoutBase
+  const DynamicBaseLayout = dynamic(
+    () =>
+      import(`@/themes/${normalizedTheme}`).then(m => {
+        const Base = m['LayoutBase']
+        if (!Base) {
+          throw new Error(
+            `[theme] LayoutBase missing in themes/${normalizedTheme}`
+          )
+        }
+        return Base
+      }),
+    { ssr: true }
+  )
+  baseLayoutCache.set(normalizedTheme, DynamicBaseLayout)
+  return DynamicBaseLayout
 }
 
 /**
@@ -127,37 +118,32 @@ export const DynamicLayout = props => {
  * @returns
  */
 export const useLayoutByTheme = ({ layoutName, theme }) => {
-  // const layoutName = getLayoutNameByPath(router.pathname, router.asPath)
-  const LayoutComponents =
-    ThemeComponents[layoutName] || ThemeComponents.LayoutSlug
-
   const router = useRouter()
   const themeQuery = getCurrentTheme(router, theme)
-  const isDefaultTheme = !themeQuery || themeQuery === BLOG.THEME
+  const cacheKey = `${themeQuery}:${layoutName}`
 
-  // 加载非当前默认主题
-  if (!isDefaultTheme) {
-    const cacheKey = `${themeQuery}:${layoutName}`
-    if (layoutByThemeCache.has(cacheKey)) {
-      scheduleFixThemeDOM(240)
-      return layoutByThemeCache.get(cacheKey)
-    }
-    const DynamicLayoutComponent = dynamic(
-      () =>
-        import(`@/themes/${themeQuery}`).then(componentsSource => {
-          return (
-            componentsSource[layoutName] || componentsSource.LayoutSlug
-          )
-        }),
-      { ssr: true }
-    )
-    layoutByThemeCache.set(cacheKey, DynamicLayoutComponent)
-    scheduleFixThemeDOM(240)
-    return DynamicLayoutComponent
+  if (layoutByThemeCache.has(cacheKey)) {
+    scheduleFixThemeDOM(themeQuery === BLOG.THEME ? 80 : 240)
+    return layoutByThemeCache.get(cacheKey)
   }
 
-  scheduleFixThemeDOM(80)
-  return LayoutComponents
+  const DynamicLayoutComponent = dynamic(
+    () =>
+      import(`@/themes/${themeQuery}`).then(componentsSource => {
+        const Selected =
+          componentsSource[layoutName] || componentsSource.LayoutSlug
+        if (!Selected) {
+          throw new Error(
+            `[theme] Layout "${layoutName}" missing in themes/${themeQuery}`
+          )
+        }
+        return Selected
+      }),
+    { ssr: true }
+  )
+  layoutByThemeCache.set(cacheKey, DynamicLayoutComponent)
+  scheduleFixThemeDOM(themeQuery === BLOG.THEME ? 80 : 240)
+  return DynamicLayoutComponent
 }
 
 /**


### PR DESCRIPTION
## 范围概述

### 全站主题（`themes/theme.js`、`next.config.js`）

- 移除编译期 `@theme-components` 绑定与运行时主题不一致的问题：Layout、`THEME_CONFIG` 统一按解析到的主题名通过 `dynamic import('@/themes/<name>')` 加载；修改 `NEXT_PUBLIC_THEME` 后无需再删 `.next` 来对齐别名。
- Webpack 不再配置 `@theme-components` 别名；保留一条说明性 webpack 日志。

### 开发体验（`next.config.js`）

- `next dev` 时多 worker 重复打印的缓存提示合并为一条，并用 `.next/dev-cache-hint.lock` 去重。

### Fuwari 主题

- **文章详情**：有封面时在卡片内展示 `ArticleHeroCover`（直角矩形、`object-cover`）；可通过 `FUWARI_ARTICLE_COVER_HERO` 关闭。
- **首页列表**：`FUWARI_POST_LIST_COVER_COL_WIDTH` 控制桌面端封面列宽；移动端使用横幅比例；**无封面时**不再占位封面列，正文与右侧 rail 两列布局以拉宽标题区。

---

## 涉及文件

| 文件 | 说明 |
|------|------|
| `themes/theme.js` | 动态加载默认主题 Layout / 配置 |
| `next.config.js` | 移除别名、日志与 dev 提示 |
| `themes/fuwari/components/ArticleHeroCover.js` | 新增：文章卡片内封面 |
| `themes/fuwari/components/PostList.js` | 封面列宽与无封面栅格 |
| `themes/fuwari/config.js` | 新增配置项 |
| `themes/fuwari/index.js` | 文章页接入封面 |
