### PR TITLE
fix(markdown): normalize details summary rendering

### DIFF
--- a/components/PrismMac.js
+++ b/components/PrismMac.js
@@ -47,7 +47,7 @@ const PrismMac = () => {
     const hasCodeBlocks = Boolean(article.querySelector('pre.notion-code'))
     if (!hasCodeBlocks) return
 
-    if (codeMacBar) {
+    if (codeMacBar || codeCollapse) {
       loadExternalResource('/css/prism-mac-style.css', 'css')
     }
     // 加载prism样式
@@ -70,7 +70,7 @@ const PrismMac = () => {
             window.Prism.plugins.autoloader.languages_path = prismjsPath
           }
 
-          const dispose = renderPrismMac(codeLineNumbers)
+          const dispose = renderPrismMac(codeLineNumbers, codeMacBar)
           stopLineNumbers = typeof dispose === 'function' ? dispose : () => {}
           renderMermaid(mermaidCDN)
           renderCollapseCode(codeCollapse, codeCollapseExpandDefault)
@@ -287,7 +287,7 @@ const renderMermaid = mermaidCDN => {
     })
 }
 
-function renderPrismMac(codeLineNumbers) {
+function renderPrismMac(codeLineNumbers, codeMacBar) {
   const container = getNotionArticle()
 
   // Add line numbers
@@ -316,7 +316,7 @@ function renderPrismMac(codeLineNumbers) {
 
   const codeToolBars = container?.getElementsByClassName('code-toolbar')
   // Add pre-mac element for Mac Style UI
-  if (codeToolBars) {
+  if (codeMacBar && codeToolBars) {
     Array.from(codeToolBars).forEach(item => {
       try {
         const existPreMac = item.getElementsByClassName('pre-mac')

--- a/styles/notion.css
+++ b/styles/notion.css
@@ -407,6 +407,32 @@ summary > .notion-h {
   display: inline;
 }
 
+.notion details {
+  width: 100%;
+  padding: 3px 2px;
+}
+
+.notion details > summary {
+  cursor: pointer;
+  outline: none;
+  font-size: 1em;
+  line-height: 1.7;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.notion details > summary::marker {
+  font-size: 0.8em;
+}
+
+.notion details > summary::-webkit-details-marker {
+  font-size: 0.8em;
+}
+
+.notion details > :not(summary) {
+  margin-left: 1.1em;
+}
+
 .notion-h {
   position: relative;
   font-weight: 600;


### PR DESCRIPTION
## Summary
- load code-collapse styles when CODE_COLLAPSE is enabled
- keep Mac code-window dots controlled by CODE_MAC_BAR
- add base styles for raw markdown details/summary blocks in Notion content

Fixes #4135

## Verification
- git diff --check -- components\\PrismMac.js styles\\notion.css
- eslint checked on components/PrismMac.js in the original worktree; existing react-hooks/exhaustive-deps warning remains