### PR TITLE
fix(security): add optional bearer token auth to cache endpoint

### DIFF
--- a/pages/api/cache.js
+++ b/pages/api/cache.js
@@ -6,10 +6,19 @@ import { cleanCache } from '@/lib/cache/local_file_cache'
  * @param {*} res
  */
 export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ status: 'error', message: 'Method not allowed' })
+  }
+
+  const token = process.env.CACHE_REVALIDATION_TOKEN
+  if (token && req.headers.authorization !== `Bearer ${token}`) {
+    return res.status(401).json({ status: 'error', message: 'Unauthorized' })
+  }
+
   try {
     await cleanCache()
     res.status(200).json({ status: 'success', message: 'Clean cache successful!' })
   } catch (error) {
-    res.status(400).json({ status: 'error', message: 'Clean cache failed!', error })
+    res.status(400).json({ status: 'error', message: 'Clean cache failed!' })
   }
 }


### PR DESCRIPTION
## Summary

- Restrict `/api/cache` to POST method only
- Add optional Bearer token authentication via `CACHE_REVALIDATION_TOKEN` env var
- Backward compatible: no auth required when token is not configured

## Problem

The cache endpoint accepts any request without authentication, allowing anyone to clear the site cache and trigger a thundering herd back to the Notion API.

## Changed files

- `pages/api/cache.js` — add method check + optional auth

## Verification

```bash
yarn lint
# Without token: POST /api/cache → 200 (backward compatible)
# With CACHE_REVALIDATION_TOKEN set:
#   POST /api/cache (no header) → 401
#   POST /api/cache (Authorization: Bearer <token>) → 200
#   GET /api/cache → 405
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)