### PR TITLE
fix: Giscus URL 清理 + Fuwari/Mermaid 样式（toolbar 衬条）

### DIFF
--- a/__tests__/lib/utils/stripTransientUrlParams.test.js
+++ b/__tests__/lib/utils/stripTransientUrlParams.test.js
@@ -1,0 +1,24 @@
+import {
+  stripTransientQueryParamsFromAsPath,
+  stripTransientQueryParamsFromUrl
+} from '@/lib/utils/stripTransientUrlParams'
+
+describe('stripTransientQueryParamsFromUrl', () => {
+  it('removes giscus and target from full URL', () => {
+    const u =
+      'https://blog.example.com/post/foo?giscus=abc&x=1&target=comment#h'
+    const out = stripTransientQueryParamsFromUrl(u)
+    expect(out).toBe('https://blog.example.com/post/foo?x=1#h')
+  })
+})
+
+describe('stripTransientQueryParamsFromAsPath', () => {
+  it('strips giscus from asPath', () => {
+    expect(stripTransientQueryParamsFromAsPath('/a/b?giscus=1')).toBe('/a/b')
+  })
+  it('preserves other query and hash', () => {
+    expect(
+      stripTransientQueryParamsFromAsPath('/p?k=1&giscus=x#c')
+    ).toBe('/p?k=1#c')
+  })
+})

--- a/components/Comment.js
+++ b/components/Comment.js
@@ -1,6 +1,7 @@
 import Tabs from '@/components/Tabs'
 import { siteConfig } from '@/lib/config'
 import { isBrowser, isSearchEngineBot } from '@/lib/utils'
+import { stripTransientQueryParamsFromAsPath } from '@/lib/utils/stripTransientUrlParams'
 import dynamic from 'next/dynamic'
 import { useRouter } from 'next/router'
 import { useEffect, useRef, useState } from 'react'
@@ -49,19 +50,29 @@ const Comment = ({ frontMatter, className }) => {
     }
   }, [frontMatter])
 
-  // 当连接中有特殊参数时跳转到评论区
-  if (
-    isBrowser &&
-    ('giscus' in router.query || router.query.target === 'comment')
-  ) {
-    setTimeout(() => {
-      const url = router.asPath.replace('?target=comment', '')
-      history.replaceState({}, '', url)
-      document
-        ?.getElementById('comment')
-        ?.scrollIntoView({ block: 'start', behavior: 'smooth' })
-    }, 1000)
-  }
+  useEffect(() => {
+    if (!isBrowser || !router.isReady) {
+      return
+    }
+    const hasGiscus = 'giscus' in router.query
+    const scrollComment = router.query.target === 'comment'
+    if (!hasGiscus && !scrollComment) {
+      return
+    }
+    const cleanPath = stripTransientQueryParamsFromAsPath(router.asPath)
+    window.history.replaceState(window.history.state, '', cleanPath)
+    router
+      .replace(cleanPath, undefined, { scroll: false, shallow: true })
+      .catch(() => {})
+    if (scrollComment || hasGiscus) {
+      const t = window.setTimeout(() => {
+        document
+          ?.getElementById('comment')
+          ?.scrollIntoView({ block: 'start', behavior: 'smooth' })
+      }, 400)
+      return () => window.clearTimeout(t)
+    }
+  }, [router.isReady, router.asPath, router.query])
 
   if (!frontMatter) {
     return null

--- a/components/Giscus.js
+++ b/components/Giscus.js
@@ -1,6 +1,8 @@
 import { siteConfig } from '@/lib/config'
 import { useGlobal } from '@/lib/global'
 import { loadExternalResource } from '@/lib/utils'
+import { stripTransientQueryParamsFromAsPath } from '@/lib/utils/stripTransientUrlParams'
+import Router from 'next/router'
 import { useEffect } from 'react'
 // import Giscus from '@giscus/react'
 
@@ -15,12 +17,30 @@ const GiscusComponent = () => {
   const { isDarkMode } = useGlobal()
   const theme = isDarkMode ? 'dark' : 'light'
   useEffect(() => {
+    const syncGiscusQueryOutOfUrl = () => {
+      if (typeof window === 'undefined') {
+        return
+      }
+      const full = `${window.location.pathname}${window.location.search}${window.location.hash}`
+      const clean = stripTransientQueryParamsFromAsPath(full)
+      if (clean === full) {
+        return
+      }
+      window.history.replaceState(window.history.state, '', clean)
+      Router.replace(clean, undefined, { scroll: false, shallow: true }).catch(() => {})
+    }
+
     loadExternalResource('/js/giscus.js', 'js').then(() => {
       if (window?.Giscus?.init) {
         window?.Giscus?.init('#giscus')
       }
+      syncGiscusQueryOutOfUrl()
     })
+
+    const onRouteDone = () => syncGiscusQueryOutOfUrl()
+    Router.events.on('routeChangeComplete', onRouteDone)
     return () => {
+      Router.events.off('routeChangeComplete', onRouteDone)
       window?.Giscus?.destroy()
     }
   }, [isDarkMode])

--- a/components/PrismMac.js
+++ b/components/PrismMac.js
@@ -242,6 +242,47 @@ const renderCollapseCode = (codeCollapse, codeCollapseExpandDefault) => {
 }
 
 /**
+ * Mermaid 主题：浅色用 neutral（打印/文档向，连线比 default 更清晰）；
+ * 深色用 dark + themeVariables 提亮连线与箭头（需 hex，见 mermaid 文档）。
+ */
+function getMermaidInitOptions() {
+  const isDark =
+    typeof document !== 'undefined' &&
+    document.documentElement.classList.contains('dark')
+  if (isDark) {
+    return {
+      startOnLoad: false,
+      securityLevel: 'loose',
+      theme: 'dark',
+      themeVariables: {
+        lineColor: '#e2e8f0',
+        secondaryColor: '#cbd5e1',
+        tertiaryColor: '#94a3b8',
+        arrowheadColor: '#f8fafc',
+        clusterBorder: '#cbd5e1',
+        edgeLabelBackground: '#0f172a',
+        primaryColor: '#64748b',
+        primaryTextColor: '#f1f5f9',
+        secondaryTextColor: '#e2e8f0',
+        tertiaryTextColor: '#cbd5e1',
+        mainBkg: '#334155',
+        secondBkg: '#1e293b'
+      }
+    }
+  }
+  return {
+    startOnLoad: false,
+    securityLevel: 'loose',
+    theme: 'neutral',
+    themeVariables: {
+      lineColor: '#475569',
+      arrowheadColor: '#1e293b',
+      clusterBorder: '#64748b'
+    }
+  }
+}
+
+/**
  * 将mermaid语言 渲染成图片
  */
 const renderMermaid = mermaidCDN => {
@@ -277,12 +318,7 @@ const renderMermaid = mermaidCDN => {
           const mermaid = window.mermaid
           if (!mermaid) return
           try {
-            mermaid.initialize({
-              startOnLoad: false,
-              theme: document.documentElement.classList.contains('dark')
-                ? 'dark'
-                : 'default'
-            })
+            mermaid.initialize(getMermaidInitOptions())
           } catch (_) {
             /* 重复 initialize 时部分版本会抛错，忽略 */
           }

--- a/components/PrismMac.js
+++ b/components/PrismMac.js
@@ -72,7 +72,7 @@ const PrismMac = () => {
 
           const dispose = renderPrismMac(codeLineNumbers)
           stopLineNumbers = typeof dispose === 'function' ? dispose : () => {}
-          renderMermaid(mermaidCDN, isDarkMode)
+          renderMermaid(mermaidCDN)
           renderCollapseCode(codeCollapse, codeCollapseExpandDefault)
         } catch (err) {
           console.warn('[PrismMac] render failed:', err)
@@ -244,7 +244,7 @@ const renderCollapseCode = (codeCollapse, codeCollapseExpandDefault) => {
 /**
  * 将mermaid语言 渲染成图片
  */
-const renderMermaid = (mermaidCDN, isDarkMode) => {
+const renderMermaid = mermaidCDN => {
   const articles = getNotionArticles()
   if (!articles || articles.length === 0) return
 
@@ -276,30 +276,6 @@ const renderMermaid = (mermaidCDN, isDarkMode) => {
         try {
           const mermaid = window.mermaid
           if (!mermaid) return
-          try {
-            mermaid.initialize({
-              startOnLoad: false,
-              theme: isDarkMode ? 'dark' : 'default',
-              securityLevel: 'loose',
-              themeVariables: isDarkMode
-                ? {
-                    lineColor: '#94a3b8',
-                    secondaryColor: '#64748b',
-                    tertiaryColor: '#475569',
-                    arrowheadColor: '#cbd5e1',
-                    clusterBorder: '#94a3b8',
-                    edgeLabelBackground: '#0f172a',
-                    mainBkg: '#1e293b',
-                    secondBkg: '#334155',
-                    primaryTextColor: '#f1f5f9',
-                    secondaryTextColor: '#e2e8f0',
-                    tertiaryTextColor: '#cbd5e1'
-                  }
-                : undefined
-            })
-          } catch (initErr) {
-            console.warn('[PrismMac] mermaid.initialize:', initErr)
-          }
           mermaid?.contentLoaded()
         } catch (err) {
           console.warn('[PrismMac] mermaid render failed:', err)

--- a/components/PrismMac.js
+++ b/components/PrismMac.js
@@ -72,7 +72,7 @@ const PrismMac = () => {
 
           const dispose = renderPrismMac(codeLineNumbers)
           stopLineNumbers = typeof dispose === 'function' ? dispose : () => {}
-          renderMermaid(mermaidCDN)
+          renderMermaid(mermaidCDN, isDarkMode)
           renderCollapseCode(codeCollapse, codeCollapseExpandDefault)
         } catch (err) {
           console.warn('[PrismMac] render failed:', err)
@@ -244,7 +244,7 @@ const renderCollapseCode = (codeCollapse, codeCollapseExpandDefault) => {
 /**
  * 将mermaid语言 渲染成图片
  */
-const renderMermaid = mermaidCDN => {
+const renderMermaid = (mermaidCDN, isDarkMode) => {
   const articles = getNotionArticles()
   if (!articles || articles.length === 0) return
 
@@ -276,6 +276,30 @@ const renderMermaid = mermaidCDN => {
         try {
           const mermaid = window.mermaid
           if (!mermaid) return
+          try {
+            mermaid.initialize({
+              startOnLoad: false,
+              theme: isDarkMode ? 'dark' : 'default',
+              securityLevel: 'loose',
+              themeVariables: isDarkMode
+                ? {
+                    lineColor: '#94a3b8',
+                    secondaryColor: '#64748b',
+                    tertiaryColor: '#475569',
+                    arrowheadColor: '#cbd5e1',
+                    clusterBorder: '#94a3b8',
+                    edgeLabelBackground: '#0f172a',
+                    mainBkg: '#1e293b',
+                    secondBkg: '#334155',
+                    primaryTextColor: '#f1f5f9',
+                    secondaryTextColor: '#e2e8f0',
+                    tertiaryTextColor: '#cbd5e1'
+                  }
+                : undefined
+            })
+          } catch (initErr) {
+            console.warn('[PrismMac] mermaid.initialize:', initErr)
+          }
           mermaid?.contentLoaded()
         } catch (err) {
           console.warn('[PrismMac] mermaid render failed:', err)

--- a/components/PrismMac.js
+++ b/components/PrismMac.js
@@ -242,47 +242,6 @@ const renderCollapseCode = (codeCollapse, codeCollapseExpandDefault) => {
 }
 
 /**
- * Mermaid 主题：浅色用 neutral（打印/文档向，连线比 default 更清晰）；
- * 深色用 dark + themeVariables 提亮连线与箭头（需 hex，见 mermaid 文档）。
- */
-function getMermaidInitOptions() {
-  const isDark =
-    typeof document !== 'undefined' &&
-    document.documentElement.classList.contains('dark')
-  if (isDark) {
-    return {
-      startOnLoad: false,
-      securityLevel: 'loose',
-      theme: 'dark',
-      themeVariables: {
-        lineColor: '#e2e8f0',
-        secondaryColor: '#cbd5e1',
-        tertiaryColor: '#94a3b8',
-        arrowheadColor: '#f8fafc',
-        clusterBorder: '#cbd5e1',
-        edgeLabelBackground: '#0f172a',
-        primaryColor: '#64748b',
-        primaryTextColor: '#f1f5f9',
-        secondaryTextColor: '#e2e8f0',
-        tertiaryTextColor: '#cbd5e1',
-        mainBkg: '#334155',
-        secondBkg: '#1e293b'
-      }
-    }
-  }
-  return {
-    startOnLoad: false,
-    securityLevel: 'loose',
-    theme: 'neutral',
-    themeVariables: {
-      lineColor: '#475569',
-      arrowheadColor: '#1e293b',
-      clusterBorder: '#64748b'
-    }
-  }
-}
-
-/**
  * 将mermaid语言 渲染成图片
  */
 const renderMermaid = mermaidCDN => {
@@ -317,11 +276,6 @@ const renderMermaid = mermaidCDN => {
         try {
           const mermaid = window.mermaid
           if (!mermaid) return
-          try {
-            mermaid.initialize(getMermaidInitOptions())
-          } catch (_) {
-            /* 重复 initialize 时部分版本会抛错，忽略 */
-          }
           mermaid?.contentLoaded()
         } catch (err) {
           console.warn('[PrismMac] mermaid render failed:', err)

--- a/components/PrismMac.js
+++ b/components/PrismMac.js
@@ -276,6 +276,16 @@ const renderMermaid = mermaidCDN => {
         try {
           const mermaid = window.mermaid
           if (!mermaid) return
+          try {
+            mermaid.initialize({
+              startOnLoad: false,
+              theme: document.documentElement.classList.contains('dark')
+                ? 'dark'
+                : 'default'
+            })
+          } catch (_) {
+            /* 重复 initialize 时部分版本会抛错，忽略 */
+          }
           mermaid?.contentLoaded()
         } catch (err) {
           console.warn('[PrismMac] mermaid render failed:', err)

--- a/lib/utils/stripTransientUrlParams.js
+++ b/lib/utils/stripTransientUrlParams.js
@@ -1,0 +1,61 @@
+/** OAuth / 评论回调等不应出现在永久链接、分享复制中的查询参数 */
+const TRANSIENT_QUERY_KEYS = ['giscus', 'target']
+
+/**
+ * @param {string} fullUrl 完整 URL（须含协议）
+ * @returns {string}
+ */
+export function stripTransientQueryParamsFromUrl(fullUrl) {
+  if (!fullUrl || typeof fullUrl !== 'string') {
+    return fullUrl
+  }
+  try {
+    const u = new URL(fullUrl)
+    let changed = false
+    for (const k of TRANSIENT_QUERY_KEYS) {
+      if (u.searchParams.has(k)) {
+        u.searchParams.delete(k)
+        changed = true
+      }
+    }
+    if (!changed) {
+      return fullUrl
+    }
+    const q = u.searchParams.toString()
+    return `${u.origin}${u.pathname}${q ? `?${q}` : ''}${u.hash}`
+  } catch {
+    return fullUrl
+  }
+}
+
+/**
+ * Next `router.asPath` 形式：`/path` 或 `/path?a=1&giscus=...`
+ * @param {string} asPath
+ * @returns {string}
+ */
+export function stripTransientQueryParamsFromAsPath(asPath) {
+  if (!asPath || typeof asPath !== 'string') {
+    return asPath
+  }
+  const hashIdx = asPath.indexOf('#')
+  const hash = hashIdx >= 0 ? asPath.slice(hashIdx) : ''
+  const noHash = hashIdx >= 0 ? asPath.slice(0, hashIdx) : asPath
+  const qm = noHash.indexOf('?')
+  if (qm < 0) {
+    return asPath
+  }
+  const path = noHash.slice(0, qm)
+  const sp = new URLSearchParams(noHash.slice(qm + 1))
+  let changed = false
+  for (const k of TRANSIENT_QUERY_KEYS) {
+    if (sp.has(k)) {
+      sp.delete(k)
+      changed = true
+    }
+  }
+  if (!changed) {
+    return asPath
+  }
+  const n = sp.toString()
+  return n ? `${path}?${n}${hash}` : `${path}${hash}`
+}

--- a/styles/notion.css
+++ b/styles/notion.css
@@ -2061,13 +2061,15 @@ html.dark pre.notion-code[class*='language-mermaid'] {
   background-color: #e2e8f0 !important;
 }
 
-/* 浅色页：Mermaid 图表区为浅底，toolbar 叠在上方时按钮（浅字）会融进白底 — 仅浅色模式给右上角加深色衬条 */
+/* Mermaid：浅底图表区上 toolbar 易与背景糊在一起，浅/深色模式均在右上角加深色衬条（按钮为浅字） */
 html.light .code-toolbar:has(pre.language-mermaid) > .toolbar,
-html.light .code-toolbar:has(pre[class*='language-mermaid']) > .toolbar {
-  background-color: rgba(27, 28, 32, 0.96) !important;
+html.light .code-toolbar:has(pre[class*='language-mermaid']) > .toolbar,
+html.dark .code-toolbar:has(pre.language-mermaid) > .toolbar,
+html.dark .code-toolbar:has(pre[class*='language-mermaid']) > .toolbar {
+  background-color: rgba(15, 15, 18, 0.98) !important;
   border-bottom-left-radius: 12px;
   padding: 6px 10px 8px 12px;
-  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.2);
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.25);
 }
 
 /* mermaid 原文隐藏 */

--- a/styles/notion.css
+++ b/styles/notion.css
@@ -2077,11 +2077,6 @@ code.language-mermaid {
   margin: auto;
 }
 
-/* 深色：仅提亮 flowchart 连线（不改 mermaid JS 配置） */
-html.dark .mermaid .edgePath .path {
-  stroke: #94a3b8 !important;
-}
-
 .notion-equation-inline .katex-display {
   margin: 0 0 !important;
 }

--- a/styles/notion.css
+++ b/styles/notion.css
@@ -2071,6 +2071,11 @@ code.language-mermaid {
   margin: auto;
 }
 
+/* 深色：仅提亮 flowchart 连线（不改 mermaid JS 配置） */
+html.dark .mermaid .edgePath .path {
+  stroke: #94a3b8 !important;
+}
+
 .notion-equation-inline .katex-display {
   margin: 0 0 !important;
 }

--- a/styles/notion.css
+++ b/styles/notion.css
@@ -2051,7 +2051,8 @@ tbody tr {
 }
 
 pre[class*='language-mermaid'] {
-  @apply bg-gray-50 dark:bg-gray-200 !important;
+  /* 浅色页：浅底；深色页：深底（勿用 gray-200，在 dark 下仍偏浅） */
+  @apply bg-gray-50 dark:bg-gray-900 !important;
 }
 
 /* mermaid 原文隐藏 */

--- a/styles/notion.css
+++ b/styles/notion.css
@@ -2057,7 +2057,8 @@ pre.notion-code[class*='language-mermaid'] {
 }
 html.dark pre.notion-code.language-mermaid,
 html.dark pre.notion-code[class*='language-mermaid'] {
-  background-color: #111827 !important;
+  /* 深色页内用浅灰衬底，衬托 Mermaid 默认的深灰/黑连线（不改 mermaid JS） */
+  background-color: #e2e8f0 !important;
 }
 
 /* mermaid 原文隐藏 */

--- a/styles/notion.css
+++ b/styles/notion.css
@@ -2061,6 +2061,15 @@ html.dark pre.notion-code[class*='language-mermaid'] {
   background-color: #e2e8f0 !important;
 }
 
+/* 深色页：Mermaid 为浅衬底时，Prism 右上角 toolbar 仍用深色条，避免「语言 / 复制」按钮与浅底糊成一片 */
+html.dark .code-toolbar:has(pre.language-mermaid) > .toolbar,
+html.dark .code-toolbar:has(pre[class*='language-mermaid']) > .toolbar {
+  background-color: rgba(27, 28, 32, 0.96) !important;
+  border-bottom-left-radius: 12px;
+  padding: 6px 10px 8px 12px;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.28);
+}
+
 /* mermaid 原文隐藏 */
 code.language-mermaid {
   display: none;

--- a/styles/notion.css
+++ b/styles/notion.css
@@ -2050,9 +2050,14 @@ tbody tr {
   display: none !important;
 }
 
-pre[class*='language-mermaid'] {
-  /* 浅色页：浅底；深色页：深底（勿用 gray-200，在 dark 下仍偏浅） */
-  @apply bg-gray-50 dark:bg-gray-900 !important;
+/* Mermaid 外层 pre：与 html.dark 对齐，避免 Tailwind dark: 跟系统偏好不同步 */
+pre.notion-code.language-mermaid,
+pre.notion-code[class*='language-mermaid'] {
+  background-color: #f9fafb !important;
+}
+html.dark pre.notion-code.language-mermaid,
+html.dark pre.notion-code[class*='language-mermaid'] {
+  background-color: #111827 !important;
 }
 
 /* mermaid 原文隐藏 */

--- a/styles/notion.css
+++ b/styles/notion.css
@@ -2061,13 +2061,13 @@ html.dark pre.notion-code[class*='language-mermaid'] {
   background-color: #e2e8f0 !important;
 }
 
-/* 深色页：Mermaid 为浅衬底时，Prism 右上角 toolbar 仍用深色条，避免「语言 / 复制」按钮与浅底糊成一片 */
-html.dark .code-toolbar:has(pre.language-mermaid) > .toolbar,
-html.dark .code-toolbar:has(pre[class*='language-mermaid']) > .toolbar {
+/* 浅色页：Mermaid 图表区为浅底，toolbar 叠在上方时按钮（浅字）会融进白底 — 仅浅色模式给右上角加深色衬条 */
+html.light .code-toolbar:has(pre.language-mermaid) > .toolbar,
+html.light .code-toolbar:has(pre[class*='language-mermaid']) > .toolbar {
   background-color: rgba(27, 28, 32, 0.96) !important;
   border-bottom-left-radius: 12px;
   padding: 6px 10px 8px 12px;
-  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.28);
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.2);
 }
 
 /* mermaid 原文隐藏 */

--- a/themes/fuwari/components/ArticleCopyright.js
+++ b/themes/fuwari/components/ArticleCopyright.js
@@ -1,6 +1,10 @@
 import SmartLink from '@/components/SmartLink'
 import { siteConfig } from '@/lib/config'
 import { useGlobal } from '@/lib/global'
+import {
+  stripTransientQueryParamsFromAsPath,
+  stripTransientQueryParamsFromUrl
+} from '@/lib/utils/stripTransientUrlParams'
 import { useRouter } from 'next/router'
 import { useEffect, useMemo, useState } from 'react'
 import CONFIG from '../config'
@@ -13,11 +17,15 @@ const ArticleCopyright = ({ post }) => {
 
   useEffect(() => {
     if (typeof window !== 'undefined') {
-      setFullUrl(window.location.href)
+      setFullUrl(stripTransientQueryParamsFromUrl(window.location.href))
       return
     }
     const base = (siteConfig('LINK') || '').replace(/\/$/, '')
-    const path = (post?.href || router?.asPath || `/${post?.slug || ''}`).replace(/^\//, '/')
+    const raw = post?.href || router?.asPath || `/${post?.slug || ''}`
+    const path =
+      raw.startsWith('http://') || raw.startsWith('https://')
+        ? stripTransientQueryParamsFromUrl(raw)
+        : stripTransientQueryParamsFromAsPath(raw)
     setFullUrl(`${base}${path}`)
   }, [post?.href, post?.slug, router?.asPath])
 


### PR DESCRIPTION
## 概要

- **Giscus**：OAuth 回调后 URL 带 `?giscus=` 导致 Fuwari 文末版权「永久链接」含多余参数；站内跳转后地址栏仍挂参数。统一剥离 `giscus` / `target` 查询参数，并与 Next 路由同步。
- **Mermaid（仅 CSS）**：深色站点下图表区用浅灰衬底突出连线；浅色/深色下 Mermaid 代码块右上角 Prism **toolbar** 使用深色衬条，避免「Mermaid / 复制」按钮与浅底糊在一起。

## 主要改动

| 区域 | 说明 |
|------|------|
| `lib/utils/stripTransientUrlParams.js` | 新增工具函数，剥离 `giscus`、`target` |
| `themes/fuwari/components/ArticleCopyright.js` | 版权链接使用干净 URL |
| `components/Comment.js` | `useEffect` 内清理查询并 `router.replace`，避免 render 里误触发 |
| `components/Giscus.js` | 初始化后与 `routeChangeComplete` 时同步清理 URL |
| `components/PrismMac.js` | Mermaid 保持仅 `contentLoaded()`（无 `initialize` 主题块） |
| `styles/notion.css` | Mermaid `pre` 浅/深背景；`:has(.language-mermaid)` 的 `.toolbar` 深色条 |
| `__tests__/lib/utils/stripTransientUrlParams.test.js` | URL 剥离单测 |

## 验证建议

- 开启 Giscus，从文章页点登录 GitHub 回跳：地址栏无 `giscus`，版权区链接无该参数。
- 浅色 / 深色模式各看一篇含 Mermaid 的文章：图表可读，右上角按钮清晰。
