### PR TITLE
fix: render quote blocks without properties.title

### DIFF
--- a/components/NotionPage.js
+++ b/components/NotionPage.js
@@ -124,6 +124,7 @@ const NotionPage = ({ post, className }) => {
           Link: NotionLink,
           Modal,
           Pdf,
+          Quote: NotionQuote,
           Tweet
         }}
       />
@@ -296,6 +297,40 @@ const Modal = dynamic(
 
 const Tweet = ({ id }) => {
   return <TweetEmbed tweetId={id} />
+}
+
+// Custom Quote override: react-notion-x drops quotes without properties.title
+// (returns null from early guard). This renders them correctly — fixes #4140.
+const NotionQuote = ({ block, children }) => {
+  const title = block?.properties?.title
+  return (
+    <blockquote className='notion-quote'>
+      {title && <NotionText value={title} />}
+      {children}
+    </blockquote>
+  )
+}
+
+// Minimal inline text renderer for Notion rich-text arrays.
+// Each segment is [plainText, [[formatType, optionalValue], ...]].
+const NotionText = ({ value }) => {
+  if (!Array.isArray(value)) return null
+  return value.map((segment, i) => {
+    if (!Array.isArray(segment) || !segment[0]) return null
+    const [text, formats] = segment
+    let element = <>{text}</>
+    if (Array.isArray(formats)) {
+      for (const fmt of formats) {
+        const type = Array.isArray(fmt) ? fmt[0] : fmt
+        if (type === 'b') element = <strong>{element}</strong>
+        else if (type === 'i') element = <em>{element}</em>
+        else if (type === 's') element = <s>{element}</s>
+        else if (type === 'c') element = <code>{element}</code>
+        else if (type === 'a') element = <a href={Array.isArray(fmt) ? fmt[1] : '#'}>{element}</a>
+      }
+    }
+    return <span key={i}>{element}</span>
+  })
 }
 
 export default NotionPage


### PR DESCRIPTION
## Summary

- Fixes #4140: Large quote blocks that lack `properties.title` no longer disappear from the rendered page
- react-notion-x has an early-return guard (`if (!block.properties) return null`) that drops these blocks entirely
- Adds a custom Quote component override that renders the `<blockquote>` regardless of whether `title` exists
- Includes a minimal inline text renderer for Notion rich-text formatting (bold, italic, strikethrough, code, links)

## Root cause

The upstream `react-notion-x` Quote renderer at line ~3123 returns `null` when `block.properties` is falsy. When a user pastes a large block of text into a Notion quote, the API may return it without the `properties.title` field, causing the entire block (and its children) to vanish.

## Fix

- Custom `NotionQuote` component in `NotionPage.js` added to the `components` prop
- Renders `<blockquote className='notion-quote'>` to match existing CSS
- `NotionText` helper handles inline formatting segments: `b`→`<strong>`, `i`→`<em>`, `s`→`<s>`, `c`→`<code>`, `a`→`<a>`

## Test plan

- [x] Quote with title: renders title + children
- [x] Quote without title: renders children only (previously invisible)
- [ ] Verify on a page with large multi-block quotes in heo theme