### PR TITLE
fix: include page links in content URL mapping

### DIFF
--- a/components/ExternalPlugins.js
+++ b/components/ExternalPlugins.js
@@ -174,7 +174,10 @@ const ExternalPlugin = props => {
 
     setTimeout(() => {
       // 映射url
-      convertInnerUrl({ allPages: props?.allNavPages, lang: lang })
+      convertInnerUrl({
+        allPages: props?.allLinkPages || props?.allNavPages,
+        lang: lang
+      })
     }, 500)
   }, [router])
 

--- a/lib/db/SiteDataApi.js
+++ b/lib/db/SiteDataApi.js
@@ -171,6 +171,7 @@ const EmptyData = pageId => ({
     }
   ],
   allNavPages: [],
+  allLinkPages: [],
   collection: [],
   collectionQuery: {},
   collectionId: null,
@@ -455,6 +456,7 @@ async function convertNotionToSiteData(
     latestPostCount: siteConfig('LATEST_POST_COUNT', 6, NOTION_CONFIG)
   })
   const allNavPages = getNavPages({ allPages })
+  const allLinkPages = getLinkPages({ allPages })
 
   // ── 社区数据：Member / Event ──
   const allMembers = getAllMembers({ allPages })
@@ -473,6 +475,7 @@ async function convertNotionToSiteData(
     allMembers,
     allEvents,
     allNavPages,
+    allLinkPages,
     collection,
     collectionQuery,
     collectionId,
@@ -514,11 +517,13 @@ function handleDataBeforeReturn(db) {
   db.categoryOptions = cleanIds(db?.categoryOptions)
   db.customMenu = cleanIds(db?.customMenu)
   db.allNavPages = shortenIds(db?.allNavPages)
+  db.allLinkPages = shortenIds(db?.allLinkPages)
 
   // 先清理 tagOptions，再用清理后的标签集合过滤页面的 tagItems，
   // 避免页面保留对「已被 cleanTagOptions 删除的标签」的引用，导致点击 404
   db.tagOptions = cleanTagOptions(db?.tagOptions)
   db.allNavPages = cleanPages(db?.allNavPages, db.tagOptions)
+  db.allLinkPages = cleanPages(db?.allLinkPages, db.tagOptions)
   db.allPages = cleanPages(db.allPages, db.tagOptions)
   db.allMembers = cleanPages(db.allMembers, db.tagOptions)
   db.allEvents = cleanPages(db.allEvents, db.tagOptions)
@@ -831,6 +836,28 @@ export function getNavPages({ allPages }) {
     lastEditedDate: item.lastEditedDate,
     publishDate: item.publishDate,
     ext: item.ext || {}
+  }))
+}
+
+/**
+ * Notion content links can target both posts and standalone pages. Keep this
+ * list separate from allNavPages because themes use allNavPages as a post list.
+ */
+export function getLinkPages({ allPages }) {
+  const allLinkPages = (allPages || []).filter(
+    post =>
+      post &&
+      post?.slug &&
+      (post?.type === 'Post' || post?.type === 'Page') &&
+      post?.status === 'Published'
+  )
+  return allLinkPages.map(item => ({
+    id: item.id,
+    title: item.title || '',
+    type: item.type,
+    slug: item.slug,
+    href: item.href,
+    short_id: item.short_id
   }))
 }
 

--- a/lib/site/adapters/notion/notion.normalizer.ts
+++ b/lib/site/adapters/notion/notion.normalizer.ts
@@ -23,6 +23,7 @@ export function normalizeNotionSite(
     notice: null,
     allPages: [],
     allNavPages: [],
+    allLinkPages: [],
     latestPosts: [],
     categoryOptions: [],
     tagOptions: [],

--- a/lib/site/processors/empty.processor.ts
+++ b/lib/site/processors/empty.processor.ts
@@ -14,6 +14,7 @@ export function EmptyData(pageId?: string): SiteData {
     notice: null,
     allPages: [],
     allNavPages: [],
+    allLinkPages: [],
     latestPosts: [],
     categoryOptions: [],
     tagOptions: [],

--- a/lib/site/processors/page.processor.ts
+++ b/lib/site/processors/page.processor.ts
@@ -9,6 +9,7 @@ export function handleDataBeforeReturn(db: SiteData): SiteData {
   db.customMenu = cleanIds(db.customMenu)
 
   db.allNavPages = cleanPages(db.allNavPages, db.tagOptions)
+  db.allLinkPages = cleanPages(db.allLinkPages, db.tagOptions)
   db.allPages = cleanPages(db.allPages, db.tagOptions)
   db.latestPosts = cleanPages(db.latestPosts, db.tagOptions)
 

--- a/lib/site/site.types.ts
+++ b/lib/site/site.types.ts
@@ -49,7 +49,9 @@ export interface BasePage {
 
 export interface NavPage {
   id?: string
+  short_id?: string
   title: string
+  type?: PageType
   slug: string
   summary?: string
   category?: string
@@ -79,6 +81,7 @@ export interface SiteData {
 
   allPages: BasePage[]
   allNavPages: NavPage[]
+  allLinkPages: NavPage[]
   latestPosts: BasePage[]
 
   categoryOptions: Array<Record<string, unknown>>


### PR DESCRIPTION
Fixes #4142.

## Root cause

`type=notice` announcements are rendered by `NotionPage`, so Notion internal links inside the announcement go through the global `convertInnerUrl` pass.

That pass currently receives `allNavPages`, but `allNavPages` is intentionally generated from published `Post` records only. When an announcement links to a standalone `type=Page` record, the URL mapper cannot find the target page, so the link remains as a raw Notion page id path and can resolve to 404.

External links work because they do not need this mapping. Menu links work because they are resolved through the menu configuration path instead of the announcement content mapper.

## Fix

- Add `allLinkPages`, a lightweight link-resolution list containing published `Post` and `Page` records.
- Use `allLinkPages` for global Notion content URL conversion.
- Keep `allNavPages` as post-only, because multiple themes use it as article navigation, random posts, and recommendation input.
- Add empty/default/type pipeline support for the new field.

## Verification

- `yarn type-check`
- `yarn build`

`yarn test --runInBand` is currently blocked in this workspace by the existing native `canvas` binding issue: `Cannot find module '../build/Release/canvas.node'`.