### PR TITLE
style(starter): 调整内容区最大宽度

### DIFF
--- a/themes/starter/style.js
+++ b/themes/starter/style.js
@@ -204,6 +204,18 @@ const Style = () => {
   height: auto;
   width: auto;
 }
+
+  /* 正文（Notion 文章 / 仪表盘页）：限制最大宽度，兼顾表格/图片与阅读行宽 */
+  #theme-starter #article-wrapper {
+    max-width: 64rem;
+  }
+
+  /* 全站 container：xl 及以上略窄于满屏，接近主题默认版心（1140px） */
+  @media (min-width: 1140px) {
+    #theme-starter .container {
+      max-width: 72rem;
+    }
+  }
   `}</style>
 }
 


### PR DESCRIPTION
## 说明

starter 主题在大屏下正文与版心偏宽，不利于阅读；收窄后又略紧，本次取中间值：

- **#article-wrapper**：max-width: 64rem（文章 / 仪表盘 Notion 正文）
- **xl 及以上**：#theme-starter .container → max-width: 72rem

改动仅限 \	hemes/starter/style.js\，不影响其它主题。

Made with [Cursor](https://cursor.com)