### PR TITLE
fix(build): 修复静态路径构建回归

### DIFF
--- a/__tests__/lib/staticPaths.test.js
+++ b/__tests__/lib/staticPaths.test.js
@@ -46,6 +46,32 @@ describe('staticPaths build helpers', () => {
     })
   })
 
+  it('does not keep a rejected allPages lookup pinned in process memory', async () => {
+    isExport.mockReturnValue(false)
+    fetchGlobalAllData
+      .mockRejectedValueOnce(new Error('notion unavailable'))
+      .mockResolvedValueOnce({
+        allPages: [
+          { id: '1', slug: 'hello', type: 'Post', status: 'Published' }
+        ]
+      })
+    getPriorityPages.mockReturnValue([])
+
+    await jest.isolateModulesAsync(async () => {
+      const { getSharedAllPages } = require('@/lib/build/staticPaths')
+
+      await expect(getSharedAllPages({ from: 'slug-paths' })).rejects.toThrow(
+        'notion unavailable'
+      )
+      await expect(getSharedAllPages({ from: 'slug-paths' })).resolves.toEqual([
+        { id: '1', slug: 'hello', type: 'Post', status: 'Published' }
+      ])
+
+      expect(fetchGlobalAllData).toHaveBeenCalledTimes(2)
+      expect(getOrSetDataWithCache).toHaveBeenCalledTimes(2)
+    })
+  })
+
   it('prefetches once per route call in export mode and returns all matching paths', async () => {
     isExport.mockReturnValue(true)
     fetchGlobalAllData.mockResolvedValue({

--- a/lib/build/staticPaths.js
+++ b/lib/build/staticPaths.js
@@ -7,7 +7,10 @@ import { isExport } from '@/lib/utils/buildMode'
 const inProcessAllPagesPromises = new Map()
 
 function getStaticPathsCacheKey({ pageId = BLOG.NOTION_PAGE_ID, locale }) {
-  const safePageId = String(pageId || 'default').replace(/[^a-z0-9,_:-]/gi, '_')
+  const safePageId = String(pageId || BLOG.NOTION_PAGE_ID).replace(
+    /[^a-z0-9,_:-]/gi,
+    '_'
+  )
   const safeLocale = String(locale || 'default').replace(/[^a-z0-9_-]/gi, '_')
   return `build_static_paths_all_pages_${safeLocale}_${safePageId}`
 }
@@ -27,6 +30,9 @@ export function getSharedAllPages({
         locale
       })
       return Array.isArray(allPages) ? allPages : []
+    })
+    promise.catch(() => {
+      inProcessAllPagesPromises.delete(cacheKey)
     })
     inProcessAllPagesPromises.set(cacheKey, promise)
   }

--- a/lib/db/SiteDataApi.js
+++ b/lib/db/SiteDataApi.js
@@ -485,10 +485,12 @@ function handleDataBeforeReturn(db) {
   db.customMenu = cleanIds(db?.customMenu)
   db.allNavPages = shortenIds(db?.allNavPages)
 
+  // 先清理 tagOptions，再用清理后的标签集合过滤页面的 tagItems，
+  // 避免页面保留对"已被 cleanTagOptions 删除的标签"的引用，导致点击 404
+  db.tagOptions = cleanTagOptions(db?.tagOptions)
   db.allNavPages = cleanPages(db?.allNavPages, db.tagOptions)
   db.allPages = cleanPages(db.allPages, db.tagOptions)
   db.latestPosts = cleanPages(db.latestPosts, db.tagOptions)
-  db.tagOptions = cleanTagOptions(db?.tagOptions)
 
   // 定时发布：检查发布时间窗口，超出范围的隐藏
   const POST_SCHEDULE_PUBLISH = siteConfig(

--- a/pages/[prefix]/[slug]/[...suffix].js
+++ b/pages/[prefix]/[slug]/[...suffix].js
@@ -4,6 +4,7 @@ import { resolvePostProps } from '@/lib/db/SiteDataApi'
 import { checkSlugHasMorThanTwoSlash } from '@/lib/utils/post'
 import Slug from '..'
 import { getStaticPathsBase } from '@/lib/build/staticPaths'
+import { isExport } from '@/lib/utils/buildMode'
 
 /**
  * 根据notion的slug访问页面

--- a/pages/[prefix]/[slug]/index.js
+++ b/pages/[prefix]/[slug]/index.js
@@ -4,6 +4,7 @@ import { resolvePostProps } from '@/lib/db/SiteDataApi'
 import Slug from '..'
 import { checkSlugHasOneSlash } from '@/lib/utils/post'
 import { getStaticPathsBase } from '@/lib/build/staticPaths'
+import { isExport } from '@/lib/utils/buildMode'
 
 /**
  * 根据notion的slug访问页面

--- a/pages/[prefix]/index.js
+++ b/pages/[prefix]/index.js
@@ -17,6 +17,7 @@ import { useRouter } from 'next/router'
 import PropTypes from 'prop-types'
 import { useEffect, useState } from 'react'
 import { getStaticPathsBase } from '@/lib/build/staticPaths'
+import { isExport } from '@/lib/utils/buildMode'
 
 /**
  * 根据notion的slug访问页面


### PR DESCRIPTION
## 背景

PR #4033 将多个路由中的 `getStaticPaths` 逻辑抽到 `getStaticPathsBase`，用于复用静态路径生成和构建缓存逻辑。合并后，三个 prefix/slug 路由文件的 `getStaticProps` 仍然会调用 `isExport()` 来决定是否设置 ISR `revalidate`，但对应的 `isExport` 导入被移除，导致构建预渲染阶段直接失败。

相关部署报错见：

- Fixes #4043
- 本修复 PR：#4046

典型错误为：

```text
ReferenceError: isExport is not defined
Error occurred prerendering page ...
Command "yarn run build" exited with 1
```

该问题会影响 Vercel、Cloudflare Pages、本地 `yarn build` / `yarn export` 等构建链路。

## 修复内容

本 PR 在保留 #4033 构建优化方向的基础上，补齐合并后遗漏的构建稳定性修复：

- 恢复三个 prefix/slug 路由文件对 `isExport` helper 的导入：
  - `pages/[prefix]/index.js`
  - `pages/[prefix]/[slug]/index.js`
  - `pages/[prefix]/[slug]/[...suffix].js`
- 继续统一使用 `@/lib/utils/buildMode` 中的 `isExport()`，避免在多个路由文件中重复内联导出模式判断逻辑。
- 保持 `getStaticPathsBase` 负责统一处理 export / ISR 两种构建路径，减少路由文件里的重复逻辑。
- 修复 `getSharedAllPages` 对失败 promise 的进程内缓存问题：当 Notion 数据拉取失败时清理对应缓存 key，避免后续请求一直复用同一个 rejected promise。
- 统一 `staticPaths` 缓存 key 的 `pageId` 默认值，使其与 `fetchGlobalAllData` 的默认行为保持一致。
- 先清理 `tagOptions`，再用清理后的标签集合过滤页面 `tagItems`，避免页面保留已被过滤标签导致标签页跳转 404。

## 修复效果

- 解决 #4043 中反馈的部署构建失败问题。
- 消除 `isExport is not defined` 导致的预渲染崩溃。
- 保留 #4033 的静态路径复用和构建缓存优化。
- 提升构建过程中 Notion 数据拉取失败后的恢复能力，避免失败状态在进程内长期残留。
- 让标签清理逻辑和页面标签引用保持一致，减少标签页 404 的风险。

## 验证

已在修复分支执行以下验证：

- `yarn install --frozen-lockfile`
- `yarn test __tests__/lib/staticPaths.test.js --runInBand`
- `yarn test --runInBand`
- `./node_modules/.bin/eslint pages/[prefix]/index.js pages/[prefix]/[slug]/index.js pages/[prefix]/[slug]/[...suffix].js lib/build/staticPaths.js lib/db/SiteDataApi.js __tests__/lib/staticPaths.test.js`
- `yarn type-check`
- `yarn build`
- `yarn export`

验证结果：

- `yarn build` 和 `yarn export` 均已通过。
- 未再出现 `ReferenceError: isExport is not defined`。
- 静态路径相关单测和全量测试均已通过。