### PR TITLE
fix: disable build prefetch by default

### DIFF
--- a/lib/build/buildEnv.js
+++ b/lib/build/buildEnv.js
@@ -28,6 +28,7 @@ function isBuildOrExport() {
 }
 
 function isBuildPrefetchEnabled() {
+  if (process.env.BUILD_PREFETCH_ENABLED === undefined) return false
   return isTruthyEnv(process.env.BUILD_PREFETCH_ENABLED)
 }
 


### PR DESCRIPTION
## 问题

`yarn export` 在构建阶段会触发全量 Notion block 预热。对于页面数量较多的站点，预热会长时间占用 Next.js page data collection worker，最终触发 300 秒超时。

典型日志：

```text
[BuildEnv] {prefetchEnabled:true,prefetchConcurrency:8,...}
[Prefetch] start 463 page blocks concurrency=8
Sending SIGTERM signal to Next.js build worker due to timeout of 300 seconds
Error: Collecting page data ... is still timing out after 2 attempts
```

## 修复

- 将 `BUILD_PREFETCH_ENABLED` 的默认值改为 `false`。
- 只有显式配置 `BUILD_PREFETCH_ENABLED=true` 时才启用构建期全量预热。
- 保留 `BUILD_PREFETCH_ENABLED=false` 的显式关闭行为。

## 验证

```text
unset BUILD_PREFETCH_ENABLED -> false
BUILD_PREFETCH_ENABLED=true -> true
BUILD_PREFETCH_ENABLED=false -> false
```