### PR TITLE
fix: preserve selected Notion view filters

### DIFF
--- a/__tests__/lib/notion-data-format.test.js
+++ b/__tests__/lib/notion-data-format.test.js
@@ -81,27 +81,53 @@ describe('Notion data format compatibility', () => {
     expect(pageIds).toEqual(['page_1', 'page_2'])
   })
 
-  it('falls back to legacy collection query block ids', () => {
+  it('supplements truncated page_sort from the selected view query only', () => {
     const pageIds = getAllPageIds(
       {
         collection_1: {
           view_1: {
             collection_group_results: {
-              blockIds: ['page_1']
+              blockIds: ['page_1', 'page_2']
             }
           },
           view_2: {
-            blockIds: ['page_2']
+            blockIds: ['hidden_page']
           }
         }
       },
       'collection_1',
-      {},
+      {
+        view_1: {
+          value: {
+            value: {
+              page_sort: ['page_1']
+            }
+          }
+        }
+      },
       ['view_1'],
       {}
     )
 
-    expect(pageIds).toEqual(expect.arrayContaining(['page_1', 'page_2']))
+    expect(pageIds).toEqual(['page_1', 'page_2'])
+    expect(pageIds).not.toContain('hidden_page')
+  })
+
+  it('falls back to all query blocks when no selected view is available', () => {
+    const pageIds = getAllPageIds(
+      {
+        collection_1: {
+          view_1: { blockIds: ['page_1'] },
+          view_2: { blockIds: ['page_2'] }
+        }
+      },
+      'collection_1',
+      {},
+      [],
+      {}
+    )
+
+    expect(pageIds).toEqual(['page_1', 'page_2'])
   })
 
   it('normalizes nested blocks and strips crdt fields before rendering', () => {

--- a/lib/db/notion/getAllPageIds.js
+++ b/lib/db/notion/getAllPageIds.js
@@ -2,11 +2,10 @@ import BLOG from "@/blog.config"
 
 export default function getAllPageIds(collectionQuery, collectionId, collectionView, viewIds, block = {}) {
   const pageSet = new Set()
+  const targetViewId = viewIds?.[BLOG.NOTION_INDEX || 0]
 
   // 策略1：page_sort（有顺序，但可能截断）
-  if (collectionView && viewIds?.length > 0) {
-    const groupIndex = BLOG.NOTION_INDEX || 0
-    const targetViewId = viewIds[groupIndex]
+  if (collectionView && targetViewId) {
     const pageSort = collectionView?.[targetViewId]?.value?.value?.page_sort
     if (Array.isArray(pageSort) && pageSort.length > 0) {
       pageSort.forEach(id => pageSet.add(id))
@@ -18,7 +17,9 @@ export default function getAllPageIds(collectionQuery, collectionId, collectionV
   if (collectionQuery && collectionId) {
     const viewQuery = collectionQuery?.[collectionId]
     if (viewQuery) {
-      Object.values(viewQuery).forEach(viewData => {
+      const selectedViewData = targetViewId ? viewQuery[targetViewId] : null
+      const queryData = selectedViewData ? [selectedViewData] : Object.values(viewQuery)
+      queryData.forEach(viewData => {
         [
           viewData?.collection_group_results?.blockIds,
           viewData?.results?.blockIds,


### PR DESCRIPTION
## Summary
- only supplement truncated Notion page_sort data from the selected collection view
- avoid mixing pages from other views that should be excluded by filters
- add regression coverage for selected-view supplementation and fallback behavior

Fixes #4039.
Also addresses #3940, which reports the same filtered page view regression.

## Verification
- yarn.cmd test __tests__/lib/notion-data-format.test.js --runInBand
- yarn.cmd lint
- yarn.cmd type-check
- yarn.cmd test --passWithNoTests
- yarn.cmd build
- VITE_GISCUS_ENABLED=false yarn.cmd docs:site:build