### PR TITLE
fix: resolve qs to patched version

### DIFF
--- a/package.json
+++ b/package.json
@@ -131,7 +131,8 @@
   },
   "resolutions": {
     "axios": ">=0.21.1",
-    "form-data": "^4.0.4"
+    "form-data": "^4.0.4",
+    "qs": "^6.15.2"
   },
   "bugs": {
     "url": "https://github.com/tangly/NotionNext/issues",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7489,17 +7489,10 @@ pure-rand@^6.0.0:
   resolved "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz"
   integrity sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==
 
-qs@~6.14.0:
-  version "6.14.2"
-  resolved "https://registry.npmmirror.com/qs/-/qs-6.14.2.tgz"
-  integrity sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==
-  dependencies:
-    side-channel "^1.1.0"
-
-qs@~6.15.1:
-  version "6.15.1"
-  resolved "https://registry.npmmirror.com/qs/-/qs-6.15.1.tgz"
-  integrity sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==
+qs@^6.15.2, qs@~6.14.0, qs@~6.15.1:
+  version "6.15.2"
+  resolved "https://registry.npmmirror.com/qs/-/qs-6.15.2.tgz#fd55426d710403ddccc45e0f9eab16db7727ece9"
+  integrity sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==
   dependencies:
     side-channel "^1.1.0"
 


### PR DESCRIPTION
## Summary
- adds a Yarn classic resolution for qs >= 6.15.2
- updates yarn.lock so @lhci/cli's transitive express dependency resolves qs to the patched 6.15.2 release
- addresses the Dependabot security update failure for qs, where the latest resolvable version was stuck at 6.14.2

## Verification
- yarn.cmd install
- yarn.cmd install --frozen-lockfile
- yarn.cmd why qs
- yarn.cmd lint
- yarn.cmd type-check