### PR TITLE
chore(release): bump package.json to 4.9.5.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "notion-next",
-  "version": "4.9.5.5",
+  "version": "4.9.5.6",
   "packageManager": "yarn@1.22.22",
   "homepage": "https://github.com/tangly1024/NotionNext.git",
   "license": "MIT",


### PR DESCRIPTION
Version bump after #4113.\n\nThis uses a fresh maintenance branch so GitHub Actions checks run normally. The merge commit subject should include [skip-version] to avoid another version bump loop.