### PR TITLE
chore(release): bump package.json to 4.10.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "notion-next",
-  "version": "4.10.0",
+  "version": "4.10.1",
   "packageManager": "yarn@1.22.22",
   "homepage": "https://github.com/tangly1024/NotionNext.git",
   "license": "MIT",


### PR DESCRIPTION
Publish patch version 4.10.1 after merging the embedded Notion collection view filter fix.