### PR TITLE
chore(build): 构建前清理 public/rss 陈旧静态文件

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -88,6 +88,16 @@ const preBuild = (function () {
     console.log('Deleted existing sitemap.xml from root directory')
   }
 
+  // 构建前删除遗留的静态 RSS 产物，避免与生成逻辑不一致时读到过时 feed（源自 PR #3123 的单一补丁）
+  const rssDir = path.resolve(__dirname, 'public', 'rss')
+  for (const name of ['feed.xml', 'atom.xml', 'feed.json']) {
+    const rssPath = path.join(rssDir, name)
+    if (fs.existsSync(rssPath)) {
+      fs.unlinkSync(rssPath)
+      console.log(`Deleted existing ${name} from public/rss`)
+    }
+  }
+
   const notionCacheRoot = path.resolve(__dirname, '.next', 'cache', 'notion')
   const prefetchDir = path.join(notionCacheRoot, 'sessions')
   const sessionFile = path.join(notionCacheRoot, 'build-session.json')


### PR DESCRIPTION
## 摘要
从历史 PR #3123（\eat-rss\）中**仅摘取**一条行为：在 \yarn build\ / \yarn export\ 预构建阶段，与现有删除 \sitemap.xml\ 逻辑一致，删除 \public/rss/\ 下可能遗留的 \eed.xml\ / \tom.xml\ / \eed.json\，避免静态产物与当前 RSS 生成路径不一致时读到过期内容。

## 说明
- 不改变 RSS 生成逻辑（主线已在 \lib/utils/rss.js\、\pages/index.js\ 等处演进）。
- 仍遵守 \NEXT_PRIVATE_BUILD_WORKER\：与 sitemap 清理同一时机，仅非 worker 进程执行。

## 关联
-  supersede / 承接 #3123 中有价值的预构建清理部分。

请合并 #3123 前可先关闭并在该 PR 内指向本 PR。
