### PR TITLE
ci: create PR for automatic version bumps

### DIFF
--- a/.github/workflows/bump-version-on-main.yml
+++ b/.github/workflows/bump-version-on-main.yml
@@ -11,6 +11,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 concurrency:
   group: bump-package-version-main
@@ -32,17 +33,17 @@ jobs:
           fetch-depth: 0
 
       - name: Bump package.json patch (last segment)
-        run: node scripts/bump-package-patch-version.js
-
-      - name: Commit and push if changed
+        id: bump
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          if git diff --quiet package.json; then
-            echo "No version change (unexpected)."
-            exit 0
-          fi
-          NEW_VER=$(node -p "require('./package.json').version")
-          git add package.json
-          git commit -m "chore(release): bump package.json to ${NEW_VER} [skip-version]"
-          git push
+          node scripts/bump-package-patch-version.js
+          VERSION=$(node -p "require('./package.json').version")
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Create version bump pull request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          commit-message: "chore(release): bump package.json to ${{ steps.bump.outputs.version }} [skip-version]"
+          title: "chore(release): bump package.json to ${{ steps.bump.outputs.version }} [skip-version]"
+          body: "Automated package version bump after a main branch update."
+          branch: chore/bump-package-version
+          delete-branch: true


### PR DESCRIPTION
## Summary
- stops the main-branch version bump workflow from pushing directly to protected main
- grants pull-request write permission and creates a version bump PR instead
- keeps [skip-version] in the generated commit/title to avoid bump loops after the PR is merged

## Verification
- inspected the failed run: direct push was rejected by branch protection
- reviewed workflow YAML diff