### PR TITLE
fix(stability): add Error Boundary to prevent full-page crashes

### DIFF
--- a/lib/utils/errorHandler.js
+++ b/lib/utils/errorHandler.js
@@ -1,3 +1,4 @@
+import React from 'react'
 /**
  * 统一错误处理工具类
  */

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -12,6 +12,7 @@ import { getBaseLayoutByTheme } from '@/themes/theme'
 import { useRouter } from 'next/router'
 import { useCallback, useEffect, useMemo } from 'react'
 import { getQueryParam } from '../lib/utils'
+import ErrorHandler from '@/lib/utils/errorHandler'
 
 // 各种扩展插件 这个要阻塞引入
 import BLOG from '@/blog.config'
@@ -22,6 +23,13 @@ import dynamic from 'next/dynamic'
 // import { ClerkProvider } from '@clerk/nextjs'
 const ClerkProvider = dynamic(() =>
   import('@clerk/nextjs').then(m => m.ClerkProvider)
+)
+const AppErrorBoundary = ErrorHandler.createErrorBoundary(
+  <div style={{ padding: '2rem', textAlign: 'center', minHeight: '100vh', display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center' }}>
+    <h1 style={{ fontSize: '1.5rem', marginBottom: '1rem' }}>Something went wrong</h1>
+    <p style={{ color: '#666', marginBottom: '1.5rem' }}>An unexpected error occurred. Please refresh the page.</p>
+    <button onClick={() => window.location.reload()} style={{ padding: '0.5rem 1.5rem', cursor: 'pointer', border: '1px solid #ccc', borderRadius: '4px', background: 'transparent' }}>Refresh</button>
+  </div>
 )
 
 /**
@@ -75,13 +83,15 @@ const MyApp = ({ Component, pageProps }) => {
 
   const enableClerk = process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY
   const content = (
-    <GlobalContextProvider {...pageProps}>
-      <GLayout {...pageProps}>
-        <SEO {...pageProps} />
-        <Component {...pageProps} />
-      </GLayout>
-      <ExternalPlugins {...pageProps} />
-    </GlobalContextProvider>
+    <AppErrorBoundary>
+      <GlobalContextProvider {...pageProps}>
+        <GLayout {...pageProps}>
+          <SEO {...pageProps} />
+          <Component {...pageProps} />
+        </GLayout>
+        <ExternalPlugins {...pageProps} />
+      </GlobalContextProvider>
+    </AppErrorBoundary>
   )
   return (
     <>


### PR DESCRIPTION
## Summary

- Add `React` import to `lib/utils/errorHandler.js` (fixes broken `createErrorBoundary`)
- Wrap component tree with `AppErrorBoundary` in `pages/_app.js`

## Problem

Multiple open issues report client-side crashes that crash the entire page (#2295, #3545, #3372). The root cause is third-party scripts (Mermaid, Live2D, Prism) mutating React-managed DOM. Adding an Error Boundary catches these errors and shows a fallback instead of a blank page.

## Changed files

- `lib/utils/errorHandler.js` — add missing `React` import
- `pages/_app.js` — add `AppErrorBoundary` wrapping the app tree

## Risks

- Low: Error Boundary is purely additive — only activates on uncaught rendering errors
- The fallback UI is minimal: error message + refresh button, inline styles only

## Verification

```bash
yarn lint
yarn build
# To test: throw an error inside any component — should see fallback instead of blank page
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)