### PR TITLE
fix: handle sync_block with content ID array

### DIFF
--- a/lib/db/notion/getPostBlocks.js
+++ b/lib/db/notion/getPostBlocks.js
@@ -118,17 +118,40 @@ export function formatNotionBlock(block) {
     sanitizeBlockUrls(b?.value)
     normalizeExternalMediaBlock(b?.value)
 
-    if (b?.value?.type === 'sync_block' && b?.value?.children) {
-      const childBlocks = b.value.children
+    if (b?.value?.type === 'sync_block') {
       const childBlockIds = []
-      delete clonedBlock[blockId]
-      childBlocks.forEach((childBlock, index) => {
-        const newBlockId = `${blockId}_child_${index}`
-        clonedBlock[newBlockId] = childBlock
-        childBlockIds.push(newBlockId)
-      })
-      blocksToProcess.splice(i, 1, ...childBlockIds)
-      continue
+
+      // Case 1: inline children (original format)
+      if (Array.isArray(b.value.children) && b.value.children.length > 0) {
+        delete clonedBlock[blockId]
+        b.value.children.forEach((childBlock, index) => {
+          const newBlockId = `${blockId}_child_${index}`
+          clonedBlock[newBlockId] = childBlock
+          childBlockIds.push(newBlockId)
+        })
+        blocksToProcess.splice(i, 1, ...childBlockIds)
+        continue
+      }
+
+      // Case 2: content array with child block IDs (some Notion API responses)
+      if (Array.isArray(b.value.content) && b.value.content.length > 0) {
+        delete clonedBlock[blockId]
+        b.value.content.forEach((childId, index) => {
+          const childBlock = clonedBlock[childId]
+          if (childBlock) {
+            const newBlockId = `${blockId}_child_${index}`
+            clonedBlock[newBlockId] = childBlock
+            childBlockIds.push(newBlockId)
+            delete clonedBlock[childId]
+          }
+        })
+        if (childBlockIds.length > 0) {
+          blocksToProcess.splice(i, 1, ...childBlockIds)
+          continue
+        }
+      }
+
+      // Case 3: no children or content — pass through to react-notion-x
     }
 
     if (b?.value?.type === 'code') {


### PR DESCRIPTION
## Summary

- Fixes #4172: Notion `sync_block` blocks now render correctly when the API returns child references via `content` (ID array) instead of inline `children` objects
- The previous flattening logic only handled `b.value.children`; blocks with `b.value.content` passed through to react-notion-x as unsupported types and rendered nothing

## Root cause

`getPostBlocks.js` formatNotionBlock loop had a single sync_block handler:
```js
if (b?.value?.type === 'sync_block' && b?.value?.children) { ... }
```

Notion API responses can store synced block children in two formats:
- `children`: inline block objects (handled)
- `content`: array of child block IDs referencing blocks already in the block map (not handled)

When `content` was used, the condition `b?.value?.children` was falsy, so the block was passed to react-notion-x which hit its `default` case and rendered an empty `<div>`.

## Fix

Expands the sync_block handler into three cases:
1. **Inline children** (original): splice children into the processing queue
2. **Content IDs**: look up child blocks from the block map by ID, splice them in, clean up originals
3. **Neither**: pass through to react-notion-x (graceful degradation)

## Test plan

- [x] sync_block with inline children: renders correctly (existing behavior preserved)
- [x] sync_block with content IDs: children now render
- [x] sync_block with neither: passes through without error
- [ ] Verify on the #4172 reporter's page (nav theme, "高考倒计时" section)