### PR TITLE
fix(styles,heo): dark mode readability + hide TOC for locked articles

### DIFF
--- a/styles/notion.css
+++ b/styles/notion.css
@@ -67,6 +67,24 @@
   --notion-header-height: 45px;
 }
 
+/* Dark mode: override Notion CSS variables so tags, mentions, etc. are readable */
+html.dark {
+  --fg-color: rgba(255, 255, 255, 0.9) !important;
+  --fg-color-0: rgba(255, 255, 255, 0.09);
+  --fg-color-1: rgba(255, 255, 255, 0.16);
+  --fg-color-2: rgba(255, 255, 255, 0.4);
+  --fg-color-3: rgba(255, 255, 255, 0.6);
+  --fg-color-4: #fff;
+  --fg-color-5: rgba(255, 255, 255, 0.024);
+  --fg-color-6: rgba(255, 255, 255, 0.8);
+  --fg-color-icon: var(--fg-color);
+
+  --bg-color: #191919;
+  --bg-color-0: rgba(200, 200, 200, 0.15);
+  --bg-color-1: rgb(30, 30, 30);
+  --bg-color-2: rgba(200, 200, 200, 0.15);
+}
+
 .notion {
   font-size: 16px;
   line-height: 1.5;
@@ -2136,4 +2154,22 @@ figure.notion-asset-wrapper.notion-asset-wrapper-video > div {
 /* 画廊左右边线不展示Bug */
 .notion-gallery {
   padding: 0 16px;
+}
+
+/* Dark mode: database property tags (select / multi_select) text readability */
+html.dark .notion-property-select-item,
+html.dark .notion-property-status-item,
+html.dark .notion-property-multi_select-item {
+  color: #fff !important;
+  text-shadow: 0 0 4px rgba(0, 0, 0, 0.4);
+}
+
+/* Dark mode: link-mention text readability */
+html.dark .notion-link-mention-title,
+html.dark .notion-link-mention-provider {
+  color: var(--fg-color) !important;
+}
+
+html.dark .notion-link-mention-link {
+  color: inherit;
 }

--- a/themes/heo/components/FloatTocButton.js
+++ b/themes/heo/components/FloatTocButton.js
@@ -7,14 +7,14 @@ import Catalog from './Catalog'
 export default function FloatTocButton(props) {
   const [tocVisible, changeTocVisible] = useState(false)
 
-  const { post } = props
+  const { post, lock } = props
 
   const toggleToc = () => {
     changeTocVisible(!tocVisible)
   }
 
-  //   没有目录就隐藏该按钮
-  if (!post || !post.toc || post.toc.length < 1) {
+  //   没有目录或文章上锁时隐藏该按钮
+  if (!post || lock || !post.toc || post.toc.length < 1) {
     return <></>
   }
 

--- a/themes/heo/components/SideRight.js
+++ b/themes/heo/components/SideRight.js
@@ -27,7 +27,7 @@ const FaceBookPage = dynamic(
  * @returns
  */
 export default function SideRight(props) {
-  const { post, tagOptions, currentTag, rightAreaSlot } = props
+  const { post, lock, tagOptions, currentTag, rightAreaSlot } = props
 
   // 只摘取标签的前60个，防止右侧过长
   const sortedTags = tagOptions?.slice(0, 60) || []
@@ -37,8 +37,8 @@ export default function SideRight(props) {
       <InfoCard {...props} className='w-72 wow fadeInUp' />
 
       <div className='sticky top-20 space-y-4'>
-        {/* 文章页显示目录 */}
-        {post && post.toc && post.toc.length > 0 && (
+        {/* 文章页显示目录（上锁文章不显示） */}
+        {!lock && post && post.toc && post.toc.length > 0 && (
           <Card className='bg-white dark:bg-[#1e1e1e] wow fadeInUp'>
             <Catalog toc={post.toc} />
           </Card>


### PR DESCRIPTION
## Summary

- **Fix #3765**: Database property tags (select/multi_select) in dark mode now render with white text instead of being unreadable
- **Fix #3727**: Link-mention titles in dark mode now inherit the correct foreground color instead of staying black
- **Fix #3728**: Table of contents (sidebar + floating button) is now hidden when an article is password-locked, preventing content structure leakage

## Changes

### `styles/notion.css`
Added `html.dark` overrides for Notion CSS variables (`--fg-color`, `--bg-color` and variants). These variables were previously hardcoded to light-mode values in `:root`, causing all Notion content elements that reference them (tags, mentions, property text) to remain dark-on-dark in dark mode.

Also added explicit dark mode rules for:
- `.notion-property-select-item` / `.notion-multi_select-item` — white text + subtle text-shadow for contrast against colored tag backgrounds
- `.notion-link-mention-title` / `.notion-link-mention-provider` — inherit foreground color

### `themes/heo/components/SideRight.js`
Added `lock` to destructured props. TOC card now only renders when `!lock`.

### `themes/heo/components/FloatTocButton.js`
Added `lock` to destructured props. Floating TOC button now returns empty when `lock` is true.

## Test plan

- [ ] Open a site in dark mode with a Notion database view (table/list) — verify property tags are readable
- [ ] Insert a link-mention (@ link) in a Notion page — verify text is visible in dark mode
- [ ] Lock an article with a password — verify TOC sidebar and floating TOC button are hidden before entering the password
- [ ] Verify light mode is unaffected by the CSS variable changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)