### PR TITLE
fix: normalize Heo infocard greetings

### DIFF
--- a/__tests__/themes/heo/InfoCard.test.js
+++ b/__tests__/themes/heo/InfoCard.test.js
@@ -1,0 +1,23 @@
+import { normalizeInfoCardGreetings } from '@/themes/heo/components/InfoCard'
+
+describe('heo InfoCard greetings', () => {
+  it('keeps configured greeting arrays intact', () => {
+    expect(normalizeInfoCardGreetings(['12', '23', '34'])).toEqual([
+      '12',
+      '23',
+      '34'
+    ])
+  })
+
+  it('parses Notion string arrays that use single quotes', () => {
+    expect(normalizeInfoCardGreetings("['12', '23', '34']")).toEqual([
+      '12',
+      '23',
+      '34'
+    ])
+  })
+
+  it('treats a plain string as a single greeting', () => {
+    expect(normalizeInfoCardGreetings('Hello')).toEqual(['Hello'])
+  })
+})

--- a/themes/heo/components/InfoCard.js
+++ b/themes/heo/components/InfoCard.js
@@ -8,6 +8,36 @@ import CONFIG from '../config'
 import Announcement from './Announcement'
 import Card from './Card'
 
+export function normalizeInfoCardGreetings(value) {
+  if (Array.isArray(value)) {
+    return value.map(item => String(item).trim()).filter(Boolean)
+  }
+
+  if (typeof value !== 'string') {
+    return []
+  }
+
+  const trimmed = value.trim()
+  if (!trimmed) {
+    return []
+  }
+
+  if (trimmed.startsWith('[') && trimmed.endsWith(']')) {
+    try {
+      const parsed = JSON.parse(trimmed.replace(/'/g, '"'))
+      return normalizeInfoCardGreetings(parsed)
+    } catch {
+      return trimmed
+        .slice(1, -1)
+        .split(',')
+        .map(item => item.trim().replace(/^['"]|['"]$/g, ''))
+        .filter(Boolean)
+    }
+  }
+
+  return [trimmed]
+}
+
 /**
  * 社交信息卡
  * @param {*} props
@@ -101,8 +131,13 @@ function MoreButton() {
  * 欢迎语
  */
 function GreetingsWords() {
-  const greetings = siteConfig('HEO_INFOCARD_GREETINGS', null, CONFIG)
+  const greetings = normalizeInfoCardGreetings(
+    siteConfig('HEO_INFOCARD_GREETINGS', null, CONFIG)
+  )
   const [greeting, setGreeting] = useState(greetings[0])
+  if (greetings.length === 0) {
+    return null
+  }
   // 每次点击，随机获取greetings中的一个
   const handleChangeGreeting = () => {
     const randomIndex = Math.floor(Math.random() * greetings.length)


### PR DESCRIPTION
## Summary
- normalize HEO_INFOCARD_GREETINGS when Notion config provides a stringified array like ['12', '23', '34']
- keep real arrays and plain strings working
- hide the greeting chip when the configured value is empty

Fixes #3921.

## Tests
- PATH="/Users/mac/qianzhu Vault/project/IGN AI 官网/node_modules/.bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/Library/Apple/usr/bin:/Users/mac/.codex/tmp/arg0/codex-arg0dM9zvp:/opt/homebrew/opt/openjdk@17/bin:/Users/mac/.local/bin:/Users/mac/.bun/bin:/Users/mac/.npm-global/bin:/Users/mac/.cargo/bin:/Users/mac/.orbstack/bin:/Applications/Codex.app/Contents/Resources" yarn test __tests__/themes/heo/InfoCard.test.js --runInBand
- PATH="/Users/mac/qianzhu Vault/project/IGN AI 官网/node_modules/.bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/Library/Apple/usr/bin:/Users/mac/.codex/tmp/arg0/codex-arg0dM9zvp:/opt/homebrew/opt/openjdk@17/bin:/Users/mac/.local/bin:/Users/mac/.bun/bin:/Users/mac/.npm-global/bin:/Users/mac/.cargo/bin:/Users/mac/.orbstack/bin:/Applications/Codex.app/Contents/Resources" yarn lint --file themes/heo/components/InfoCard.js --file __tests__/themes/heo/InfoCard.test.js