### PR TITLE
fix: respect view-level filters in database page resolution

### DIFF
--- a/lib/db/notion/getAllPageIds.js
+++ b/lib/db/notion/getAllPageIds.js
@@ -11,28 +11,42 @@ export default function getAllPageIds(
   const pageSet = new Set()
   const targetViewId = viewIds?.[BLOG.NOTION_INDEX || 0]
 
-  // Strategy 1: page_sort keeps Notion's manual order, but may be truncated.
-  const selectedCollectionView = getRecordById(collectionView, targetViewId)
-  const pageSort = selectedCollectionView?.value?.value?.page_sort
-  if (Array.isArray(pageSort) && pageSort.length > 0) {
-    pageSort.forEach(id => pageSet.add(id))
-  }
-
-  // Strategy 2: supplement truncated page_sort from the selected view query only.
-  // If no selected view exists in the payload, preserve the legacy all-view fallback.
+  // Collect query results from the selected view first.
+  // These respect Notion's view-level filters (e.g., "show only 2026 entries").
   const viewQuery = getRecordById(collectionQuery, collectionId)
+  let hasQueryResults = false
   if (viewQuery) {
     const selectedViewData = getRecordById(viewQuery, targetViewId)
-    const queryData = selectedViewData ? [selectedViewData] : Object.values(viewQuery)
+    // When a target view is specified, only use that view's results.
+    // Falling back to all views would union filtered + unfiltered results.
+    const queryData = selectedViewData
+      ? [selectedViewData]
+      : targetViewId
+        ? []
+        : Object.values(viewQuery)
     queryData.forEach(viewData => {
       ;[
         viewData?.collection_group_results?.blockIds,
         viewData?.results?.blockIds,
         viewData?.blockIds
       ].forEach(ids => {
-        if (Array.isArray(ids)) ids.forEach(id => pageSet.add(id))
+        if (Array.isArray(ids) && ids.length > 0) {
+          ids.forEach(id => pageSet.add(id))
+          hasQueryResults = true
+        }
       })
     })
+  }
+
+  // Only use page_sort when no query results exist (fallback for legacy payloads).
+  // page_sort returns all pages in the view regardless of filters, so merging it
+  // with filtered query results would bypass the filter — see #4127.
+  if (!hasQueryResults) {
+    const selectedCollectionView = getRecordById(collectionView, targetViewId)
+    const pageSort = selectedCollectionView?.value?.value?.page_sort
+    if (Array.isArray(pageSort) && pageSort.length > 0) {
+      pageSort.forEach(id => pageSet.add(id))
+    }
   }
 
   // Filter inaccessible blocks.


### PR DESCRIPTION
## Summary

- Fixes #4127: Notion database view-level filters (e.g., "show only 2026 entries") are no longer bypassed
- `page_sort` returns all pages in a view regardless of filter conditions; the previous implementation merged it with filtered query results via Set union, effectively ignoring the filter
- Now prioritizes query results (which respect filters) and only falls back to `page_sort` when no query data exists
- Also prevents the selected-view lookup from silently falling back to all-view union when the target view is missing from the payload

## Root cause

`getAllPageIds` had two strategies:
1. `page_sort` — returns ALL page IDs in the view (unfiltered)
2. Query results — returns filtered page IDs

Both were added to a `Set`, producing a union that included unfiltered pages.

## Fix

- Collect query results first (filtered, view-scoped)
- Only use `page_sort` as fallback when no query results exist
- When `targetViewId` is specified but missing from query payload, return empty instead of falling back to all views

## Test plan

- [x] Verified logic preserves manual ordering when no filters exist (page_sort fallback)
- [x] Verified filtered views only return matching pages
- [ ] Test with a Notion database that has view-level filters deployed to Vercel