### PR TITLE
fix: avoid undefined dynamic layout loading

### DIFF
--- a/themes/theme.js
+++ b/themes/theme.js
@@ -44,7 +44,6 @@ const getLayoutLoading = (themeName, layoutName) => {
   if (themeName === 'magzine' && layoutName === 'LayoutIndex') {
     return MagzineLayoutLoading
   }
-  return undefined
 }
 
 const normalizeThemeName = themeValue => {
@@ -164,20 +163,21 @@ export const useLayoutByTheme = ({ layoutName, theme }) => {
     return layoutByThemeCache.get(cacheKey)
   }
 
-  const DynamicLayoutComponent = dynamic(
-    () =>
-      import(`@/themes/${themeQuery}`).then(componentsSource => {
-        const Selected =
-          componentsSource[layoutName] || componentsSource.LayoutSlug
-        if (!Selected) {
-          throw new Error(
-            `[theme] Layout "${layoutName}" missing in themes/${themeQuery}`
-          )
-        }
-        return Selected
-      }),
-    { ssr: true, loading: getLayoutLoading(themeQuery, layoutName) }
-  )
+  const loadLayout = () =>
+    import(`@/themes/${themeQuery}`).then(componentsSource => {
+      const Selected =
+        componentsSource[layoutName] || componentsSource.LayoutSlug
+      if (!Selected) {
+        throw new Error(
+          `[theme] Layout "${layoutName}" missing in themes/${themeQuery}`
+        )
+      }
+      return Selected
+    })
+  const layoutLoading = getLayoutLoading(themeQuery, layoutName)
+  const DynamicLayoutComponent = layoutLoading
+    ? dynamic(loadLayout, { ssr: true, loading: layoutLoading })
+    : dynamic(loadLayout, { ssr: true })
   layoutByThemeCache.set(cacheKey, DynamicLayoutComponent)
   scheduleFixThemeDOM(themeQuery === BLOG.THEME ? 80 : 240)
   return DynamicLayoutComponent


### PR DESCRIPTION
## Summary
- Fixes #4158.
- Avoids passing `loading: undefined` into `next/dynamic` for theme layouts.
- Keeps the magzine `LayoutIndex` skeleton loading component while using plain `{ ssr: true }` for other layouts.

## Verification
- `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_test_... yarn.cmd build`