### PR TITLE
feat: Fuwari theme polish, dev UX, and Claude/Fuwari nested navigation

### DIFF
--- a/themes/claude/components/MenuList.js
+++ b/themes/claude/components/MenuList.js
@@ -1,16 +1,30 @@
-import { siteConfig } from '@/lib/config'
 import { useGlobal } from '@/lib/global'
 import { useRouter } from 'next/router'
-import CONFIG from '../config'
+import { useState } from 'react'
 import SmartLink from '@/components/SmartLink'
+import { getClaudeMenuLinks } from './menu'
+
+const pathMatches = (asPath, href) => {
+  if (!href) return false
+  if (asPath === href) return true
+  if (href !== '/' && asPath.startsWith(href)) {
+    const next = asPath.charAt(href.length)
+    return next === '' || next === '/' || next === '?'
+  }
+  return false
+}
 
 /**
- * 菜单导航 — Claude Docs 风格
- * 简洁文字链接，带左边框活跃指示器
+ * 菜单导航 — Claude Docs 风格；桌面侧栏 + 移动纵向列表，支持二级展开（subMenus / children）
  */
 export const MenuList = ({ customNav, customMenu }) => {
   const { locale } = useGlobal()
   const router = useRouter()
+  const [openSubId, setOpenSubId] = useState(null)
+
+  const links = getClaudeMenuLinks({ locale, customNav, customMenu }).filter(
+    l => l?.show !== false
+  )
 
   const renderMenuIcon = icon => {
     if (!icon || typeof icon !== 'string') {
@@ -21,8 +35,9 @@ export const MenuList = ({ customNav, customMenu }) => {
       return null
     }
 
-    // Notion icon 字段可直接写 Font Awesome 类名，例如 "fas fa-clock-rotate-left"
-    const isFontAwesomeIcon = /(^|\s)fa[srldb]?\s/.test(normalizedIcon) || /(^|\s)fa-[\w-]+/.test(normalizedIcon)
+    const isFontAwesomeIcon =
+      /(^|\s)fa[srldb]?\s/.test(normalizedIcon) ||
+      /(^|\s)fa-[\w-]+/.test(normalizedIcon)
     if (isFontAwesomeIcon) {
       return <i className={`${normalizedIcon} claude-nav-icon`} aria-hidden='true' />
     }
@@ -34,67 +49,108 @@ export const MenuList = ({ customNav, customMenu }) => {
     )
   }
 
-  let links = [
-    {
-      icon: 'fas fa-archive',
-      name: locale.NAV.ARCHIVE,
-      href: '/archive',
-      show: siteConfig('CLAUDE_MENU_ARCHIVE', null, CONFIG)
-    },
-    {
-      icon: 'fas fa-folder',
-      name: locale.COMMON.CATEGORY,
-      href: '/category',
-      show: siteConfig('CLAUDE_MENU_CATEGORY', null, CONFIG)
-    },
-    {
-      icon: 'fas fa-tag',
-      name: locale.COMMON.TAGS,
-      href: '/tag',
-      show: siteConfig('CLAUDE_MENU_TAG', null, CONFIG)
+  const toggleSub = id => {
+    setOpenSubId(prev => (prev === id ? null : id))
+  }
+
+  const renderLeafLink = link => {
+    const isActive = pathMatches(router.asPath, link.href)
+
+    return (
+      <SmartLink key={link.id} href={link.href} target={link.target}>
+        <div className={`claude-nav-link ${isActive ? 'active' : ''}`}>
+          {renderMenuIcon(link.icon)}
+          <span className='claude-nav-label'>{link.name}</span>
+        </div>
+      </SmartLink>
+    )
+  }
+
+  const renderGroup = link => {
+    const hasSub = link.subMenus?.length > 0
+    const isOpen = openSubId === link.id
+
+    if (!hasSub && link.href) {
+      return renderLeafLink(link)
     }
-  ]
 
-  if (Array.isArray(customNav) && customNav.length > 0) {
-    links = links.concat(customNav)
+    const childActive = link.subMenus?.some(s => pathMatches(router.asPath, s.href))
+    const parentLooksActive = childActive
+
+    return (
+      <div key={link.id} className='claude-nav-group'>
+        <div className='claude-nav-parent-row'>
+          <div
+            className={`claude-nav-link claude-nav-parent-link claude-nav-parent-fallback ${parentLooksActive ? 'active' : ''}`}
+            role='button'
+            tabIndex={0}
+            aria-expanded={isOpen}
+            aria-controls={`claude-submenu-${link.id}`}
+            onClick={() => toggleSub(link.id)}
+            onKeyDown={e => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault()
+                toggleSub(link.id)
+              }
+            }}>
+            {renderMenuIcon(link.icon)}
+            <span className='claude-nav-label'>{link.name}</span>
+          </div>
+          <button
+            type='button'
+            className='claude-nav-submenu-toggle'
+            aria-expanded={isOpen}
+            aria-controls={`claude-submenu-${link.id}`}
+            aria-label={
+              router.locale?.startsWith?.('zh')
+                ? isOpen
+                  ? '收起子菜单'
+                  : '展开子菜单'
+                : isOpen
+                  ? 'Collapse submenu'
+                  : 'Expand submenu'
+            }
+            onClick={() => toggleSub(link.id)}>
+            <i className={`fas fa-angle-down claude-nav-chevron ${isOpen ? 'claude-nav-chevron-open' : ''}`} />
+          </button>
+        </div>
+        {isOpen && (
+          <div id={`claude-submenu-${link.id}`} className='claude-nav-submenu'>
+            {link.subMenus.map(sub => (
+              <SmartLink key={sub.id || sub.href} href={sub.href} target={sub.target}>
+                <div
+                  className={`claude-nav-link claude-nav-sublink ${pathMatches(router.asPath, sub.href) ? 'active' : ''}`}>
+                  {renderMenuIcon(sub.icon)}
+                  <span className='claude-nav-label'>{sub.name}</span>
+                </div>
+              </SmartLink>
+            ))}
+          </div>
+        )}
+      </div>
+    )
   }
 
-  if (siteConfig('CUSTOM_MENU') && Array.isArray(customMenu) && customMenu.length > 0) {
-    links = customMenu
-  }
-
-  if (!links || links.length === 0) {
+  if (!links.length) {
     return null
   }
 
   return (
     <>
-      {/* 桌面端 — 垂直列表 */}
       <div id='nav-menu-pc' className='hidden md:flex md:flex-col md:gap-0.5'>
-        {links?.filter(l => l?.show !== false).map((link, index) => {
-          const isActive = router.asPath === link.href ||
-            (link.href !== '/' && router.asPath.startsWith(link.href))
-          return (
-            <SmartLink key={index} href={link.href}>
-              <div className={`claude-nav-link ${isActive ? 'active' : ''}`}>
-                {renderMenuIcon(link.icon)}
-                <span className='claude-nav-label'>{link.name}</span>
-              </div>
-            </SmartLink>
-          )
-        })}
+        {links.map((link, index) =>
+          link.subMenus?.length
+            ? renderGroup({ ...link, id: link.id ?? `menu-${index}` })
+            : renderLeafLink({ ...link, id: link.id ?? `menu-${index}` })
+        )}
       </div>
 
-      {/* 移动端 — 水平行 */}
-      <div id='nav-menu-mobile' className='flex md:hidden justify-center gap-4'>
-        {links?.filter(l => l?.show !== false).map((link, index) => (
-          <SmartLink key={index} href={link.href}>
-            <div className='claude-nav-link'>
-              {renderMenuIcon(link.icon)}
-              <span className='claude-nav-label'>{link.name}</span>
-            </div>
-          </SmartLink>
-        ))}
+      <div id='nav-menu-mobile' className='flex md:hidden flex-col gap-0.5 w-full'>
+        {links.map((link, index) =>
+          link.subMenus?.length
+            ? renderGroup({ ...link, id: link.id ?? `menu-${index}` })
+            : renderLeafLink({ ...link, id: link.id ?? `menu-${index}` })
+        )}
       </div>
     </>
   )

--- a/themes/claude/components/menu.js
+++ b/themes/claude/components/menu.js
@@ -1,0 +1,76 @@
+import { siteConfig } from '@/lib/config'
+import CONFIG from '../config'
+
+const normalizeSubMenus = subMenus =>
+  (Array.isArray(subMenus) ? subMenus : [])
+    .map((item, index) => {
+      if (!item) return null
+      return {
+        id: item.id || `sub-${index}`,
+        name: item.name || item.title || item.label || '',
+        href: item.href || item.url || '',
+        target: item.target,
+        icon: item.icon
+      }
+    })
+    .filter(item => item && item.name && item.href)
+
+const normalizeMenu = links =>
+  (Array.isArray(links) ? links : [])
+    .map((link, index) => {
+      if (!link) return null
+      const subMenus = normalizeSubMenus(link.subMenus || link.children)
+      return {
+        ...link,
+        id: link.id ?? `menu-${index}`,
+        name: link.name || link.title || link.label || '',
+        href: link.href || link.url || '',
+        subMenus
+      }
+    })
+    .filter(link => {
+      if (!link || link.show === false) return false
+      const subs = link.subMenus?.length > 0
+      return Boolean(link.href) || subs
+    })
+
+/**
+ * Claude 侧栏 / 移动导航菜单（支持 subMenus / children 二级项）
+ * 与 fuwari / Notion CUSTOM_MENU 结构对齐
+ */
+export function getClaudeMenuLinks({ locale, customNav, customMenu }) {
+  let links = [
+    {
+      icon: 'fas fa-archive',
+      name: locale.NAV.ARCHIVE,
+      href: '/archive',
+      show: siteConfig('CLAUDE_MENU_ARCHIVE', null, CONFIG)
+    },
+    {
+      icon: 'fas fa-folder',
+      name: locale.COMMON.CATEGORY,
+      href: '/category',
+      show: siteConfig('CLAUDE_MENU_CATEGORY', null, CONFIG)
+    },
+    {
+      icon: 'fas fa-tag',
+      name: locale.COMMON.TAGS,
+      href: '/tag',
+      show: siteConfig('CLAUDE_MENU_TAG', null, CONFIG)
+    }
+  ]
+
+  if (Array.isArray(customNav) && customNav.length > 0) {
+    links = links.concat(customNav)
+  }
+
+  if (
+    siteConfig('CUSTOM_MENU') &&
+    Array.isArray(customMenu) &&
+    customMenu.length > 0
+  ) {
+    links = customMenu
+  }
+
+  return normalizeMenu(links)
+}

--- a/themes/claude/style.js
+++ b/themes/claude/style.js
@@ -620,6 +620,70 @@ const Style = () => {
         color: inherit;
       }
 
+      .claude-nav-group {
+        display: flex;
+        flex-direction: column;
+      }
+      .claude-nav-parent-row {
+        display: flex;
+        align-items: stretch;
+        gap: 0;
+      }
+      .claude-nav-parent-link {
+        flex: 1 1 auto;
+        min-width: 0;
+        display: block;
+        text-decoration: none;
+        color: inherit;
+      }
+      .claude-nav-parent-fallback {
+        flex: 1 1 auto;
+        min-width: 0;
+        cursor: pointer;
+      }
+      .claude-nav-submenu-toggle {
+        flex: 0 0 auto;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 2.25rem;
+        min-width: 2.25rem;
+        padding: 0;
+        margin: 0;
+        border: none;
+        background: transparent;
+        color: var(--claude-text-tertiary);
+        cursor: pointer;
+        border-radius: 6px;
+        transition: color 0.15s ease, background-color 0.15s ease;
+      }
+      .claude-nav-submenu-toggle:hover {
+        color: var(--claude-sidebar-active-text);
+        background-color: var(--claude-sidebar-active-bg);
+      }
+      .claude-nav-chevron {
+        font-size: 0.75rem;
+        transition: transform 0.2s ease;
+      }
+      .claude-nav-chevron-open {
+        transform: rotate(-180deg);
+      }
+      .claude-nav-submenu {
+        display: flex;
+        flex-direction: column;
+        gap: 0.125rem;
+        padding: 0.125rem 0 0.375rem 0;
+        margin-left: 0.625rem;
+        padding-left: 0.625rem;
+        border-left: 1px solid var(--claude-profile-divider-border);
+      }
+      .claude-profile-nav-section .claude-nav-submenu {
+        margin-left: 0.5rem;
+      }
+      .claude-nav-sublink {
+        padding-left: 0.625rem;
+      }
+
       /* Social icons */
       .claude-social-row {
         display: flex;

--- a/themes/fuwari/components/MenuList.js
+++ b/themes/fuwari/components/MenuList.js
@@ -3,11 +3,19 @@ import { useState } from 'react'
 import { getFuwariMenuLinks } from './menu'
 
 const MenuList = ({ locale, customNav, customMenu, mobile = false }) => {
-  const [activeId, setActiveId] = useState(null)
+  const [hoverSubId, setHoverSubId] = useState(null)
+  const [clickSubId, setClickSubId] = useState(null)
   const links = getFuwariMenuLinks({ locale, customNav, customMenu })
   if (!links.length) return null
 
   const displayLinks = mobile ? links.slice(0, 4) : links
+
+  const isDesktopSubOpen = linkId =>
+    linkId != null && (hoverSubId === linkId || clickSubId === linkId)
+
+  const toggleDesktopSub = linkId => {
+    setClickSubId(prev => (prev === linkId ? null : linkId))
+  }
 
   if (mobile) {
     return (
@@ -30,8 +38,8 @@ const MenuList = ({ locale, customNav, customMenu, mobile = false }) => {
         <div
           key={link.id || `${link.href}-${index}`}
           className='relative'
-          onMouseEnter={() => setActiveId(link.id)}
-          onMouseLeave={() => setActiveId(null)}>
+          onMouseEnter={() => setHoverSubId(link.id)}
+          onMouseLeave={() => setHoverSubId(null)}>
           {!link.subMenus?.length && link.href ? (
             <SmartLink
               href={link.href}
@@ -39,17 +47,37 @@ const MenuList = ({ locale, customNav, customMenu, mobile = false }) => {
               {link.name || link.title}
             </SmartLink>
           ) : (
-            <div className='px-3 py-1.5 rounded-lg font-semibold hover:bg-[var(--fuwari-bg-soft)] cursor-default select-none'>
+            <div
+              className={`px-3 py-1.5 rounded-lg font-semibold hover:bg-[var(--fuwari-bg-soft)] select-none ${
+                link.subMenus?.length ? 'cursor-pointer' : 'cursor-default'
+              }`}
+              role={link.subMenus?.length ? 'button' : undefined}
+              tabIndex={link.subMenus?.length ? 0 : undefined}
+              aria-expanded={
+                link.subMenus?.length ? isDesktopSubOpen(link.id) : undefined
+              }
+              onClick={() => link.subMenus?.length && toggleDesktopSub(link.id)}
+              onKeyDown={e => {
+                if (
+                  link.subMenus?.length &&
+                  (e.key === 'Enter' || e.key === ' ')
+                ) {
+                  e.preventDefault()
+                  toggleDesktopSub(link.id)
+                }
+              }}>
               {link.name || link.title}
-              {!!link.subMenus?.length && <i className='fas fa-angle-down ml-1 text-xs' />}
+              {!!link.subMenus?.length && (
+                <i className='fas fa-angle-down ml-1 text-xs' aria-hidden />
+              )}
             </div>
           )}
 
           {!!link.subMenus?.length && (
             <ul
-              onMouseEnter={() => setActiveId(link.id)}
-              onMouseLeave={() => setActiveId(null)}
-              className={`${activeId === link.id ? 'visible opacity-100 translate-y-0 pointer-events-auto' : 'invisible opacity-0 -translate-y-1 pointer-events-none'} absolute left-0 top-10 min-w-[10rem] fuwari-card p-1.5 transition-all duration-200 z-40`}>
+              onMouseEnter={() => setHoverSubId(link.id)}
+              onMouseLeave={() => setHoverSubId(null)}
+              className={`${isDesktopSubOpen(link.id) ? 'visible opacity-100 translate-y-0 pointer-events-auto' : 'invisible opacity-0 -translate-y-1 pointer-events-none'} absolute left-0 top-10 min-w-[10rem] fuwari-card p-1.5 transition-all duration-200 z-40`}>
               <div className='absolute -top-2 left-0 w-full h-2' />
               {link.subMenus.map(sub => (
                 <li key={sub.id || sub.href}>

--- a/themes/fuwari/components/MobileNav.js
+++ b/themes/fuwari/components/MobileNav.js
@@ -46,7 +46,29 @@ const MobileNav = ({ locale, customNav, customMenu }) => {
                       {link.name || link.title}
                     </SmartLink>
                   ) : (
-                    <span className='flex-1 px-3 py-2 rounded-lg font-semibold cursor-default select-none'>
+                    <span
+                      className={`flex-1 px-3 py-2 rounded-lg font-semibold hover:bg-[var(--fuwari-bg-soft)] select-none ${
+                        link.subMenus?.length ? 'cursor-pointer' : 'cursor-default'
+                      }`}
+                      role={link.subMenus?.length ? 'button' : undefined}
+                      tabIndex={link.subMenus?.length ? 0 : undefined}
+                      aria-expanded={
+                        link.subMenus?.length ? openSub === link.id : undefined
+                      }
+                      onClick={() => {
+                        if (link.subMenus?.length) {
+                          setOpenSub(prev => (prev === link.id ? '' : link.id))
+                        }
+                      }}
+                      onKeyDown={e => {
+                        if (
+                          link.subMenus?.length &&
+                          (e.key === 'Enter' || e.key === ' ')
+                        ) {
+                          e.preventDefault()
+                          setOpenSub(prev => (prev === link.id ? '' : link.id))
+                        }
+                      }}>
                       {link.name || link.title}
                     </span>
                   )}


### PR DESCRIPTION
## Summary
This PR bundles theme and navigation improvements.

### Fuwari + dev (previous commit on branch)
- Fuwari theme polish, reliable theme loading, and local dev UX tweaks.

### Claude / Fuwari nested nav (latest commit)
- **Claude**: getClaudeMenuLinks in \	hemes/claude/components/menu.js\, \MenuList\ supports \subMenus\ / \children\; sidebar styles for parent row, chevron, and indented submenu.
- **Fuwari desktop**: Dropdown opens on hover or when clicking the parent label; keyboard accessible.
- **Fuwari mobile** (\MobileNav\): Tapping the menu title toggles the submenu, not only the chevron.
- **Behavior**: If an item has child menus, the parent row **does not navigate**; it only expands/collapses. Child links still navigate as usual.

### How to test
- Set \CUSTOM_MENU\ with entries that include \subMenus\ or \children\, then verify Claude theme sidebar and Fuwari desktop + mobile menu.

Made with [Cursor](https://cursor.com)