### PR TITLE
fix(thoughtlite): submenu transparent bg & page bottom gap

### DIFF
--- a/themes/thoughtlite/components/MenuItemDrop.js
+++ b/themes/thoughtlite/components/MenuItemDrop.js
@@ -73,11 +73,11 @@ export const MenuItemDrop = ({ link, variant = 'default' }) => {
     <ul
       className={
         isInline
-          ? `tl-card min-w-[10rem] py-1 shadow-lg border border-[var(--tl-border)] bg-[var(--tl-surface)] transition-all duration-200 ${
-              show ? 'visible opacity-100' : 'invisible pointer-events-none opacity-0'
+          ? `tl-card min-w-[10rem] py-1 shadow-lg border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-900 transition-all duration-200 ${
+              show ? 'visible opacity-100' : 'hidden pointer-events-none opacity-0'
             }`
           : `${
-              show ? 'visible opacity-100' : 'invisible pointer-events-none opacity-0'
+              show ? 'visible opacity-100' : 'hidden pointer-events-none opacity-0'
             } absolute z-30 transition-all duration-200 left-0 top-12 block border border-gray-100 bg-white drop-shadow-lg dark:border-gray-800 dark:bg-black`
       }
       style={


### PR DESCRIPTION
## Summary

Fix two related submenu issues in the thoughtlite theme (`MenuItemDrop.js`):

### 1. Transparent submenu background (inline/header variant)
The inline submenu uses `createPortal` to render at `document.body`, which is **outside** `#theme-thoughtlite` where `--tl-surface` and `--tl-border` CSS variables are defined. These variables resolve to nothing at the portal destination, making the background transparent.

**Fix:** Replace CSS variables with hardcoded Tailwind colors (`bg-white dark:bg-gray-900`, `border-gray-200 dark:border-gray-700`).

### 2. White gap at page bottom (stack variant)
The stack variant uses `invisible` to hide the submenu when closed. Unlike `hidden` (`display: none`), `invisible` keeps the element in layout flow — an `absolute`-positioned element with `invisible` still extends the scrollable area of its nearest positioned ancestor, creating a large white gap at the bottom of the page.

**Fix:** Replace `invisible pointer-events-none opacity-0` with `hidden pointer-events-none opacity-0` for both variants.

Fixes #4121

🤖 Generated with [Claude Code](https://claude.ai/code)