### PR TITLE
feat: community backend — Member & Event data types (#4035)

### DIFF
--- a/__tests__/lib/db/notion/memberDataSource.test.js
+++ b/__tests__/lib/db/notion/memberDataSource.test.js
@@ -1,0 +1,89 @@
+import {
+  fetchMembersFromOfficialAPI,
+  mapOfficialMemberPage
+} from '@/lib/db/notion/memberDataSource'
+
+const originalEnv = process.env
+const originalFetch = global.fetch
+
+function memberPage({ id, title, slug, status = 'Published' }) {
+  return {
+    id,
+    created_time: '2026-01-01T00:00:00.000Z',
+    last_edited_time: '2026-01-02T00:00:00.000Z',
+    properties: {
+      title: { type: 'title', title: [{ plain_text: title }] },
+      slug: { type: 'rich_text', rich_text: [{ plain_text: slug }] },
+      status: { type: 'select', select: { name: status } },
+      featured: { type: 'checkbox', checkbox: true }
+    }
+  }
+}
+
+describe('memberDataSource', () => {
+  beforeEach(() => {
+    process.env = { ...originalEnv }
+    global.fetch = jest.fn()
+  })
+
+  afterEach(() => {
+    process.env = originalEnv
+    global.fetch = originalFetch
+  })
+
+  it('maps an official Notion member page to site data', () => {
+    const mapped = mapOfficialMemberPage(
+      memberPage({ id: 'member-1', title: 'Ada', slug: 'ada' })
+    )
+
+    expect(mapped).toMatchObject({
+      id: 'member-1',
+      title: 'Ada',
+      slug: 'members/ada',
+      href: '/members/ada',
+      type: 'Member',
+      status: 'Published',
+      featured: true
+    })
+  })
+
+  it('paginates official API results and filters unpublished members', async () => {
+    process.env.NOTION_API_TOKEN = 'secret'
+    process.env.NOTION_MEMBERS_DATA_SOURCE_ID = 'source-id'
+
+    global.fetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          has_more: true,
+          next_cursor: 'cursor-2',
+          results: [
+            memberPage({ id: 'member-1', title: 'Ada', slug: 'ada' })
+          ]
+        })
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          has_more: false,
+          next_cursor: null,
+          results: [
+            memberPage({
+              id: 'member-2',
+              title: 'Draft',
+              slug: 'draft',
+              status: 'Invisible'
+            })
+          ]
+        })
+      })
+
+    const members = await fetchMembersFromOfficialAPI()
+
+    expect(global.fetch).toHaveBeenCalledTimes(2)
+    expect(JSON.parse(global.fetch.mock.calls[1][1].body)).toMatchObject({
+      start_cursor: 'cursor-2'
+    })
+    expect(members.map(member => member.id)).toEqual(['member-1'])
+  })
+})

--- a/conf/notion.config.js
+++ b/conf/notion.config.js
@@ -19,6 +19,10 @@ module.exports = {
     type_menu: process.env.NEXT_PUBLIC_NOTION_PROPERTY_TYPE_MENU || 'Menu', // 当type文章类型与此值相同时，为菜单。
     type_sub_menu:
       process.env.NEXT_PUBLIC_NOTION_PROPERTY_TYPE_SUB_MENU || 'SubMenu', // 当type文章类型与此值相同时，为子菜单。
+    type_member:
+      process.env.NEXT_PUBLIC_NOTION_PROPERTY_TYPE_MEMBER || 'Member', // 社区成员资料
+    type_event:
+      process.env.NEXT_PUBLIC_NOTION_PROPERTY_TYPE_EVENT || 'Event', // 社区活动
     title: process.env.NEXT_PUBLIC_NOTION_PROPERTY_TITLE || 'title', // 文章标题
     status: process.env.NEXT_PUBLIC_NOTION_PROPERTY_STATUS || 'status',
     status_publish:

--- a/lib/db/SiteDataApi.js
+++ b/lib/db/SiteDataApi.js
@@ -27,6 +27,7 @@ import { fetchPageFromNotion } from './notion/getNotionPost'
 import { processPostData } from '../utils/post'
 import { adapterNotionBlockMap } from '../utils/notion.util'
 import { sortPinnedPostsByLatestUpdate } from '@/lib/utils/pinnedPosts'
+import { fetchMembersFromOfficialAPI } from './notion/memberDataSource'
 // import pLimit from 'p-limit'
 
 export { getAllTags } from './notion/getAllTags'
@@ -395,6 +396,26 @@ async function convertNotionToSiteData(
     )
   }
   collectionData.forEach(element => adjustPageProperties(element, NOTION_CONFIG))
+
+  const officialMembers = await fetchMembersFromOfficialAPI({
+    typeProperty: BLOG.NOTION_PROPERTY_NAME.type,
+    statusProperty: BLOG.NOTION_PROPERTY_NAME.status,
+    typeValue: BLOG.NOTION_PROPERTY_NAME.type_member,
+    statusValue: BLOG.NOTION_PROPERTY_NAME.status_publish
+  })
+  if (officialMembers.length > 0) {
+    const existingMembers = new Set(
+      collectionData
+        .filter(item => item?.type === 'Member')
+        .flatMap(item => [item.id, item.slug].filter(Boolean))
+    )
+    officialMembers.forEach(member => {
+      if (!existingMembers.has(member.id) && !existingMembers.has(member.slug)) {
+        collectionData.push(member)
+      }
+    })
+  }
+
   const siteInfo = getSiteInfo({ collection, block, rawMetadata, NOTION_CONFIG })
   const stepEnd9 = Date.now()
   console.log(`[${traceId}] ⏱ 配置站点信息耗时: ${stepEnd9 - stepStart9}ms @ ${new Date().toISOString()}`)
@@ -823,9 +844,13 @@ export function getAllMembers({ allPages }) {
     .filter(page => page?.type === 'Member' && page?.status === 'Published')
     .sort((a, b) => {
       // Featured 优先
-      if (a.featured !== b.featured) return b.featured ? 1 : -1
+      const aFeatured = Boolean(a.featured)
+      const bFeatured = Boolean(b.featured)
+      if (aFeatured !== bFeatured) return bFeatured ? 1 : -1
       // Verified 优先
-      if (a.verified !== b.verified) return b.verified ? 1 : -1
+      const aVerified = Boolean(a.verified)
+      const bVerified = Boolean(b.verified)
+      if (aVerified !== bVerified) return bVerified ? 1 : -1
       // sortOrder 升序
       if (a.sortOrder != null && b.sortOrder != null) return a.sortOrder - b.sortOrder
       // 发布时间倒序

--- a/lib/db/SiteDataApi.js
+++ b/lib/db/SiteDataApi.js
@@ -182,6 +182,8 @@ const EmptyData = pageId => ({
   rawMetadata: {},
   customNav: [],
   customMenu: [],
+  allMembers: [],
+  allEvents: [],
   postCount: 1,
   pageIds: [],
   latestPosts: []
@@ -432,6 +434,11 @@ async function convertNotionToSiteData(
     latestPostCount: siteConfig('LATEST_POST_COUNT', 6, NOTION_CONFIG)
   })
   const allNavPages = getNavPages({ allPages })
+
+  // ── 社区数据：Member / Event ──
+  const allMembers = getAllMembers({ allPages })
+  const allEvents = getAllEvents({ allPages })
+
   const stepEnd11 = Date.now()
   console.log(`[${traceId}] ⏱ 其他数据生成耗时: ${stepEnd11 - stepStart11}ms @ ${new Date().toISOString()}`)
   const overallEnd = Date.now()
@@ -442,6 +449,8 @@ async function convertNotionToSiteData(
     notice,
     siteInfo,
     allPages,
+    allMembers,
+    allEvents,
     allNavPages,
     collection,
     collectionQuery,
@@ -490,9 +499,12 @@ function handleDataBeforeReturn(db) {
   db.tagOptions = cleanTagOptions(db?.tagOptions)
   db.allNavPages = cleanPages(db?.allNavPages, db.tagOptions)
   db.allPages = cleanPages(db.allPages, db.tagOptions)
+  db.allMembers = cleanPages(db.allMembers, db.tagOptions)
+  db.allEvents = cleanPages(db.allEvents, db.tagOptions)
   db.latestPosts = cleanPages(db.latestPosts, db.tagOptions)
 
   // 定时发布：检查发布时间窗口，超出范围的隐藏
+  // 仅对 Post/Page 生效，Event 和 Member 不受此限制
   const POST_SCHEDULE_PUBLISH = siteConfig(
     'POST_SCHEDULE_PUBLISH',
     null,
@@ -500,6 +512,7 @@ function handleDataBeforeReturn(db) {
   )
   if (POST_SCHEDULE_PUBLISH) {
     db.allPages?.forEach(p => {
+      if (p.type === 'Event' || p.type === 'Member') return
       if (!isInRange(p.title, p.date)) {
         console.log('[定时发布] 隐藏-->', p.title, p.date)
         p.status = 'Invisible'
@@ -798,4 +811,35 @@ export function getNavPages({ allPages }) {
     publishDate: item.publishDate,
     ext: item.ext || {}
   }))
+}
+
+/**
+ * 获取所有已发布的社区成员
+ * 从 allPages 中筛选 type=Member && status=Published 的条目
+ */
+export function getAllMembers({ allPages }) {
+  if (!Array.isArray(allPages)) return []
+  return allPages
+    .filter(page => page?.type === 'Member' && page?.status === 'Published')
+    .sort((a, b) => {
+      // Featured 优先
+      if (a.featured !== b.featured) return b.featured ? 1 : -1
+      // Verified 优先
+      if (a.verified !== b.verified) return b.verified ? 1 : -1
+      // sortOrder 升序
+      if (a.sortOrder != null && b.sortOrder != null) return a.sortOrder - b.sortOrder
+      // 发布时间倒序
+      return (b?.publishDate ?? 0) - (a?.publishDate ?? 0)
+    })
+}
+
+/**
+ * 获取所有已发布的社区活动
+ * 从 allPages 中筛选 type=Event && status=Published 的条目
+ */
+export function getAllEvents({ allPages }) {
+  if (!Array.isArray(allPages)) return []
+  return allPages
+    .filter(page => page?.type === 'Event' && page?.status === 'Published')
+    .sort((a, b) => (b?.publishDate ?? 0) - (a?.publishDate ?? 0))
 }

--- a/lib/db/notion/getPageProperties.js
+++ b/lib/db/notion/getPageProperties.js
@@ -154,7 +154,9 @@ function mapProperties(properties) {
     [BLOG.NOTION_PROPERTY_NAME.type_page]: 'Page',
     [BLOG.NOTION_PROPERTY_NAME.type_notice]: 'Notice',
     [BLOG.NOTION_PROPERTY_NAME.type_menu]: 'Menu',
-    [BLOG.NOTION_PROPERTY_NAME.type_sub_menu]: 'SubMenu'
+    [BLOG.NOTION_PROPERTY_NAME.type_sub_menu]: 'SubMenu',
+    [BLOG.NOTION_PROPERTY_NAME.type_member]: 'Member',
+    [BLOG.NOTION_PROPERTY_NAME.type_event]: 'Event'
   }
 
   const statusMap = {

--- a/lib/db/notion/memberDataSource.js
+++ b/lib/db/notion/memberDataSource.js
@@ -1,0 +1,161 @@
+/**
+ * memberDataSource.js
+ *
+ * Member 数据的官方 API 补充管道。
+ *
+ * 背景：NotionNext 的非官方 API (notion-client) 读取数据库视图，
+ * 可能会过滤掉某些 entry type（如 Member）。此模块通过 Notion 官方 API
+ * 补充读取 Member 条目，确保成员数据完整。
+ *
+ * 用法：
+ *   在 SiteDataApi.js 的 convertNotionToSiteData 中调用
+ *   fetchMembersFromOfficialAPI()，将结果合并到 allPages。
+ *
+ * 环境变量：
+ *   NOTION_API_TOKEN                 — Notion Integration Token（需要 read 权限）
+ *   NOTION_MEMBERS_DATA_SOURCE_ID    — Member 数据源 ID
+ */
+
+/**
+ * 读取 Notion 属性值，兼容多种类型
+ */
+function readPropertyValue(property) {
+  if (!property) return null
+  const type = property.type
+  switch (type) {
+    case 'title':
+      return property.title?.map(t => t.plain_text).join('') || null
+    case 'rich_text':
+      return property.rich_text?.map(t => t.plain_text).join('') || null
+    case 'url':
+      return property.url || null
+    case 'select':
+      return property.select?.name || null
+    case 'status':
+      return property.status?.name || null
+    case 'checkbox':
+      return property.checkbox ?? null
+    case 'number':
+      return property.number ?? null
+    case 'date':
+      return property.date?.start || null
+    case 'email':
+      return property.email || null
+    case 'phone_number':
+      return property.phone_number || null
+    default:
+      return null
+  }
+}
+
+/**
+ * 查找属性名（大小写不敏感）
+ * Notion 官方 API 的 data_source 端点使用内部 key（小写），
+ * 而非界面显示名。此函数兼容两种情况。
+ */
+function findPropertyKey(properties, candidates) {
+  if (!properties) return null
+  for (const candidate of candidates) {
+    if (properties[candidate]) return candidate
+    // 大小写不敏感匹配
+    const lower = candidate.toLowerCase()
+    for (const key of Object.keys(properties)) {
+      if (key.toLowerCase() === lower) return key
+    }
+  }
+  return null
+}
+
+/**
+ * 将 Notion 官方 API 返回的 page 映射为 Member 数据对象
+ */
+export function mapOfficialMemberPage(page) {
+  const props = page.properties || {}
+  const get = (candidates) => {
+    const key = findPropertyKey(props, Array.isArray(candidates) ? candidates : [candidates])
+    return key ? readPropertyValue(props[key]) : null
+  }
+
+  const title = get(['title', 'Title'])
+  const slug = get(['slug', 'Slug'])
+  if (!title || !slug) return null
+
+  return {
+    id: page.id,
+    title,
+    slug: slug.startsWith('members/') ? slug : `members/${slug}`,
+    type: 'Member',
+    status: 'Published',
+    summary: get(['summary', 'Summary']) || '',
+    avatar: get(['avatar', 'Avatar']) || null,
+    role: get(['role', 'Role']) || '',
+    bio: get(['bio', 'Bio']) || '',
+    quote: get(['quote', 'Quote']) || '',
+    featured: get(['featured', 'Featured']) || false,
+    verified: get(['verified', 'Verified']) || false,
+    website: get(['website', 'Website']) || null,
+    joinedAtText: get(['joinedAtText', 'joined_at_text', 'Joined At']) || '',
+    sortOrder: get(['sortOrder', 'sort_order', 'Sort Order']) ?? null,
+    author_slug: get(['author_slug', 'authorSlug', 'Author Slug']) || '',
+    social_github: get(['social_github', 'github', 'GitHub']) || null,
+    social_x: get(['social_x', 'twitter', 'x', 'Twitter', 'X']) || null,
+    social_linkedin: get(['social_linkedin', 'linkedin', 'LinkedIn']) || null,
+    publishDate: page.created_time ? new Date(page.created_time).getTime() : Date.now(),
+    lastEditedDate: page.last_edited_time ? new Date(page.last_edited_time).getTime() : Date.now(),
+    pageIcon: page.icon?.type === 'external' ? page.icon.external?.url : null,
+    pageCover: page.cover?.type === 'external' ? page.cover.external?.url : null,
+    pageCoverThumbnail: page.cover?.type === 'external' ? page.cover.external?.url : null,
+    ext: {},
+    href: `/members/${slug.replace(/^members\//, '')}`,
+  }
+}
+
+/**
+ * 通过 Notion 官方 API 获取 Member 数据
+ * @returns {Promise<Array>} 已发布的 Member 列表
+ */
+export async function fetchMembersFromOfficialAPI() {
+  const token = process.env.NOTION_API_TOKEN
+  const dataSourceId = process.env.NOTION_MEMBERS_DATA_SOURCE_ID
+
+  if (!token || !dataSourceId) return []
+
+  try {
+    const response = await fetch(
+      `https://api.notion.com/v1/data_sources/${dataSourceId}/query`,
+      {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Notion-Version': '2022-06-28',
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          filter: {
+            and: [
+              { property: 'type', select: { equals: 'Member' } },
+              { property: 'status', status: { equals: 'Published' } },
+            ],
+          },
+          page_size: 100,
+        }),
+      }
+    )
+
+    if (!response.ok) {
+      console.error('[memberDataSource] API request failed:', response.status)
+      return []
+    }
+
+    const data = await response.json()
+    const members = (data.results || [])
+      .map(mapOfficialMemberPage)
+      .filter(Boolean)
+
+    console.log(`[memberDataSource] Fetched ${members.length} members from official API`)
+    return members
+  } catch (error) {
+    console.error('[memberDataSource] Error fetching members:', error)
+    return []
+  }
+}

--- a/lib/db/notion/memberDataSource.js
+++ b/lib/db/notion/memberDataSource.js
@@ -69,7 +69,7 @@ function findPropertyKey(properties, candidates) {
 /**
  * 将 Notion 官方 API 返回的 page 映射为 Member 数据对象
  */
-export function mapOfficialMemberPage(page) {
+export function mapOfficialMemberPage(page, { statusProperty = 'status' } = {}) {
   const props = page.properties || {}
   const get = (candidates) => {
     const key = findPropertyKey(props, Array.isArray(candidates) ? candidates : [candidates])
@@ -85,7 +85,7 @@ export function mapOfficialMemberPage(page) {
     title,
     slug: slug.startsWith('members/') ? slug : `members/${slug}`,
     type: 'Member',
-    status: 'Published',
+    status: get([statusProperty, 'status', 'Status']) || 'Published',
     summary: get(['summary', 'Summary']) || '',
     avatar: get(['avatar', 'Avatar']) || null,
     role: get(['role', 'Role']) || '',
@@ -114,43 +114,53 @@ export function mapOfficialMemberPage(page) {
  * 通过 Notion 官方 API 获取 Member 数据
  * @returns {Promise<Array>} 已发布的 Member 列表
  */
-export async function fetchMembersFromOfficialAPI() {
+export async function fetchMembersFromOfficialAPI({
+  typeProperty = 'type',
+  statusProperty = 'status',
+  typeValue = 'Member',
+  statusValue = 'Published'
+} = {}) {
   const token = process.env.NOTION_API_TOKEN
   const dataSourceId = process.env.NOTION_MEMBERS_DATA_SOURCE_ID
 
   if (!token || !dataSourceId) return []
 
   try {
-    const response = await fetch(
-      `https://api.notion.com/v1/data_sources/${dataSourceId}/query`,
-      {
-        method: 'POST',
-        headers: {
-          Authorization: `Bearer ${token}`,
-          'Notion-Version': '2022-06-28',
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
-          filter: {
-            and: [
-              { property: 'type', select: { equals: 'Member' } },
-              { property: 'status', status: { equals: 'Published' } },
-            ],
+    const members = []
+    let startCursor = undefined
+
+    do {
+      const response = await fetch(
+        `https://api.notion.com/v1/data_sources/${dataSourceId}/query`,
+        {
+          method: 'POST',
+          headers: {
+            Authorization: `Bearer ${token}`,
+            'Notion-Version': '2022-06-28',
+            'Content-Type': 'application/json',
           },
-          page_size: 100,
-        }),
+          body: JSON.stringify({
+            filter: { property: typeProperty, select: { equals: typeValue } },
+            page_size: 100,
+            ...(startCursor ? { start_cursor: startCursor } : {})
+          }),
+        }
+      )
+
+      if (!response.ok) {
+        console.error('[memberDataSource] API request failed:', response.status)
+        return members
       }
-    )
 
-    if (!response.ok) {
-      console.error('[memberDataSource] API request failed:', response.status)
-      return []
-    }
-
-    const data = await response.json()
-    const members = (data.results || [])
-      .map(mapOfficialMemberPage)
-      .filter(Boolean)
+      const data = await response.json()
+      members.push(
+        ...(data.results || [])
+          .map(page => mapOfficialMemberPage(page, { statusProperty }))
+          .filter(member => member?.status === statusValue)
+          .filter(Boolean)
+      )
+      startCursor = data.has_more ? data.next_cursor : undefined
+    } while (startCursor)
 
     console.log(`[memberDataSource] Fetched ${members.length} members from official API`)
     return members


### PR DESCRIPTION
## Closes #4035

NotionNext 目前非常适合个人博客和知识库，但要搭建**社区官网 / 组织官网**，缺少对 `Member` 和 `Event` 数据类型的一等支持。

这个 PR 是 #4035 提案的**完整代码实现**，提取自我在 NotionNext 上搭建 [IGNAI 社区官网](https://github.com/qianzhu18/IGN-AI) 的实践。

---

## 改了什么

### 1. 数据类型注册 (`conf/notion.config.js`)

新增 `type_member` 和 `type_event`，与已有的 `type_post`/`type_page`/`type_menu` 同级：

```js
type_member: process.env.NEXT_PUBLIC_NOTION_PROPERTY_TYPE_MEMBER || 'Member',
type_event: process.env.NEXT_PUBLIC_NOTION_PROPERTY_TYPE_EVENT || 'Event',
```

### 2. 数据管道扩展 (`lib/db/SiteDataApi.js`)

在 `convertNotionToSiteData` 返回值中新增：

| 字段 | 来源 | 排序 |
|------|------|------|
| `allMembers` | `type=Member, status=Published` | featured > verified > sortOrder > publishDate |
| `allEvents` | `type=Event, status=Published` | publishDate 倒序 |

同时修复了一个 **bug**：`POST_SCHEDULE_PUBLISH`（定时发布）会把未来日期的 Event 条目当成"未到发布日"隐藏。但活动的 `start_date` 本身就是未来日期——它们是"即将到来的活动"，不是"未发布的草稿"。现在 `Event` 和 `Member` 类型不受定时发布逻辑限制。

### 3. Member 官方 API 补充 (`lib/db/notion/memberDataSource.js`)

NotionNext 的非官方 API (`notion-client`) 读取数据库视图时，可能会过滤掉 `Member` 类型的条目。此模块通过 Notion 官方 API (`data_sources/{id}/query`) 补充读取，确保成员数据完整。

```
非官方 API → allPages (可能缺少 Member)
官方 API   → fetchMembersFromOfficialAPI() → 合并到 allPages
```

---

## 架构总览

```
Notion Database (单库多类型)
├── type=Post    → allPages / allNavPages / latestPosts  (已有)
├── type=Page    → customNav                             (已有)
├── type=Menu    → customMenu                            (已有)
├── type=Notice  → notice                                (已有)
├── type=Member  → allMembers                            ← 新增
├── type=Event   → allEvents                             ← 新增
└── type=CONFIG  → NOTION_CONFIG                         (已有)
```

## 主题如何消费

```jsx
const { allMembers, allEvents } = await getGlobalData()

// 成员展示
<MembersSection members={allMembers} />

// 活动展示
<EventsSection events={allEvents} />

// 活动记录（已结束的活动）
<FieldNotesSection events={allEvents.filter(e => e.ext?.status === 'finished')} />
```

## Event 的 ext 字段约定

活动使用已有的 `ext` JSON 字段存储结构化数据：

```json
{
  "status": "open",
  "location": "长沙",
  "format": "offline",
  "dateText": "2026 / 06 / 14",
  "registrationUrl": "https://...",
  "agenda": ["签到", "分享", "讨论"],
  "hosts": ["社区名"]
}
```

## 完整实现参考

这个 PR 是上游提取。完整的社区官网实现（含主题、页面、Join 表单、作者联动）在：
https://github.com/qianzhu18/IGN-AI

已验证的功能：
- `/members` 成员目录页（从 Notion 读取真实数据）
- `/members/[slug]` 成员详情页（含社交链接、相关文章）
- `/events` 活动列表页
- `/events/[slug]` 活动详情页（含议程、报名入口）
- `/join` 表单 → Notion 写回（status=Invisible，人工审核后 Published）
- 作者到成员页的映射

## 环境变量

```env
NOTION_PAGE_ID=<主库ID>                            # 必填
NOTION_API_TOKEN=<integration-token>               # 可选，启用官方 API 成员补充
NOTION_MEMBERS_DATA_SOURCE_ID=<data-source-id>     # 可选，启用官方 API 成员补充
```