### PR TITLE
fix: load Font Awesome version with X icon

### DIFF
--- a/conf/font.config.js
+++ b/conf/font.config.js
@@ -54,7 +54,7 @@ module.exports = {
   ],
   FONT_AWESOME:
     process.env.NEXT_PUBLIC_FONT_AWESOME_PATH ||
-    'https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css' // font-awesome 字体图标地址; 可选 /css/all.min.css ， https://lf9-cdn-tos.bytecdntp.com/cdn/expire-1-M/font-awesome/6.0.0/css/all.min.css
+    'https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css' // font-awesome 字体图标地址; 可选 /css/all.min.css ， https://lf9-cdn-tos.bytecdntp.com/cdn/expire-1-M/font-awesome/6.0.0/css/all.min.css
 
   // END ************网站字体*****************
 }


### PR DESCRIPTION
## Summary
- updates the default Font Awesome CDN from 6.4.0 to 6.4.2
- keeps the existing fa-x-twitter share icon working with the default config

Fixes #3984.

Stacked on #4099 because main currently needs the CI baseline fixes there. After #4099 merges, this PR should be retargeted to main.

## Verification
- yarn.cmd lint
- yarn.cmd type-check