### PR TITLE
refactor: add content type registry

### DIFF
--- a/__tests__/lib/contentTypes.test.js
+++ b/__tests__/lib/contentTypes.test.js
@@ -1,0 +1,49 @@
+import {
+  CONTENT_STATUS,
+  CONTENT_TYPES,
+  hasVisibleStatus,
+  isCommunityContentType,
+  isKnownContentType,
+  isLinkableContentType,
+  isNavContentType,
+  isPublishedContent
+} from '@/lib/site/contentTypes'
+
+describe('contentTypes registry', () => {
+  test('recognizes core and community content types', () => {
+    expect(isKnownContentType(CONTENT_TYPES.POST)).toBe(true)
+    expect(isKnownContentType(CONTENT_TYPES.MEMBER)).toBe(true)
+    expect(isKnownContentType(CONTENT_TYPES.EVENT)).toBe(true)
+    expect(isKnownContentType('Unknown')).toBe(false)
+  })
+
+  test('separates community, nav, and linkable types', () => {
+    expect(isCommunityContentType(CONTENT_TYPES.MEMBER)).toBe(true)
+    expect(isCommunityContentType(CONTENT_TYPES.POST)).toBe(false)
+
+    expect(isNavContentType(CONTENT_TYPES.MENU)).toBe(true)
+    expect(isNavContentType(CONTENT_TYPES.SUB_MENU)).toBe(true)
+    expect(isNavContentType(CONTENT_TYPES.PAGE)).toBe(false)
+
+    expect(isLinkableContentType(CONTENT_TYPES.POST)).toBe(true)
+    expect(isLinkableContentType(CONTENT_TYPES.PAGE)).toBe(true)
+    expect(isLinkableContentType(CONTENT_TYPES.EVENT)).toBe(false)
+  })
+
+  test('handles public and invisible statuses', () => {
+    expect(hasVisibleStatus(CONTENT_STATUS.PUBLISHED)).toBe(true)
+    expect(hasVisibleStatus(CONTENT_STATUS.INVISIBLE)).toBe(true)
+    expect(hasVisibleStatus('Draft')).toBe(false)
+  })
+
+  test('matches published content with optional type filter', () => {
+    const post = { type: CONTENT_TYPES.POST, status: CONTENT_STATUS.PUBLISHED }
+    const hiddenPost = { type: CONTENT_TYPES.POST, status: CONTENT_STATUS.INVISIBLE }
+
+    expect(isPublishedContent(post)).toBe(true)
+    expect(isPublishedContent(post, CONTENT_TYPES.POST)).toBe(true)
+    expect(isPublishedContent(post, CONTENT_TYPES.PAGE)).toBe(false)
+    expect(isPublishedContent(hiddenPost)).toBe(false)
+    expect(isPublishedContent(null)).toBe(false)
+  })
+})

--- a/lib/db/SiteDataApi.js
+++ b/lib/db/SiteDataApi.js
@@ -28,6 +28,14 @@ import { processPostData } from '../utils/post'
 import { adapterNotionBlockMap } from '../utils/notion.util'
 import { sortPinnedPostsByLatestUpdate } from '@/lib/utils/pinnedPosts'
 import { fetchMembersFromOfficialAPI } from './notion/memberDataSource'
+import {
+  CONTENT_STATUS,
+  CONTENT_TYPES,
+  hasVisibleStatus,
+  isLinkableContentType,
+  isNavContentType,
+  isPublishedContent
+} from '@/lib/site/contentTypes'
 // import pLimit from 'p-limit'
 
 export { getAllTags } from './notion/getAllTags'
@@ -569,7 +577,7 @@ async function convertNotionToSiteData(
   if (officialMembers.length > 0) {
     const existingMembers = new Set(
       collectionData
-        .filter(item => item?.type === 'Member')
+        .filter(item => item?.type === CONTENT_TYPES.MEMBER)
         .flatMap(item => [item.id, item.slug].filter(Boolean))
     )
     officialMembers.forEach(member => {
@@ -587,8 +595,8 @@ async function convertNotionToSiteData(
   // const stepStart10 = Date.now()
   let postCount = 0
   let allPages = collectionData.filter(post => {
-    if (post?.type === 'Post' && post.status === 'Published') postCount++
-    return post?.slug && (post?.status === 'Invisible' || post?.status === 'Published')
+    if (isPublishedContent(post, CONTENT_TYPES.POST)) postCount++
+    return post?.slug && hasVisibleStatus(post?.status)
   })
   const sortBy = siteConfig('POSTS_SORT_BY', null, NOTION_CONFIG)
   if (sortBy === 'date') {
@@ -606,11 +614,17 @@ async function convertNotionToSiteData(
 
   // ── 其他数据生成 ──
   const stepStart11 = Date.now()
-  const notice = await getNotice(collectionData.find(post => post?.type === 'Notice' && post.status === 'Published'))
+  const notice = await getNotice(
+    collectionData.find(post => isPublishedContent(post, CONTENT_TYPES.NOTICE))
+  )
   const categoryOptions = getAllCategories({ allPages, categoryOptions: getCategoryOptions(schema) })
   const tagSchemaOptions = getTagOptions(schema)
   const tagOptions = getAllTags({ allPages, tagOptions: tagSchemaOptions ?? [], NOTION_CONFIG }) ?? null
-  const customNav = getCustomNav({ allPages: collectionData.filter(post => post?.type === 'Page' && post.status === 'Published') })
+  const customNav = getCustomNav({
+    allPages: collectionData.filter(post =>
+      isPublishedContent(post, CONTENT_TYPES.PAGE)
+    )
+  })
   const customMenu = getCustomMenu({ collectionData, NOTION_CONFIG })
   const latestPosts = getLatestPosts({
     allPages,
@@ -700,10 +714,10 @@ function handleDataBeforeReturn(db) {
   )
   if (POST_SCHEDULE_PUBLISH) {
     db.allPages?.forEach(p => {
-      if (p.type === 'Event' || p.type === 'Member') return
+      if (p.type === CONTENT_TYPES.EVENT || p.type === CONTENT_TYPES.MEMBER) return
       if (!isInRange(p.title, p.date)) {
         console.log('[定时发布] 隐藏-->', p.title, p.date)
-        p.status = 'Invisible'
+        p.status = CONTENT_STATUS.INVISIBLE
       }
     })
   }
@@ -795,7 +809,7 @@ function cleanBlock(item) {
  */
 function getLatestPosts({ allPages, from, latestPostCount }) {
   const allPosts = allPages?.filter(
-    page => page.type === 'Post' && page.status === 'Published'
+    page => isPublishedContent(page, CONTENT_TYPES.POST)
   )
   return [...(allPosts ?? [])]
     .sort((a, b) => {
@@ -825,17 +839,15 @@ function getCustomNav({ allPages }) {
 
 function getCustomMenu({ collectionData, NOTION_CONFIG }) {
   const menuPages = collectionData.filter(
-    post =>
-      post.status === 'Published' &&
-      (post?.type === 'Menu' || post?.type === 'SubMenu')
+    post => isPublishedContent(post) && isNavContentType(post?.type)
   )
   const menus = []
   if (menuPages && menuPages.length > 0) {
     menuPages.forEach(e => {
       e.show = true
-      if (e.type === 'Menu') {
+      if (e.type === CONTENT_TYPES.MENU) {
         menus.push(e)
-      } else if (e.type === 'SubMenu') {
+      } else if (e.type === CONTENT_TYPES.SUB_MENU) {
         const parentMenu = menus[menus.length - 1]
         if (parentMenu) {
           if (parentMenu.subMenus) {
@@ -984,8 +996,7 @@ export function getNavPages({ allPages }) {
     post =>
       post &&
       post?.slug &&
-      post?.type === 'Post' &&
-      post?.status === 'Published'
+      isPublishedContent(post, CONTENT_TYPES.POST)
   )
   return allNavPages.map(item => ({
     id: item.id,
@@ -1012,8 +1023,8 @@ export function getLinkPages({ allPages }) {
     post =>
       post &&
       post?.slug &&
-      (post?.type === 'Post' || post?.type === 'Page') &&
-      post?.status === 'Published'
+      isLinkableContentType(post?.type) &&
+      isPublishedContent(post)
   )
   return allLinkPages.map(item => ({
     id: item.id,
@@ -1033,15 +1044,15 @@ export function getAllMembers({ allPages }) {
   if (!Array.isArray(allPages)) return []
 
   const published = allPages.filter(
-    page => page?.type === 'Member' && page?.status === 'Published'
+    page => isPublishedContent(page, CONTENT_TYPES.MEMBER)
   )
 
   // 精简成员数据，只保留前端需要的字段，减少 pageProps 体积
   const slim = published.map(m => ({
     id: m.id || '',
     title: m.title || '',
-    type: m.type || 'Member',
-    status: m.status || 'Published',
+    type: m.type || CONTENT_TYPES.MEMBER,
+    status: m.status || CONTENT_STATUS.PUBLISHED,
     slug: m.slug || '',
     summary: m.summary || '',
     avatar: m.avatar || '',
@@ -1081,6 +1092,6 @@ export function getAllMembers({ allPages }) {
 export function getAllEvents({ allPages }) {
   if (!Array.isArray(allPages)) return []
   return allPages
-    .filter(page => page?.type === 'Event' && page?.status === 'Published')
+    .filter(page => isPublishedContent(page, CONTENT_TYPES.EVENT))
     .sort((a, b) => (b?.publishDate ?? 0) - (a?.publishDate ?? 0))
 }

--- a/lib/db/notion/getAllCategories.js
+++ b/lib/db/notion/getAllCategories.js
@@ -1,4 +1,5 @@
 import { isIterable } from '../../utils'
+import { CONTENT_TYPES, isPublishedContent } from '@/lib/site/contentTypes'
 
 /**
  * 获取所有文章的标签
@@ -19,7 +20,7 @@ export function getAllCategories({
   sliceCount = 0
 }) {
   const allPosts = allPages?.filter(
-    page => page.type === 'Post' && page.status === 'Published'
+    page => isPublishedContent(page, CONTENT_TYPES.POST)
   )
   if (!allPosts || !categoryOptions) {
     return []

--- a/lib/db/notion/getAllTags.js
+++ b/lib/db/notion/getAllTags.js
@@ -1,5 +1,10 @@
 import { siteConfig } from '../../config'
 import { isIterable } from '../../utils'
+import {
+  CONTENT_STATUS,
+  CONTENT_TYPES,
+  isContentType
+} from '@/lib/site/contentTypes'
 
 /**
  * 获取所有文章的标签
@@ -17,8 +22,9 @@ export function getAllTags({
   // 保留Invisible的Page中的Tags，最后再过滤掉
   const allPosts = allPages?.filter(
     page =>
-      page.type === 'Post' &&
-      (page.status === 'Published' || page.status === 'Invisible')
+      isContentType(page.type, CONTENT_TYPES.POST) &&
+      (page.status === CONTENT_STATUS.PUBLISHED ||
+        page.status === CONTENT_STATUS.INVISIBLE)
   )
 
   if (!allPosts || !tagOptions) {
@@ -32,8 +38,8 @@ export function getAllTags({
       // 如果标签已经存在
       if (AllTagInfos[tag]) {
         if (
-          AllTagInfos[tag].source === 'Invisible' &&
-          post.status === 'Published'
+          AllTagInfos[tag].source === CONTENT_STATUS.INVISIBLE &&
+          post.status === CONTENT_STATUS.PUBLISHED
         ) {
           AllTagInfos[tag].source = post.status
         }

--- a/lib/db/notion/getPageProperties.js
+++ b/lib/db/notion/getPageProperties.js
@@ -12,6 +12,7 @@ import {
 } from '../../utils/password'
 import { mapImgUrl } from './mapImage'
 import notionAPI from '@/lib/db/notion/getNotionAPI'
+import { CONTENT_TYPES, isNavContentType } from '@/lib/site/contentTypes'
 
 /**
  * 获取页面元素成员属性
@@ -150,13 +151,13 @@ function convertToJSON(str) {
  */
 function mapProperties(properties) {
   const typeMap = {
-    [BLOG.NOTION_PROPERTY_NAME.type_post]: 'Post',
-    [BLOG.NOTION_PROPERTY_NAME.type_page]: 'Page',
-    [BLOG.NOTION_PROPERTY_NAME.type_notice]: 'Notice',
-    [BLOG.NOTION_PROPERTY_NAME.type_menu]: 'Menu',
-    [BLOG.NOTION_PROPERTY_NAME.type_sub_menu]: 'SubMenu',
-    [BLOG.NOTION_PROPERTY_NAME.type_member]: 'Member',
-    [BLOG.NOTION_PROPERTY_NAME.type_event]: 'Event'
+    [BLOG.NOTION_PROPERTY_NAME.type_post]: CONTENT_TYPES.POST,
+    [BLOG.NOTION_PROPERTY_NAME.type_page]: CONTENT_TYPES.PAGE,
+    [BLOG.NOTION_PROPERTY_NAME.type_notice]: CONTENT_TYPES.NOTICE,
+    [BLOG.NOTION_PROPERTY_NAME.type_menu]: CONTENT_TYPES.MENU,
+    [BLOG.NOTION_PROPERTY_NAME.type_sub_menu]: CONTENT_TYPES.SUB_MENU,
+    [BLOG.NOTION_PROPERTY_NAME.type_member]: CONTENT_TYPES.MEMBER,
+    [BLOG.NOTION_PROPERTY_NAME.type_event]: CONTENT_TYPES.EVENT
   }
 
   const statusMap = {
@@ -181,12 +182,12 @@ export function adjustPageProperties(properties, NOTION_CONFIG) {
   // 处理URL
   // 1.按照用户配置的URL_PREFIX 转换一下slug
   // 2.为文章添加一个href字段，存储最终调整的路径
-  if (properties.type === 'Post') {
+  if (properties.type === CONTENT_TYPES.POST) {
     properties.slug = generateCustomizeSlug(properties, NOTION_CONFIG)
     properties.href = properties.slug ?? properties.id
-  } else if (properties.type === 'Page') {
+  } else if (properties.type === CONTENT_TYPES.PAGE) {
     properties.href = properties.slug ?? properties.id
-  } else if (properties.type === 'Menu' || properties.type === 'SubMenu') {
+  } else if (isNavContentType(properties.type)) {
     // 菜单路径为空、作为可展开菜单使用
     properties.href = properties.slug ?? '#'
     properties.name = properties.title ?? ''

--- a/lib/site/contentTypes.js
+++ b/lib/site/contentTypes.js
@@ -1,0 +1,84 @@
+export const CONTENT_TYPES = Object.freeze({
+  POST: 'Post',
+  PAGE: 'Page',
+  NOTICE: 'Notice',
+  MENU: 'Menu',
+  SUB_MENU: 'SubMenu',
+  MEMBER: 'Member',
+  EVENT: 'Event'
+})
+
+export const CORE_CONTENT_TYPES = Object.freeze([
+  CONTENT_TYPES.POST,
+  CONTENT_TYPES.PAGE,
+  CONTENT_TYPES.NOTICE,
+  CONTENT_TYPES.MENU,
+  CONTENT_TYPES.SUB_MENU
+])
+
+export const COMMUNITY_CONTENT_TYPES = Object.freeze([
+  CONTENT_TYPES.MEMBER,
+  CONTENT_TYPES.EVENT
+])
+
+export const NAV_CONTENT_TYPES = Object.freeze([
+  CONTENT_TYPES.MENU,
+  CONTENT_TYPES.SUB_MENU
+])
+
+export const LINKABLE_CONTENT_TYPES = Object.freeze([
+  CONTENT_TYPES.POST,
+  CONTENT_TYPES.PAGE
+])
+
+export const PUBLISHABLE_CONTENT_TYPES = Object.freeze([
+  CONTENT_TYPES.POST,
+  CONTENT_TYPES.PAGE,
+  CONTENT_TYPES.MEMBER,
+  CONTENT_TYPES.EVENT
+])
+
+export const CONTENT_STATUS = Object.freeze({
+  PUBLISHED: 'Published',
+  INVISIBLE: 'Invisible'
+})
+
+export function isContentType(type, expectedType) {
+  return type === expectedType
+}
+
+export function isKnownContentType(type) {
+  return [
+    ...CORE_CONTENT_TYPES,
+    ...COMMUNITY_CONTENT_TYPES
+  ].includes(type)
+}
+
+export function isCommunityContentType(type) {
+  return COMMUNITY_CONTENT_TYPES.includes(type)
+}
+
+export function isNavContentType(type) {
+  return NAV_CONTENT_TYPES.includes(type)
+}
+
+export function isLinkableContentType(type) {
+  return LINKABLE_CONTENT_TYPES.includes(type)
+}
+
+export function isPublished(status) {
+  return status === CONTENT_STATUS.PUBLISHED
+}
+
+export function isInvisible(status) {
+  return status === CONTENT_STATUS.INVISIBLE
+}
+
+export function hasVisibleStatus(status) {
+  return isPublished(status) || isInvisible(status)
+}
+
+export function isPublishedContent(page, type) {
+  if (!page || !isPublished(page.status)) return false
+  return type ? isContentType(page.type, type) : isKnownContentType(page.type)
+}

--- a/lib/site/site.types.ts
+++ b/lib/site/site.types.ts
@@ -13,7 +13,14 @@ export interface SiteInfo {
 }
 
 export type PageStatus = 'Published' | 'Invisible'
-export type PageType = 'Post' | 'Page' | 'Notice' | 'Menu' | 'SubMenu'
+export type PageType =
+  | 'Post'
+  | 'Page'
+  | 'Notice'
+  | 'Menu'
+  | 'SubMenu'
+  | 'Member'
+  | 'Event'
 
 export interface PageDate {
   start_date?: string


### PR DESCRIPTION
## Problem
NotionNext now recognizes more than the original blog/page content types: `Member` and `Event` are already part of the data contract, but core logic still repeats raw string checks such as `Post`, `Page`, `Menu`, `Member`, and `Event` across the data pipeline.

This makes the next community/organization-site additions harder to review because every new content type risks adding more scattered conditionals.

## What this PR adds
- Adds a small `lib/site/contentTypes.js` registry for canonical content type and status values.
- Adds helpers for known, community, navigation, linkable, visible, and published content checks.
- Updates core data-layer call sites in `SiteDataApi`, `getPageProperties`, taxonomy helpers, and site types to use the registry.
- Extends `PageType` to include the already-supported `Member` and `Event` types.
- Adds focused unit coverage for the registry helpers.

## What this PR does not include
- No new routes.
- No theme-specific UI.
- No IGNAI/community branding or local operations workflow.
- No `Record` type yet; this keeps the first registry step intentionally small.

## Why this is useful
This creates a clean foundation for community and organization-site content types while keeping the existing blog behavior unchanged. Later PRs can build on the registry instead of adding more scattered string checks.

## Verification
- `node --check lib/site/contentTypes.js`
- `node --check lib/db/SiteDataApi.js`
- `node --check lib/db/notion/getPageProperties.js`
- `node --check lib/db/notion/getAllTags.js`
- `node --check lib/db/notion/getAllCategories.js`
- `node --check __tests__/lib/contentTypes.test.js`
- `../../node_modules/.bin/jest __tests__/lib/contentTypes.test.js --runInBand`
- `../../node_modules/.bin/next lint --file lib/site/contentTypes.js --file lib/db/SiteDataApi.js --file lib/db/notion/getPageProperties.js --file lib/db/notion/getAllTags.js --file lib/db/notion/getAllCategories.js --file __tests__/lib/contentTypes.test.js`