### PR TITLE
fix: normalize Apple Music song embeds

### DIFF
--- a/__tests__/lib/db/notion/getPostBlocks.test.js
+++ b/__tests__/lib/db/notion/getPostBlocks.test.js
@@ -1,0 +1,86 @@
+jest.mock('@/lib/db/notion/getNotionAPI', () => ({}))
+jest.mock('p-limit', () => () => fn => fn())
+
+import { formatNotionBlock } from '@/lib/db/notion/getPostBlocks'
+import {
+  isAppleMusicEmbedUrl,
+  normalizeExternalMediaBlock
+} from '@/lib/db/notion/normalizeExternalMediaBlock'
+
+describe('formatNotionBlock', () => {
+  it('detects Apple Music single-track embed URLs', () => {
+    expect(
+      isAppleMusicEmbedUrl(
+        'https://embed.music.apple.com/us/song/neon-blue/324357768'
+      )
+    ).toBe(true)
+
+    expect(
+      isAppleMusicEmbedUrl(
+        'https://embed.music.apple.com/us/album/girls-come-too/324357208'
+      )
+    ).toBe(false)
+  })
+
+  it('rewrites Apple Music song video blocks to embeds directly', () => {
+    const blockValue = {
+      type: 'video',
+      properties: {
+        source: [
+          ['https://embed.music.apple.com/us/song/neon-blue/324357768']
+        ]
+      }
+    }
+
+    normalizeExternalMediaBlock(blockValue)
+
+    expect(blockValue.type).toBe('embed')
+  })
+
+  it('leaves non-matching video blocks unchanged during direct normalization', () => {
+    const blockValue = {
+      type: 'video',
+      properties: {
+        source: [['https://www.youtube.com/watch?v=dQw4w9WgXcQ']]
+      }
+    }
+
+    normalizeExternalMediaBlock(blockValue)
+
+    expect(blockValue.type).toBe('video')
+  })
+
+  it('normalizes Apple Music song embeds from video blocks to embed blocks', () => {
+    const formatted = formatNotionBlock({
+      'apple-music-song': {
+        value: {
+          id: 'apple-music-song',
+          type: 'video',
+          properties: {
+            source: [[
+              'https://embed.music.apple.com/us/song/never-gonna-give-you-up/1559523357?i=1559523359'
+            ]]
+          }
+        }
+      }
+    })
+
+    expect(formatted['apple-music-song'].value.type).toBe('embed')
+  })
+
+  it('keeps regular hosted videos as video blocks', () => {
+    const formatted = formatNotionBlock({
+      'hosted-video': {
+        value: {
+          id: 'hosted-video',
+          type: 'video',
+          properties: {
+            source: [['https://cdn.example.com/videos/demo.mp4']]
+          }
+        }
+      }
+    })
+
+    expect(formatted['hosted-video'].value.type).toBe('video')
+  })
+})

--- a/lib/db/notion/getPostBlocks.js
+++ b/lib/db/notion/getPostBlocks.js
@@ -7,6 +7,7 @@ import { deepClone, delay } from '../../utils'
 import notionAPI from '@/lib/db/notion/getNotionAPI'
 import pLimit from 'p-limit'
 import { normalizeNotionBlockType } from '@/lib/utils/notion.util'
+import { normalizeExternalMediaBlock } from '@/lib/db/notion/normalizeExternalMediaBlock'
 
 // ⚠️ 全局限流器（非常关键）
 const limit = pLimit(15)
@@ -24,7 +25,7 @@ export async function fetchNotionPageBlocks(id, from = null) {
 
   const pageBlock = await getOrSetDataWithCache(
     cacheKey,
-    async () => limit(() => getPageWithRetry(id, from))
+    () => limit(() => getPageWithRetry(id, from))
   )
 
   if (!pageBlock) {
@@ -115,6 +116,7 @@ export function formatNotionBlock(block) {
     // 原有逻辑不变 ↓↓↓
 
     sanitizeBlockUrls(b?.value)
+    normalizeExternalMediaBlock(b?.value)
 
     if (b?.value?.type === 'sync_block' && b?.value?.children) {
       const childBlocks = b.value.children

--- a/lib/db/notion/normalizeExternalMediaBlock.js
+++ b/lib/db/notion/normalizeExternalMediaBlock.js
@@ -1,0 +1,16 @@
+export function normalizeExternalMediaBlock(blockValue) {
+  if (!blockValue || typeof blockValue !== 'object') return
+
+  const source = blockValue?.properties?.source?.[0]?.[0]
+  if (blockValue.type !== 'video' || typeof source !== 'string') return
+
+  // Apple Music single-track embeds can arrive as `video` blocks from Notion.
+  // react-notion-x treats unknown `video` sources as native <video>, which breaks playback.
+  if (isAppleMusicEmbedUrl(source)) {
+    blockValue.type = 'embed'
+  }
+}
+
+export function isAppleMusicEmbedUrl(url) {
+  return /^https:\/\/embed\.music\.apple\.com\/.+\/song\//i.test(url)
+}


### PR DESCRIPTION
## Summary
- normalize Apple Music single-track embed URLs when Notion stores them as `video` blocks
- keep non-matching video sources unchanged
- add regression coverage for direct normalization and `formatNotionBlock` integration

## Why
Notion can store Apple Music single-track embeds using the newer `/song/` URL format as `video` blocks. `react-notion-x` then treats them as native video sources, so playback breaks.

This patch rewrites only matching Apple Music single-track `video` blocks back to `embed`, matching the behavior users already get with the older album-style embed format.

## Validation
- `yarn test __tests__/lib/db/notion/getPostBlocks.test.js --runInBand`
- `npx eslint lib/db/notion/getPostBlocks.js lib/db/notion/normalizeExternalMediaBlock.js __tests__/lib/db/notion/getPostBlocks.test.js`