### PR TITLE
修复无标题引用容器子块不渲染

### DIFF
--- a/__tests__/lib/db/notion/getPostBlocks.test.js
+++ b/__tests__/lib/db/notion/getPostBlocks.test.js
@@ -83,4 +83,33 @@ describe('formatNotionBlock', () => {
 
     expect(formatted['hosted-video'].value.type).toBe('video')
   })
+
+  it('keeps child blocks renderable for quote containers without title properties', () => {
+    const formatted = formatNotionBlock({
+      quote_container: {
+        value: {
+          id: 'quote_container',
+          type: 'quote',
+          content: ['quote_child']
+        }
+      },
+      quote_child: {
+        value: {
+          id: 'quote_child',
+          type: 'text',
+          parent_id: 'quote_container',
+          properties: {
+            title: [['Nested quote text']]
+          }
+        }
+      }
+    })
+
+    expect(formatted.quote_container.value).toMatchObject({
+      type: 'quote',
+      content: ['quote_child'],
+      properties: { title: [] }
+    })
+    expect(formatted.quote_child.value.parent_id).toBe('quote_container')
+  })
 })

--- a/lib/db/notion/getPostBlocks.js
+++ b/lib/db/notion/getPostBlocks.js
@@ -118,6 +118,14 @@ export function formatNotionBlock(block) {
     sanitizeBlockUrls(b?.value)
     normalizeExternalMediaBlock(b?.value)
 
+    if (
+      b?.value?.type === 'quote' &&
+      !b.value.properties &&
+      b.value.content?.length > 0
+    ) {
+      b.value.properties = { title: [] }
+    }
+
     if (b?.value?.type === 'sync_block' && b?.value?.children) {
       const childBlocks = b.value.children
       const childBlockIds = []


### PR DESCRIPTION
Fixes #4140

## 已知问题

1. Notion 可能返回只有 `content`、但没有 `properties` 的 `quote` 容器块
   - `react-notion-x` 在 quote 渲染分支中遇到缺失 `properties` 会直接返回 `null`
   - 这会导致 quote 下挂的 text/header/list/table 等子块一起无法显示

## 解决方案

1. 在 `formatNotionBlock` 中补充兼容处理
   - 当 quote 块存在子块但缺少 `properties` 时，补上空的 `properties.title`
   - 不改动 `content`、`parent_id` 或子块顺序，保留原有父子层级
   - 普通有标题 quote 不受影响

## 改动收益

1. 无标题引用容器可以继续交给现有渲染器渲染
   - 子块不会因为父 quote 缺少 `properties` 被整段丢弃
   - 保持对当前 `react-notion-x` 版本的最小兼容修复

## 具体改动

1. `lib/db/notion/getPostBlocks.js`
   - 为带子块但缺少 `properties` 的 quote 容器补空 title

2. `__tests__/lib/db/notion/getPostBlocks.test.js`
   - 增加无标题 quote 容器保留子块层级并可渲染的回归测试

## 测试确认

- [x] `yarn test __tests__/lib/db/notion/getPostBlocks.test.js --runInBand`
- [x] `yarn test __tests__/lib/notion-data-format.test.js --runInBand`
- [x] `yarn type-check`
- [x] `yarn lint --file lib/db/notion/getPostBlocks.js --file __tests__/lib/db/notion/getPostBlocks.test.js`
- [ ] 生产环境构建测试通过

## 用户文档（`docs/user-guide/`）

- [x] 不适用（无文档改动）