### PR TITLE
docs: add contributor acknowledgements page

### DIFF
--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -38,6 +38,7 @@ export default defineConfig({
       { text: '维护策略', link: '/DOCUMENTATION_POLICY' },
       { text: '参与社区', link: '/user-guide/community-participate' },
       { text: '参与维护', link: '/user-guide/maintain-docs' },
+      { text: '致谢', link: '/user-guide/acknowledgements' },
       { text: '旧版手册', link: '/user-guide/help/legacy-docs' },
       {
         text: 'GitHub',
@@ -219,6 +220,7 @@ export default defineConfig({
             { text: '众筹计划', link: '/user-guide/help/crowdfunding' },
             { text: '旧版手册入口', link: '/user-guide/help/legacy-docs' },
             { text: '参与维护（在线站）', link: '/user-guide/maintain-docs' },
+            { text: '致谢', link: '/user-guide/acknowledgements' },
             { text: '维护工作流', link: '/user-guide/MAINTENANCE_WORKFLOW' },
             { text: '迁移索引', link: '/user-guide/ARTICLE_INDEX' }
           ]
@@ -243,7 +245,8 @@ export default defineConfig({
             { text: '使用说明', link: '/user-guide/intro' },
             { text: '参与社区', link: '/user-guide/community-participate' },
             { text: '文档维护策略', link: '/DOCUMENTATION_POLICY' },
-            { text: '参与维护', link: '/user-guide/maintain-docs' }
+            { text: '参与维护', link: '/user-guide/maintain-docs' },
+            { text: '致谢', link: '/user-guide/acknowledgements' }
           ]
         }
       ]

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,6 +5,7 @@
 | **在线阅读** | [https://notionnext.tangly1024.com](https://notionnext.tangly1024.com) |
 | **参与社区** | [user-guide/community-participate.md](./user-guide/community-participate.md) · [GOVERNANCE.zh-CN.md](../GOVERNANCE.zh-CN.md) |
 | **参与维护** | 在线页底「在 GitHub 上维护此页」· [user-guide/maintain-docs.md](./user-guide/maintain-docs.md) |
+| **致谢贡献者** | [user-guide/acknowledgements.md](./user-guide/acknowledgements.md) · [Contributors](https://github.com/notionnext-org/NotionNext/graphs/contributors) |
 | **旧版手册** | [user-guide/help/legacy-docs.md](./user-guide/help/legacy-docs.md) · 源站 [docs.tangly1024.com](https://docs.tangly1024.com) |
 
 ## 本目录结构（仅两类）

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,6 +22,9 @@ hero:
       text: 维护说明
       link: /user-guide/maintain-docs
     - theme: alt
+      text: 致谢
+      link: /user-guide/acknowledgements
+    - theme: alt
       text: 旧版 Notion 教程
       link: https://docs.tangly1024.com
 
@@ -40,10 +43,14 @@ features:
     details: 项目由 notionnext-org 社区维护；提问、改文档、提 PR、成为维护者。
     link: /user-guide/community-participate
     linkText: 查看指南
+  - title: 致谢贡献者
+    details: 感谢所有参与代码、主题、文档、Issue、Review 与发布维护的贡献者。
+    link: /user-guide/acknowledgements
+    linkText: 查看致谢
 ---
 
 ::: tip 参与社区维护
-NotionNext 已移交组织仓库，欢迎站长与开发者共建。请参阅 **[参与社区](/user-guide/community-participate)** · [GitHub Discussions](https://github.com/notionnext-org/NotionNext/discussions) · [贡献指南](https://github.com/notionnext-org/NotionNext/blob/main/CONTRIBUTING.zh-CN.md)。
+NotionNext 已移交组织仓库，欢迎站长与开发者共建。请参阅 **[参与社区](/user-guide/community-participate)** · [参与维护](/user-guide/maintain-docs) · [致谢](/user-guide/acknowledgements) · [GitHub Discussions](https://github.com/notionnext-org/NotionNext/discussions) · [贡献指南](https://github.com/notionnext-org/NotionNext/blob/main/CONTRIBUTING.zh-CN.md)。
 :::
 
 ::: info 还在找旧版教程？

--- a/docs/user-guide/acknowledgements.md
+++ b/docs/user-guide/acknowledgements.md
@@ -1,0 +1,54 @@
+# 致谢
+
+NotionNext 能持续运行、修复和更新，依赖长期参与代码、主题、文档、Issue 复现、PR Review、答疑和发布维护的所有开发者与站长。
+
+本页用于在文档站公开致谢这些维护工作，也作为新贡献者了解项目协作入口的页面。
+
+## 贡献者名单
+
+完整贡献者名单以 GitHub 自动统计为准：
+
+- [NotionNext Contributors](https://github.com/notionnext-org/NotionNext/graphs/contributors)
+- [所有已合并 Pull Requests](https://github.com/notionnext-org/NotionNext/pulls?q=is%3Apr+is%3Amerged)
+- [文档目录提交记录](https://github.com/notionnext-org/NotionNext/commits/main/docs)
+
+感谢每一位提交代码、维护主题、修正文档、补充翻译、复现问题、优化 CI、回复 Issue / Discussions、参与发布流程的人。很多维护工作并不会体现在单个功能里，但它们决定了项目能否被更多站长稳定使用。
+
+## 文档维护者
+
+用户文档由社区共同维护，主要位于 `docs/user-guide/`。以下工作同样属于项目维护：
+
+- 修正教程中的过时步骤、错别字和失效链接。
+- 补充部署平台、主题配置、插件配置和故障排查说明。
+- 将 Issue / Discussions 中反复出现的问题沉淀为可搜索的文档。
+- 审阅文档 PR，保持目录结构和术语一致。
+
+如果你更新了文档，合并后会出现在 [docs 提交记录](https://github.com/notionnext-org/NotionNext/commits/main/docs) 与对应 PR 记录中。
+
+## 主题与生态贡献
+
+NotionNext 的主题系统来自长期社区共建。主题作者、迁移者和维护者的工作包括视觉实现、多端适配、配置项整理、预览图、文档和后续兼容性维护。
+
+- [主题全览](./themes/THEMES_CATALOG.md)
+- [主题总览](./themes/overview.md)
+- [主题开发与迁移指南（GitHub）](https://github.com/notionnext-org/NotionNext/blob/main/docs/developer/THEME_MIGRATION_GUIDE.zh-CN.md)
+
+## 维护者与协作规则
+
+长期维护者、仓库协作者和负责域以仓库治理文件为准：
+
+- [MAINTAINERS.md](https://github.com/notionnext-org/NotionNext/blob/main/MAINTAINERS.md)
+- [GOVERNANCE.zh-CN.md](https://github.com/notionnext-org/NotionNext/blob/main/GOVERNANCE.zh-CN.md)
+- [维护者运行手册（GitHub）](https://github.com/notionnext-org/NotionNext/blob/main/docs/developer/MAINTAINER_RUNBOOK.zh-CN.md)
+
+## 如何加入维护
+
+最推荐从小改动开始：修正文档、补充截图说明、复现 Issue、提交主题配置表修正，或认领 `good first issue`。
+
+- [参与社区](./community-participate.md)
+- [参与维护在线文档](./maintain-docs.md)
+- [维护工作流](./MAINTENANCE_WORKFLOW.md)
+- [good first issue](https://github.com/notionnext-org/NotionNext/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
+- [help wanted](https://github.com/notionnext-org/NotionNext/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22)
+
+我们鼓励持续、小步、可验证的贡献。哪怕只修正一处教程，也是在帮助后来的使用者减少一次踩坑。

--- a/docs/user-guide/community-participate.md
+++ b/docs/user-guide/community-participate.md
@@ -1,6 +1,6 @@
 ﻿# 参与社区
 
-NotionNext 已由个人仓库移交至组织 **[notionnext-org](https://github.com/notionnext-org)**，欢迎**既是站长又是开发者**的参与者一起维护代码与文档。
+NotionNext 已由个人仓库移交至组织 **[notionnext-org](https://github.com/notionnext-org)**，欢迎**既是站长又是开发者**的参与者一起维护代码与文档。所有参与代码、主题、文档、Issue、Review 与发布维护的贡献者，都会在 [致谢页](./acknowledgements.md) 与 GitHub 贡献记录中被看见。
 
 ## 四步参与路径
 
@@ -38,7 +38,7 @@ NotionNext 已由个人仓库移交至组织 **[notionnext-org](https://github.c
 3. 本地预览：`yarn docs:site:dev`  
 4. 按 [CONTRIBUTING.zh-CN.md](https://github.com/notionnext-org/NotionNext/blob/main/CONTRIBUTING.zh-CN.md) 提 PR  
 
-详细流程：[参与维护在线文档](./maintain-docs.md) · [维护工作流](./MAINTENANCE_WORKFLOW.md)
+详细流程：[参与维护在线文档](./maintain-docs.md) · [维护工作流](./MAINTENANCE_WORKFLOW.md) · [致谢](./acknowledgements.md)
 
 **改代码 / 主题**：阅读 [开发者文档（GitHub）](https://github.com/notionnext-org/NotionNext/blob/main/docs/developer/README.md) · [贡献指南](https://github.com/notionnext-org/NotionNext/blob/main/CONTRIBUTING.zh-CN.md) · 大改动先写 [RFC（GitHub）](https://github.com/notionnext-org/NotionNext/blob/main/docs/developer/rfc/README.md)
 

--- a/docs/user-guide/maintain-docs.md
+++ b/docs/user-guide/maintain-docs.md
@@ -6,6 +6,8 @@
 
 源码与 GitHub 上的 Markdown **一一对应**；改仓库 → 合并 `main` → 自动发布。
 
+每一次文档修正都会帮助后来的站长少踩一次坑。参与维护文档的开发者会出现在 [文档提交记录](https://github.com/notionnext-org/NotionNext/commits/main/docs) 与 [致谢页](./acknowledgements.md) 中。
+
 ## 改当前这一页
 
 任意教程页底部有 **「在 GitHub 上维护此页」**，直达该文件的编辑界面。


### PR DESCRIPTION
## 变更

- 新增 VitePress 文档站致谢页，集中感谢代码、主题、文档、Issue、Review 与发布维护贡献者。
- 在首页、顶部导航、侧边栏、参与社区页、参与维护页和 docs README 中加入致谢入口。
- 致谢页链接到 GitHub Contributors、已合并 PR、docs 提交记录、维护者名单和主题贡献相关文档，避免静态名单过期。

## 验证

- `yarn.cmd docs:site:build`