### PR TITLE
docs(endspace): credit original theme author

### DIFF
--- a/docs/themes/ENDSPACE.en.md
+++ b/docs/themes/ENDSPACE.en.md
@@ -2,6 +2,8 @@
 
 Endspace is a NotionNext theme inspired by the visual language of *Arknights: Endfield*’s official site, maintained by the community. Upstream repository: [cloud-oc/endspace](https://github.com/cloud-oc/endspace). Tracking issue: [#3990](https://github.com/tangly1024/NotionNext/issues/3990).
 
+**Original author / upstream**: [@cloud-oc](https://github.com/cloud-oc) ([cloud-oc/endspace](https://github.com/cloud-oc/endspace)).
+
 ## Enable
 
 1. Install dependencies at the repo root (`yarn install`):

--- a/docs/themes/ENDSPACE.md
+++ b/docs/themes/ENDSPACE.md
@@ -2,6 +2,8 @@
 
 Endspace 是受《明日方舟：终末地》官网视觉风格启发的 NotionNext 主题，由社区作者维护；上游仓库见 [cloud-oc/endspace](https://github.com/cloud-oc/endspace)。收录相关讨论见 [Issue #3990](https://github.com/tangly1024/NotionNext/issues/3990)。
 
+**原作者 / 上游**：[@cloud-oc](https://github.com/cloud-oc)（仓库 [cloud-oc/endspace](https://github.com/cloud-oc/endspace)）。
+
 ## 启用方式
 
 1. 安装依赖（根目录已声明，首次拉代码后执行 `yarn install`）：


### PR DESCRIPTION
Add explicit upstream credit in Endspace theme docs.

Co-authored-by trailer attributes the theme to @cloud-oc (email from their PR #3991 commits) for GitHub contribution visibility.

Related: #3990

Made with [Cursor](https://cursor.com)