### PR TITLE
fix(endspace): support custom nested menus

### DIFF
--- a/themes/endspace/components/MobileNav.js
+++ b/themes/endspace/components/MobileNav.js
@@ -1,11 +1,11 @@
 import { useRouter } from 'next/router'
-import { useState, useEffect, useRef } from 'react'
+import { useState, useEffect, useMemo, useRef } from 'react'
 import { siteConfig } from '@/lib/config'
 import { handleEmailClick } from '@/lib/plugins/mailEncrypt'
 import { useGlobal } from '@/lib/global'
-import CONFIG from '../config'
 import SmartLink from '@/components/SmartLink'
 import { EndspacePlayer } from './EndspacePlayer'
+import { buildMenuItems, isMenuItemActive } from './menu'
 import {
   IconMenu2,
   IconX,
@@ -70,23 +70,19 @@ const SocialIconComponents = {
 export const MobileNav = (props) => {
   const router = useRouter()
   const { siteInfo } = useGlobal()
+  const { customNav, customMenu } = props
   const [activeTab, setActiveTab] = useState('Home')
   const [isMenuOpen, setIsMenuOpen] = useState(false)
+  const [openSubMenu, setOpenSubMenu] = useState(null)
   const emailIcon = useRef(null)
   
   // Get avatar from props or global context
   const avatarUrl = props?.siteInfo?.icon || siteInfo?.icon || siteConfig('AVATAR')
 
-  // All navigation items
-  const menuItems = [
-    { name: 'Home', path: '/' },
-    { name: 'Category', path: '/category', show: siteConfig('ENDSPACE_MENU_CATEGORY', null, CONFIG) },
-    { name: 'Tag', path: '/tag', show: siteConfig('ENDSPACE_MENU_TAG', null, CONFIG) },
-    { name: 'Archive', path: '/archive', show: siteConfig('ENDSPACE_MENU_ARCHIVE', null, CONFIG) },
-    { name: 'Portfolio', path: '/portfolio' },
-    { name: 'Friends', path: '/friends' },
-    { name: 'Search', path: '/search', show: siteConfig('ENDSPACE_MENU_SEARCH', null, CONFIG) }
-  ].filter(item => item.show !== false)
+  const menuItems = useMemo(
+    () => buildMenuItems({ customNav, customMenu }),
+    [customNav, customMenu]
+  )
 
   // Social icon config - using contact.config.js settings
   const socialLinks = [
@@ -107,18 +103,14 @@ export const MobileNav = (props) => {
 
   useEffect(() => {
     const path = router.asPath
-    if (path === '/') setActiveTab('Home')
-    else if (path.includes('/category')) setActiveTab('Category')
-    else if (path.includes('/tag')) setActiveTab('Tag')
-    else if (path.includes('/archive')) setActiveTab('Archive')
-    else if (path.includes('/search')) setActiveTab('Search')
-    else if (path.includes('/friends')) setActiveTab('Friends')
-    else if (path.includes('/portfolio')) setActiveTab('Portfolio')
-  }, [router.asPath])
+    const activeItem = menuItems.find(item => isMenuItemActive(item, path))
+    setActiveTab(activeItem?.name || 'Home')
+  }, [router.asPath, menuItems])
 
   // Close menu when route changes
   useEffect(() => {
     setIsMenuOpen(false)
+    setOpenSubMenu(null)
   }, [router.asPath])
 
   // Prevent body scroll when menu is open
@@ -135,8 +127,7 @@ export const MobileNav = (props) => {
 
   // Render icon component
   const renderIcon = (name) => {
-    const IconComponent = IconComponents[name]
-    if (!IconComponent) return null
+    const IconComponent = IconComponents[name] || BookMarkFillIcon
     return <IconComponent size={20} className="w-6 text-center" />
   }
 
@@ -199,22 +190,69 @@ export const MobileNav = (props) => {
       >
         {/* Navigation Items */}
         <div className="flex flex-col items-start p-6 space-y-2">
-          {menuItems.map(item => (
-            <SmartLink
-              key={item.name}
-              href={item.path}
-              className={`flex items-center gap-4 py-3 w-full transition-all group ${
-                activeTab === item.name
-                  ? 'text-black font-bold'
-                  : 'text-[var(--endspace-text-secondary)] hover:text-black'
-              }`}
-            >
-              <div className={`transition-colors ${activeTab === item.name ? 'text-black' : 'text-gray-400 group-hover:text-black'}`}>
-                 {renderIcon(item.name)}
+          {menuItems.map(item => {
+            const hasSubMenu = item.subMenus?.length > 0
+            const itemKey = `${item.name}-${item.path}`
+            const isOpen = openSubMenu === itemKey
+            const itemClassName = `flex items-center gap-4 py-3 w-full transition-all group ${
+              activeTab === item.name
+                ? 'text-black font-bold'
+                : 'text-[var(--endspace-text-secondary)] hover:text-black'
+            }`
+            const itemContent = (
+              <>
+                <div className={`transition-colors ${activeTab === item.name ? 'text-black' : 'text-gray-400 group-hover:text-black'}`}>
+                  {item.icon ? <i className={item.icon} /> : renderIcon(item.name)}
+                </div>
+                <span className="text-xl font-medium">{item.name}</span>
+                {hasSubMenu && (
+                  <span className={`ml-auto text-xl transition-transform duration-200 ${isOpen ? 'rotate-90' : ''}`}>
+                    &rsaquo;
+                  </span>
+                )}
+              </>
+            )
+
+            return (
+              <div key={itemKey} className='w-full'>
+                {hasSubMenu ? (
+                  <button
+                    type='button'
+                    onClick={() => setOpenSubMenu(isOpen ? null : itemKey)}
+                    className={itemClassName}
+                  >
+                    {itemContent}
+                  </button>
+                ) : (
+                  <SmartLink
+                    href={item.path}
+                    target={item.target}
+                    className={itemClassName}
+                  >
+                    {itemContent}
+                  </SmartLink>
+                )}
+
+                {hasSubMenu && isOpen && (
+                  <div className='mb-2 ml-10 flex flex-col border-l border-[var(--endspace-border-base)] pl-4'>
+                    {item.subMenus.map(subMenu => (
+                      <SmartLink
+                        key={`${subMenu.name}-${subMenu.path}`}
+                        href={subMenu.path}
+                        target={subMenu.target || item.target}
+                        className='flex items-center gap-3 py-2 text-base text-[var(--endspace-text-secondary)] transition-colors hover:text-black'
+                      >
+                        <span className='w-4 text-center text-gray-400'>
+                          {subMenu.icon ? <i className={subMenu.icon} /> : renderIcon(subMenu.name)}
+                        </span>
+                        <span>{subMenu.name}</span>
+                      </SmartLink>
+                    ))}
+                  </div>
+                )}
               </div>
-              <span className="text-xl font-medium">{item.name}</span>
-            </SmartLink>
-          ))}
+            )
+          })}
         </div>
 
         {/* Music Player (No Label, No Divider) */}

--- a/themes/endspace/components/SideNav.js
+++ b/themes/endspace/components/SideNav.js
@@ -1,11 +1,11 @@
 import { useRouter } from 'next/router'
-import { useState, useEffect, useRef } from 'react'
+import { useState, useEffect, useMemo, useRef } from 'react'
 import { siteConfig } from '@/lib/config'
 import { handleEmailClick } from '@/lib/plugins/mailEncrypt'
 import { useGlobal } from '@/lib/global'
-import CONFIG from '../config'
 import SmartLink from '@/components/SmartLink'
 import { EndspacePlayer } from './EndspacePlayer'
+import { buildMenuItems, isMenuItemActive } from './menu'
 import {
   IconBrandGithub,
   IconBrandTwitter,
@@ -71,6 +71,7 @@ const SocialIconComponents = {
 export const SideNav = (props) => {
   const router = useRouter()
   const { siteInfo } = useGlobal()
+  const { customNav, customMenu } = props
   const [isHovered, setIsHovered] = useState(false)
   const [activeTab, setActiveTab] = useState('Home')
   const [indicatorStyle, setIndicatorStyle] = useState({ top: 0, opacity: 0 })
@@ -81,16 +82,10 @@ export const SideNav = (props) => {
   // Get avatar from props or global context (Hexo way uses props)
   const avatarUrl = props?.siteInfo?.icon || siteInfo?.icon || siteConfig('AVATAR')
 
-  // All navigation items
-  const menuItems = [
-    { name: 'Home', path: '/' },
-    { name: 'Category', path: '/category', show: siteConfig('ENDSPACE_MENU_CATEGORY', null, CONFIG) },
-    { name: 'Tag', path: '/tag', show: siteConfig('ENDSPACE_MENU_TAG', null, CONFIG) },
-    { name: 'Archive', path: '/archive', show: siteConfig('ENDSPACE_MENU_ARCHIVE', null, CONFIG) },
-    { name: 'Portfolio', path: '/portfolio' },
-    { name: 'Friends', path: '/friends' },
-    { name: 'Search', path: '/search', show: siteConfig('ENDSPACE_MENU_SEARCH', null, CONFIG) }
-  ].filter(item => item.show !== false)
+  const menuItems = useMemo(
+    () => buildMenuItems({ customNav, customMenu }),
+    [customNav, customMenu]
+  )
 
   // Social icon config - using contact.config.js settings
   const socialLinks = [
@@ -130,17 +125,11 @@ export const SideNav = (props) => {
   useEffect(() => {
     // Set active tab based on path
     const path = router.asPath
-    let newTab = 'Home'
-    if (path === '/') newTab = 'Home'
-    else if (path.includes('/category')) newTab = 'Category'
-    else if (path.includes('/tag')) newTab = 'Tag'
-    else if (path.includes('/archive')) newTab = 'Archive'
-    else if (path.includes('/search')) newTab = 'Search'
-    else if (path.includes('/friends')) newTab = 'Friends'
-    else if (path.includes('/portfolio')) newTab = 'Portfolio'
+    const activeItem = menuItems.find(item => isMenuItemActive(item, path))
+    const newTab = activeItem?.name || 'Home'
     
     setActiveTab(newTab)
-  }, [router.asPath])
+  }, [router.asPath, menuItems])
 
   // Update indicator position when activeTab changes
   useEffect(() => {
@@ -162,8 +151,7 @@ export const SideNav = (props) => {
 
   // Render icon component
   const renderIcon = (name, isActive) => {
-    const IconComponent = IconComponents[name]
-    if (!IconComponent) return null
+    const IconComponent = IconComponents[name] || BookMarkFillIcon
     return (
       <IconComponent 
         size={20} 
@@ -226,24 +214,58 @@ export const SideNav = (props) => {
         />
         
         {menuItems.map((item) => {
+          const hasSubMenu = item.subMenus?.length > 0
           const isActive = activeTab === item.name
           return (
-            <SmartLink key={item.name} href={item.path}>
+            <div
+              key={`${item.name}-${item.path}`}
+              className='group/menu relative'
+            >
+              <SmartLink href={item.path} target={item.target}>
               <div 
                 ref={el => itemRefs.current[item.name] = el}
                 className={`nier-nav-item relative h-[3rem] flex items-center cursor-pointer group transition-colors duration-300 hover:bg-[#d4d4d8] ${isActive ? 'active bg-[#d4d4d8]' : ''}`}
               >
                 {/* Icon Container */}
                 <div className="w-[5rem] flex-shrink-0 flex items-center justify-center z-10">
-                  {renderIcon(item.name, isActive)}
+                  {item.icon ? <i className={item.icon} /> : renderIcon(item.name, isActive)}
                 </div>
 
                 {/* Text Label (Reveal on Hover) */}
                 <span className={`text-sm font-medium tracking-wide uppercase whitespace-nowrap transition-opacity duration-300 z-10 ${isHovered ? 'opacity-100 delay-75' : 'opacity-0 w-0'}`}>
                   {item.name.toUpperCase()}
                 </span>
+                {hasSubMenu && (
+                  <span className={`ml-auto pr-4 text-xs transition-opacity duration-300 ${isHovered ? 'opacity-100' : 'opacity-0'}`}>
+                    &rsaquo;
+                  </span>
+                )}
               </div>
-            </SmartLink>
+              </SmartLink>
+              {hasSubMenu && (
+                <div
+                  className={`grid overflow-hidden transition-all duration-300 ${isHovered ? 'grid-rows-[0fr] opacity-0 group-hover/menu:grid-rows-[1fr] group-hover/menu:opacity-100' : 'grid-rows-[0fr] opacity-0'}`}
+                >
+                  <div className='min-h-0 py-1'>
+                    {item.subMenus.map(subMenu => (
+                      <SmartLink
+                        key={`${subMenu.name}-${subMenu.path}`}
+                        href={subMenu.path}
+                        target={subMenu.target || item.target}
+                        className='flex h-10 items-center text-sm font-medium text-[var(--endspace-text-secondary)] transition-colors hover:bg-[#d4d4d8] hover:text-black'
+                      >
+                        <span className='flex w-[5rem] flex-shrink-0 items-center justify-center text-xs'>
+                          {subMenu.icon ? <i className={subMenu.icon} /> : renderIcon(subMenu.name, false)}
+                        </span>
+                        <span className='min-w-0 flex-1 truncate pr-4 text-xs uppercase tracking-wide'>
+                          {subMenu.name}
+                        </span>
+                      </SmartLink>
+                    ))}
+                  </div>
+                </div>
+              )}
+            </div>
           )
         })}
       </div>

--- a/themes/endspace/components/menu.js
+++ b/themes/endspace/components/menu.js
@@ -1,0 +1,71 @@
+import BLOG from '@/blog.config'
+import { siteConfig } from '@/lib/config'
+import CONFIG from '../config'
+
+export const buildMenuItems = ({ customNav, customMenu }) => {
+  const defaultMenuItems = [
+    { name: 'Home', path: '/' },
+    {
+      name: 'Category',
+      path: '/category',
+      show: siteConfig('ENDSPACE_MENU_CATEGORY', null, CONFIG)
+    },
+    {
+      name: 'Tag',
+      path: '/tag',
+      show: siteConfig('ENDSPACE_MENU_TAG', null, CONFIG)
+    },
+    {
+      name: 'Archive',
+      path: '/archive',
+      show: siteConfig('ENDSPACE_MENU_ARCHIVE', null, CONFIG)
+    },
+    { name: 'Portfolio', path: '/portfolio' },
+    { name: 'Friends', path: '/friends' },
+    {
+      name: 'Search',
+      path: '/search',
+      show: siteConfig('ENDSPACE_MENU_SEARCH', null, CONFIG)
+    }
+  ]
+
+  const normalizeMenuItem = link => ({
+    name: link?.name || link?.title || '',
+    path: link?.href || link?.to || link?.slug || '/',
+    target: link?.target,
+    icon: link?.icon,
+    show: link?.show,
+    subMenus: Array.isArray(link?.subMenus)
+      ? link.subMenus.map(normalizeMenuItem)
+      : []
+  })
+
+  const customNavItems = Array.isArray(customNav)
+    ? customNav.map(normalizeMenuItem)
+    : []
+  const customMenuItems = Array.isArray(customMenu)
+    ? customMenu.map(normalizeMenuItem)
+    : []
+
+  let links =
+    customNavItems.length > 0
+      ? customNavItems.concat(defaultMenuItems)
+      : defaultMenuItems
+
+  if (siteConfig('CUSTOM_MENU', BLOG.CUSTOM_MENU) && customMenuItems.length > 0) {
+    links = customMenuItems
+  }
+
+  return links.filter(item => item.show !== false)
+}
+
+export const isMenuItemActive = (item, currentPath) => {
+  if (!item || !currentPath) return false
+  const itemPath = item.path
+  const selfActive =
+    itemPath === '/' ? currentPath === '/' : itemPath && currentPath.startsWith(itemPath)
+
+  if (selfActive) return true
+
+  return item.subMenus?.some(subMenu => isMenuItemActive(subMenu, currentPath))
+}


### PR DESCRIPTION
## Summary

- Add shared endspace menu normalization to preserve legacy default menu behavior while supporting dynamic `customNav` / `customMenu` data.
- Support `CUSTOM_MENU + customMenu` override when custom menu data exists, with fallback to the original endspace default menu settings.
- Preserve and render `subMenus` for nested menus on both desktop and mobile navigation.
- Fix desktop nested menu layout so second-level text stays inside the expanded sidebar and does not get clipped at the edge.

## Verification

- Ran `eslint` on `themes/endspace/components/SideNav.js`, `themes/endspace/components/MobileNav.js`, and `themes/endspace/components/menu.js`.
- Result: no errors; existing `<img>` optimization warnings remain.