### PR TITLE
fix(rss): add API fallback for RSS feed generation

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -262,6 +262,19 @@ const nextConfig = {
 
       return [
         ...langsRewrites,
+        // RSS fallback: when static file doesn't exist, route to API
+        {
+          source: '/rss/feed.xml',
+          destination: '/api/rss'
+        },
+        {
+          source: '/rss/atom.xml',
+          destination: '/api/rss?format=atom'
+        },
+        {
+          source: '/rss/feed.json',
+          destination: '/api/rss?format=json'
+        },
         // 伪静态重写
         {
           source: '/:path*.html',

--- a/pages/api/rss.js
+++ b/pages/api/rss.js
@@ -1,0 +1,136 @@
+import BLOG from '@/blog.config'
+import { fetchGlobalAllData } from '@/lib/db/SiteDataApi'
+import { generateRss, shouldGenerateRssForLocale } from '@/lib/utils/rss'
+import { Feed } from 'feed'
+
+/**
+ * In-memory RSS cache to avoid regenerating on every request.
+ * Survives across ISR revalidations within the same serverless instance.
+ */
+let rssCache = {
+  xml: null,
+  atomXml: null,
+  json: null,
+  updatedAt: 0
+}
+
+const CACHE_TTL_MS = 10 * 60 * 1000 // 10 minutes
+
+function isCacheFresh() {
+  return rssCache.xml && Date.now() - rssCache.updatedAt < CACHE_TTL_MS
+}
+
+/**
+ * Generate RSS feed content from site data.
+ * Reuses the same data pipeline as the homepage getStaticProps.
+ */
+async function generateRssContent() {
+  const locale = BLOG.LANG
+  const defaultLocale = BLOG.LANG
+  const pageId = BLOG.NOTION_PAGE_ID
+
+  // Parse the first (default) page ID for data fetching
+  const pageIds = pageId.split(',')
+  const targetId = pageIds[0].includes(':')
+    ? pageIds[0].split(':')[1]
+    : pageIds[0]
+
+  const props = await fetchGlobalAllData({ from: 'rss-api', pageId: targetId, locale })
+  if (!props || !props.allPages) {
+    return null
+  }
+
+  const { siteInfo, allPages, NOTION_CONFIG } = props
+
+  // Filter published posts only
+  const latestPosts = allPages
+    .filter(p => p.type === 'Post' && p.status === 'Published')
+    .sort((a, b) => {
+      const dateA = new Date(a.publishDay || a.publishDate || 0)
+      const dateB = new Date(b.publishDay || b.publishDate || 0)
+      return dateB - dateA
+    })
+    .slice(0, 20)
+
+  if (latestPosts.length === 0) {
+    return null
+  }
+
+  const TITLE = siteInfo?.title || BLOG.AUTHOR
+  const DESCRIPTION = siteInfo?.description || BLOG.BIO
+  const LINK = siteInfo?.link || BLOG.LINK
+  const AUTHOR = NOTION_CONFIG?.AUTHOR || BLOG.AUTHOR
+  const LANG = NOTION_CONFIG?.LANG || BLOG.LANG
+  const year = new Date().getFullYear()
+
+  const feed = new Feed({
+    title: TITLE,
+    description: DESCRIPTION,
+    link: LINK,
+    language: LANG,
+    favicon: `${LINK}/favicon.png`,
+    copyright: `All rights reserved ${year}, ${AUTHOR}`,
+    author: {
+      name: AUTHOR,
+      link: LINK
+    }
+  })
+
+  for (const post of latestPosts) {
+    feed.addItem({
+      title: post.title,
+      link: `${LINK}/${post.slug}`,
+      description: post.summary || '',
+      date: new Date(post?.publishDay || post?.publishDate || Date.now())
+    })
+  }
+
+  return {
+    xml: feed.rss2(),
+    atomXml: feed.atom1(),
+    json: feed.json1()
+  }
+}
+
+export default async function handler(req, res) {
+  if (req.method !== 'GET') {
+    return res.status(405).json({ message: 'Method Not Allowed' })
+  }
+
+  try {
+    if (!isCacheFresh()) {
+      const content = await generateRssContent()
+      if (content) {
+        rssCache = {
+          ...content,
+          updatedAt: Date.now()
+        }
+      }
+    }
+
+    if (!rssCache.xml) {
+      return res.status(503).json({ message: 'RSS feed not available' })
+    }
+
+    const format = req.query.format || 'rss'
+
+    res.setHeader('Cache-Control', 'public, s-maxage=600, stale-while-revalidate=3600')
+
+    if (format === 'atom') {
+      res.setHeader('Content-Type', 'application/atom+xml; charset=utf-8')
+      return res.status(200).send(rssCache.atomXml)
+    }
+
+    if (format === 'json') {
+      res.setHeader('Content-Type', 'application/json; charset=utf-8')
+      return res.status(200).send(rssCache.json)
+    }
+
+    // Default: RSS 2.0
+    res.setHeader('Content-Type', 'application/rss+xml; charset=utf-8')
+    return res.status(200).send(rssCache.xml)
+  } catch (error) {
+    console.error('[RSS API] Error generating feed:', error)
+    return res.status(500).json({ message: 'Failed to generate RSS feed' })
+  }
+}


### PR DESCRIPTION
## Summary

- **Fix #3983**: RSS feed returns 404 on Vercel deployments
- **Fix #3931**: RSS feed returns 502 due to Notion API timeout during build
- **Fix #3872**: RSS broken after upgrade to 4.9.3.1

## Root Cause

The existing RSS generation (`lib/utils/rss.js`) only runs during `yarn build` and writes to `public/rss/feed.xml`. On Vercel's serverless environment, if the Notion API times out or rate-limits during the build phase, the static file is never created. All subsequent requests to `/rss/feed.xml` return 404.

## Solution

### New: `pages/api/rss.js`
An API route that generates RSS on-demand with in-memory caching (10-minute TTL). It:
- Fetches site data via `fetchGlobalAllData()` (same pipeline as homepage)
- Filters to published posts, sorted by date (top 20)
- Generates RSS 2.0, Atom, and JSON Feed using the `feed` library
- Caches results in-memory to avoid repeated Notion API calls
- Sets `Cache-Control: s-maxage=600, stale-while-revalidate=3600`

### Modified: `next.config.js`
Added rewrite rules so `/rss/feed.xml`, `/rss/atom.xml`, and `/rss/feed.json` route to the API when static files don't exist. Static files still take precedence when available (fast, zero API cost).

## Design Decisions

- **Why in-memory cache?** Simple, no external dependencies. Survives across ISR revalidations within the same serverless instance. 10-minute TTL is a good balance between freshness and cost.
- **Why not Redis?** The existing RSS code already has a Redis path via `lib/cache/`, but adding Redis dependency to the API route would increase complexity. In-memory is sufficient for RSS.
- **Why 20 posts?** Matches the default RSS feed size. Can be made configurable later.

## Test plan

- [ ] `curl /rss/feed.xml` — returns valid RSS XML
- [ ] `curl /rss/atom.xml` — returns valid Atom XML
- [ ] `curl /rss/feed.json` — returns valid JSON Feed
- [ ] Delete `public/rss/feed.xml` and verify the API fallback works
- [ ] Verify `Cache-Control` headers are present in the response

🤖 Generated with [Claude Code](https://claude.com/claude-code)