### PR TITLE
fix: security hardening, error boundary, and context performance

### DIFF
--- a/lib/global.js
+++ b/lib/global.js
@@ -7,7 +7,7 @@ import {
 } from '@/themes/theme'
 import { useUser } from '@clerk/nextjs'
 import { useRouter } from 'next/router'
-import { createContext, useContext, useEffect, useMemo, useState } from 'react'
+import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react'
 import { generateLocaleDict, initLocale, redirectUserLang } from './utils/lang'
 
 /**
@@ -52,7 +52,7 @@ export function GlobalContextProvider(props) {
   const fullWidth = post?.fullWidth ?? false
 
   // 切换主题
-  function switchTheme() {
+  const switchTheme = useCallback(() => {
     const query = router.query
     const currentTheme = query.theme || theme
     const currentIndex = THEMES.indexOf(currentTheme)
@@ -61,30 +61,30 @@ export function GlobalContextProvider(props) {
     query.theme = newTheme
     router.push({ pathname: router.pathname, query })
     return newTheme
-  }
+  }, [router, theme, THEMES])
 
   // 抓取主题配置
-  const updateThemeConfig = async theme => {
+  const updateThemeConfig = useCallback(async theme => {
     const config = await getThemeConfig(theme)
     SET_THEME_CONFIG(config)
-  }
+  }, [])
 
   // 切换深色模式
-  const toggleDarkMode = () => {
+  const toggleDarkMode = useCallback(() => {
     const newStatus = !isDarkMode
     saveDarkModeToLocalStorage(newStatus)
     updateDarkMode(newStatus)
     const htmlElement = document.getElementsByTagName('html')[0]
     htmlElement.classList?.remove(newStatus ? 'light' : 'dark')
     htmlElement.classList?.add(newStatus ? 'dark' : 'light')
-  }
+  }, [isDarkMode])
 
-  function changeLang(lang) {
+  const changeLang = useCallback(lang => {
     if (lang) {
       updateLang(lang)
       updateLocale(generateLocaleDict(lang))
     }
-  }
+  }, [])
 
   // 添加路由变化时的语言处理
   useEffect(() => {
@@ -133,7 +133,7 @@ export function GlobalContextProvider(props) {
     }
   }, [router.events])
 
-  const contextValue = {
+  const contextValue = useMemo(() => ({
     isLiteMode,
     isLoaded,
     isSignedIn,
@@ -156,7 +156,7 @@ export function GlobalContextProvider(props) {
     siteInfo,
     categoryOptions,
     tagOptions
-  }
+  }), [isLiteMode, isLoaded, isSignedIn, user, fullWidth, NOTION_CONFIG, THEME_CONFIG, toggleDarkMode, onLoading, setOnLoading, lang, changeLang, locale, updateLocale, isDarkMode, updateDarkMode, theme, setTheme, switchTheme, siteInfo, categoryOptions, tagOptions])
   globalSnapshot = contextValue
 
   return (

--- a/lib/utils/errorHandler.js
+++ b/lib/utils/errorHandler.js
@@ -1,3 +1,5 @@
+import React from 'react'
+
 /**
  * 统一错误处理工具类
  */

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -12,6 +12,7 @@ import { getBaseLayoutByTheme } from '@/themes/theme'
 import { useRouter } from 'next/router'
 import { useCallback, useEffect, useMemo } from 'react'
 import { getQueryParam } from '../lib/utils'
+import ErrorHandler from '@/lib/utils/errorHandler'
 
 // 各种扩展插件 这个要阻塞引入
 import BLOG from '@/blog.config'
@@ -22,6 +23,14 @@ import dynamic from 'next/dynamic'
 // import { ClerkProvider } from '@clerk/nextjs'
 const ClerkProvider = dynamic(() =>
   import('@clerk/nextjs').then(m => m.ClerkProvider)
+)
+
+const AppErrorBoundary = ErrorHandler.createErrorBoundary(
+  <div style={{ padding: '2rem', textAlign: 'center', minHeight: '100vh', display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center' }}>
+    <h1 style={{ fontSize: '1.5rem', marginBottom: '1rem' }}>Something went wrong</h1>
+    <p style={{ color: '#666', marginBottom: '1.5rem' }}>An unexpected error occurred. Please refresh the page.</p>
+    <button onClick={() => window.location.reload()} style={{ padding: '0.5rem 1.5rem', cursor: 'pointer', border: '1px solid #ccc', borderRadius: '4px', background: 'transparent' }}>Refresh</button>
+  </div>
 )
 
 /**
@@ -75,13 +84,15 @@ const MyApp = ({ Component, pageProps }) => {
 
   const enableClerk = process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY
   const content = (
-    <GlobalContextProvider {...pageProps}>
-      <GLayout {...pageProps}>
-        <SEO {...pageProps} />
-        <Component {...pageProps} />
-      </GLayout>
-      <ExternalPlugins {...pageProps} />
-    </GlobalContextProvider>
+    <AppErrorBoundary>
+      <GlobalContextProvider {...pageProps}>
+        <GLayout {...pageProps}>
+          <SEO {...pageProps} />
+          <Component {...pageProps} />
+        </GLayout>
+        <ExternalPlugins {...pageProps} />
+      </GlobalContextProvider>
+    </AppErrorBoundary>
   )
   return (
     <>

--- a/pages/api/cache.js
+++ b/pages/api/cache.js
@@ -6,10 +6,20 @@ import { cleanCache } from '@/lib/cache/local_file_cache'
  * @param {*} res
  */
 export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ status: 'error', message: 'Method not allowed' })
+  }
+
+  const token = process.env.CACHE_REVALIDATION_TOKEN
+  if (token && req.headers.authorization !== `Bearer ${token}`) {
+    return res.status(401).json({ status: 'error', message: 'Unauthorized' })
+  }
+
   try {
     await cleanCache()
     res.status(200).json({ status: 'success', message: 'Clean cache successful!' })
   } catch (error) {
-    res.status(400).json({ status: 'error', message: 'Clean cache failed!', error })
+    console.error('Cache clean error:', error)
+    res.status(400).json({ status: 'error', message: 'Clean cache failed!' })
   }
 }

--- a/pages/api/subscribe.js
+++ b/pages/api/subscribe.js
@@ -10,11 +10,11 @@ export default async function handler(req, res) {
     const { email, firstName, lastName } = req.body
     try {
       const response = await subscribeToMailchimpApi({ email, first_name: firstName, last_name: lastName })
-      const data = await response.json()
-      console.log('data', data)
+      await response.json()
       res.status(200).json({ status: 'success', message: 'Subscription successful!' })
     } catch (error) {
-      res.status(400).json({ status: 'error', message: 'Subscription failed!', error })
+      console.error('Subscription error:', error)
+      res.status(400).json({ status: 'error', message: 'Subscription failed!' })
     }
   } else {
     res.status(405).json({ status: 'error', message: 'Method not allowed' })


### PR DESCRIPTION
## Summary

- **Security**: Sanitize API error responses — `subscribe.js` and `cache.js` no longer expose raw `error` objects to clients; errors are logged server-side only
- **Security**: Add optional Bearer token auth to `/api/cache` endpoint via `CACHE_REVALIDATION_TOKEN` env var (backward compatible — no auth when token is unset)
- **Stability**: Add Error Boundary in `_app.js` to prevent full-page crashes; fix missing `React` import in `errorHandler.js`
- **Performance**: Memoize `GlobalContext` value and callbacks (`toggleDarkMode`, `switchTheme`, `changeLang`) with `useMemo`/`useCallback` to reduce unnecessary re-renders

## Background

Multiple open issues report client-side crashes that crash the entire page (#2295, #3545, #3372). API endpoints leak internal error details. GlobalContext causes unnecessary re-renders across all consumers.

## Changed files

- `pages/api/subscribe.js` — remove debug log, sanitize error response
- `pages/api/cache.js` — add POST-only + optional Bearer auth + sanitize error
- `lib/utils/errorHandler.js` — add missing `React` import for `createErrorBoundary`
- `pages/_app.js` — wrap component tree with `AppErrorBoundary`
- `lib/global.js` — `useMemo` for context value, `useCallback` for callbacks

## Risks

- **Low risk**: Error Boundary is additive — only activates on uncaught errors
- **Low risk**: Cache auth is backward compatible — no change when `CACHE_REVALIDATION_TOKEN` is not set
- **Low risk**: Context memoization preserves identical behavior, only avoids redundant object creation
- **Medium risk**: `useCallback` deps for `toggleDarkMode` include `isDarkMode` — this is correct but changes the reference identity pattern

## Verification

```bash
yarn lint
yarn type-check
yarn test
yarn build
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)