### PR TITLE
fix: await async generateRss/checkDataFromAlgolia in getStaticProps

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -91,11 +91,11 @@ export async function getStaticProps(req) {
     // 生成robotTxt
     generateRobotsTxt(props)
     // 生成Feed订阅
-    generateRss(props)
+    await generateRss(props)
     // 生成
     generateSitemapXml(props)
     // 检查数据是否需要从algolia删除
-    checkDataFromAlgolia(props)
+    await checkDataFromAlgolia(props)
     if (siteConfig('UUID_REDIRECT', false, props?.NOTION_CONFIG)) {
       // 生成重定向 JSON
       generateRedirectJson(props)


### PR DESCRIPTION
## 已知问题

1. `generateRss` 和 `checkDataFromAlgolia` 是 `async` 异步函数，但在 `pages/index.js` 的 `getStaticProps` 中调用时缺少 `await`
   - `generateRss` 内部需要对每篇文章调用 `await getPostBlocks()` 从 Notion API 获取内容，再通过 `ReactDOMServer.renderToString()` 渲染，最后才写入 `public/rss/` 目录
   - 没有 `await` 导致 `getStaticProps` 在 RSS 文件写入磁盘前就已返回，构建进程提前完成
   - 这是一个**竞态条件**（race condition），非确定性复现，在 CI/CD 环境中尤为明显，会导致 RSS 页面 404

2. 对比同处调用的同步函数不受影响
   - `generateRobotsTxt`：同步函数，直接 `fs.writeFileSync`，立即完成
   - `generateSitemapXml`：同步函数，直接 `fs.writeFileSync`，立即完成

3. 部署后的典型表现
   - 访问 `/feed` 或 `/rss/feed.xml` 返回 404 或内容损坏
   - VPS / Docker / 自建 CI 等非 Vercel 环境更容易触发

## 解决方案

1. 为 `generateRss(props)` 和 `checkDataFromAlgolia(props)` 添加 `await`
   - `getStaticProps` 本身已是 `async function`，无需额外改动
   - 确保构建进程等待 RSS 文件完整生成后再返回

## 改动收益

1. 彻底修复 RSS 文件缺失的竞态问题
   - 保证 `public/rss/feed.xml`、`atom.xml`、`feed.json` 在构建完成前被写入
   - 所有部署环境（Vercel / VPS / Docker / CI）行为一致
2. 无副作用
   - Vercel 只读文件系统在 `generateRss` 内部已有 try-catch 处理，不受影响
   - 构建时间仅增加 Notion API 请求耗时（原本就需要执行，只是之前没等它完成）

## 具体改动

1. `pages/index.js`
   - 第 94 行：`generateRss(props)` → `await generateRss(props)`
   - 第 98 行：`checkDataFromAlgolia(props)` → `await checkDataFromAlgolia(props)`

## 测试确认

- [x] 本地开发环境测试通过
- [x] CI/CD 构建部署测试通过（GitHub Actions → VPS）
- [x] 部署后 `/rss/feed.xml` 正常返回完整 RSS 内容
- [x] `robots.txt` 和 `sitemap.xml` 生成不受影响