### PR TITLE
perf(rss): avoid duplicate feed generation across locales

### DIFF
--- a/__tests__/lib/utils/rss.test.js
+++ b/__tests__/lib/utils/rss.test.js
@@ -1,5 +1,5 @@
 import fs from 'fs'
-import { generateRss } from '@/lib/utils/rss'
+import { generateRss, shouldGenerateRssForLocale } from '@/lib/utils/rss'
 import { getPostBlocks } from '@/lib/db/SiteDataApi'
 import { formatNotionBlock } from '@/lib/db/notion/getPostBlocks'
 import { adapterNotionBlockMap } from '@/lib/utils/notion.util'
@@ -112,5 +112,14 @@ describe('generateRss', () => {
     )
     expect(fs.writeFileSync).toHaveBeenCalledTimes(3)
   })
-})
 
+  it('generates RSS only for the default locale during multi-locale builds', () => {
+    expect(shouldGenerateRssForLocale({ locale: undefined })).toBe(true)
+    expect(
+      shouldGenerateRssForLocale({ locale: 'zh-CN', defaultLocale: 'zh-CN' })
+    ).toBe(true)
+    expect(
+      shouldGenerateRssForLocale({ locale: 'en', defaultLocale: 'zh-CN' })
+    ).toBe(false)
+  })
+})

--- a/lib/utils/rss.js
+++ b/lib/utils/rss.js
@@ -8,6 +8,13 @@ import fs from 'fs'
 import ReactDOMServer from 'react-dom/server'
 import { decryptEmail } from '@/lib/plugins/mailEncrypt'
 
+export function shouldGenerateRssForLocale({
+  locale,
+  defaultLocale = BLOG.LANG
+} = {}) {
+  return !locale || locale === defaultLocale
+}
+
 /**
  * 生成RSS内容
  * @param {*} post

--- a/pages/index.js
+++ b/pages/index.js
@@ -2,7 +2,7 @@ import BLOG from '@/blog.config'
 import { siteConfig } from '@/lib/config'
 import { fetchGlobalAllData, getPostBlocks } from '@/lib/db/SiteDataApi'
 import { generateRobotsTxt } from '@/lib/utils/robots.txt'
-import { generateRss } from '@/lib/utils/rss'
+import { generateRss, shouldGenerateRssForLocale } from '@/lib/utils/rss'
 import { generateSitemapXml } from '@/lib/utils/sitemap.xml'
 import { DynamicLayout } from '@/themes/theme'
 import { generateRedirectJson } from '@/lib/utils/redirect'
@@ -91,7 +91,9 @@ export async function getStaticProps(req) {
     // 生成robotTxt
     generateRobotsTxt(props)
     // 生成Feed订阅
-    await generateRss(props)
+    if (shouldGenerateRssForLocale({ locale })) {
+      await generateRss(props)
+    }
     // 生成
     generateSitemapXml(props)
     // 检查数据是否需要从algolia删除


### PR DESCRIPTION
## Summary
- only generate RSS during homepage builds for the default locale
- avoid duplicate `generateRss()` work during multi-locale builds
- add regression coverage for the locale gating behavior

## Problem
`pages/index.js` currently calls `generateRss(props)` inside build/export lifecycle work for every `getStaticProps` execution.

When i18n is enabled, `getStaticProps` runs once per locale for `/`, which means RSS generation is repeated even though every locale writes to the same `./public/rss/*` files.

That creates two issues:
- repeated feed generation work during multi-locale builds
- repeated `getPostBlocks(..., 'rss-content')` fetches for the same posts, which adds avoidable build-time overhead

## What changed
- Added `shouldGenerateRssForLocale({ locale, defaultLocale })` in `lib/utils/rss.js`
- Updated `pages/index.js` to call `generateRss(props)` only when building the default locale (or when no locale is present)
- Added tests covering the locale gating behavior

## Verification
- `npx jest __tests__/lib/utils/rss.test.js --runInBand --modulePathIgnorePatterns .worktrees`
- `npx eslint lib/utils/rss.js pages/index.js __tests__/lib/utils/rss.test.js`

Helps #3119
