### PR TITLE
perf(context): memoize GlobalContext value and callbacks

### DIFF
--- a/lib/global.js
+++ b/lib/global.js
@@ -7,7 +7,7 @@ import {
 } from '@/themes/theme'
 import { useUser } from '@clerk/nextjs'
 import { useRouter } from 'next/router'
-import { createContext, useContext, useEffect, useMemo, useState } from 'react'
+import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react'
 import { generateLocaleDict, initLocale, redirectUserLang } from './utils/lang'
 
 /**
@@ -52,7 +52,7 @@ export function GlobalContextProvider(props) {
   const fullWidth = post?.fullWidth ?? false
 
   // 切换主题
-  function switchTheme() {
+  const switchTheme = useCallback(() => {
     const query = router.query
     const currentTheme = query.theme || theme
     const currentIndex = THEMES.indexOf(currentTheme)
@@ -61,30 +61,30 @@ export function GlobalContextProvider(props) {
     query.theme = newTheme
     router.push({ pathname: router.pathname, query })
     return newTheme
-  }
+  }, [router, theme, THEMES])
 
   // 抓取主题配置
-  const updateThemeConfig = async theme => {
+  const updateThemeConfig = useCallback(async theme => {
     const config = await getThemeConfig(theme)
     SET_THEME_CONFIG(config)
-  }
+  }, [])
 
   // 切换深色模式
-  const toggleDarkMode = () => {
+  const toggleDarkMode = useCallback(() => {
     const newStatus = !isDarkMode
     saveDarkModeToLocalStorage(newStatus)
     updateDarkMode(newStatus)
     const htmlElement = document.getElementsByTagName('html')[0]
     htmlElement.classList?.remove(newStatus ? 'light' : 'dark')
     htmlElement.classList?.add(newStatus ? 'dark' : 'light')
-  }
+  }, [isDarkMode])
 
-  function changeLang(lang) {
+  const changeLang = useCallback(lang => {
     if (lang) {
       updateLang(lang)
       updateLocale(generateLocaleDict(lang))
     }
-  }
+  }, [])
 
   // 添加路由变化时的语言处理
   useEffect(() => {
@@ -133,7 +133,7 @@ export function GlobalContextProvider(props) {
     }
   }, [router.events])
 
-  const contextValue = {
+  const contextValue = useMemo(() => ({
     isLiteMode,
     isLoaded,
     isSignedIn,
@@ -156,7 +156,7 @@ export function GlobalContextProvider(props) {
     siteInfo,
     categoryOptions,
     tagOptions
-  }
+  }), [isLiteMode, isLoaded, isSignedIn, user, fullWidth, NOTION_CONFIG, THEME_CONFIG, toggleDarkMode, onLoading, setOnLoading, lang, changeLang, locale, updateLocale, isDarkMode, updateDarkMode, theme, setTheme, switchTheme, siteInfo, categoryOptions, tagOptions])
   globalSnapshot = contextValue
 
   return (


### PR DESCRIPTION
## Summary

- Wrap `contextValue` in `useMemo` to avoid creating a new object on every render
- Wrap `toggleDarkMode`, `switchTheme`, `changeLang`, `updateThemeConfig` in `useCallback` for stable references

## Problem

`GlobalContext.Provider` creates a new `contextValue` object on every render, causing all `useGlobal()` consumers across the entire component tree to re-render unnecessarily.

## Changed files

- `lib/global.js` — add `useCallback` import; memoize context value and callbacks

## Risks

- **Low**: `useMemo`/`useCallback` are transparent optimizations — behavior is identical
- **Note**: `toggleDarkMode` has `[isDarkMode]` as dependency, which is correct since it reads and flips that state
- This is a high-impact file (used by all themes), but the change is purely additive — no behavior change, only reference stability

## Verification

```bash
yarn lint
yarn build
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)