### PR TITLE
fix(api): sanitize error responses in subscribe and cache endpoints

### DIFF
--- a/pages/api/cache.js
+++ b/pages/api/cache.js
@@ -10,6 +10,7 @@ export default async function handler(req, res) {
     await cleanCache()
     res.status(200).json({ status: 'success', message: 'Clean cache successful!' })
   } catch (error) {
-    res.status(400).json({ status: 'error', message: 'Clean cache failed!', error })
+    console.error('Cache clean error:', error)
+    res.status(400).json({ status: 'error', message: 'Clean cache failed!' })
   }
 }

--- a/pages/api/subscribe.js
+++ b/pages/api/subscribe.js
@@ -10,11 +10,11 @@ export default async function handler(req, res) {
     const { email, firstName, lastName } = req.body
     try {
       const response = await subscribeToMailchimpApi({ email, first_name: firstName, last_name: lastName })
-      const data = await response.json()
-      console.log('data', data)
+      await response.json()
       res.status(200).json({ status: 'success', message: 'Subscription successful!' })
     } catch (error) {
-      res.status(400).json({ status: 'error', message: 'Subscription failed!', error })
+      console.error('Subscription error:', error)
+      res.status(400).json({ status: 'error', message: 'Subscription failed!' })
     }
   } else {
     res.status(405).json({ status: 'error', message: 'Method not allowed' })


### PR DESCRIPTION
## Summary

- Remove raw `error` object from API responses in `subscribe.js` and `cache.js`
- Log full error server-side via `console.error` instead
- Remove debug `console.log` in subscribe handler

## Problem

Both endpoints return the raw `error` object to clients, potentially leaking internal stack traces and implementation details.

## Changed files

- `pages/api/subscribe.js` — remove debug log, sanitize error response
- `pages/api/cache.js` — sanitize error response

## Verification

```bash
yarn lint
yarn build
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)