### PR TITLE
refactor: add typed collection helpers

### DIFF
--- a/__tests__/lib/site/typedCollections.test.js
+++ b/__tests__/lib/site/typedCollections.test.js
@@ -1,0 +1,38 @@
+import {
+  getPublishedTypedPages,
+  getTypedPages,
+  sortTypedPagesByPublishDate
+} from '@/lib/site/typedCollections'
+
+const pages = [
+  { id: 'post-1', type: 'Post', status: 'Published', publishDate: 10 },
+  { id: 'member-1', type: 'Member', status: 'Published', publishDate: 20 },
+  { id: 'member-2', type: 'Member', status: 'Invisible', publishDate: 30 },
+  { id: 'event-1', type: 'Event', status: 'Published', publishDate: 40 }
+]
+
+describe('typedCollections', () => {
+  it('filters pages by content type', () => {
+    expect(getTypedPages({ allPages: pages, type: 'Member' })).toEqual([
+      pages[1],
+      pages[2]
+    ])
+  })
+
+  it('filters published pages by content type', () => {
+    expect(getPublishedTypedPages({ allPages: pages, type: 'Member' })).toEqual(
+      [pages[1]]
+    )
+  })
+
+  it('sorts typed pages by publish date without mutating input', () => {
+    const input = [pages[1], pages[3], pages[0]]
+
+    expect(sortTypedPagesByPublishDate(input).map(page => page.id)).toEqual([
+      'event-1',
+      'member-1',
+      'post-1'
+    ])
+    expect(input.map(page => page.id)).toEqual(['member-1', 'event-1', 'post-1'])
+  })
+})

--- a/lib/db/SiteDataApi.js
+++ b/lib/db/SiteDataApi.js
@@ -29,6 +29,10 @@ import { processPostData } from '../utils/post'
 import { adapterNotionBlockMap } from '../utils/notion.util'
 import { sortPinnedPostsByLatestUpdate } from '@/lib/utils/pinnedPosts'
 import { fetchMembersFromOfficialAPI } from './notion/memberDataSource'
+import {
+  getPublishedTypedPages,
+  sortTypedPagesByPublishDate
+} from '@/lib/site/typedCollections'
 // import pLimit from 'p-limit'
 
 export { getAllTags } from './notion/getAllTags'
@@ -1037,11 +1041,7 @@ export function getLinkPages({ allPages }) {
  * 从 allPages 中筛选 type=Member && status=Published 的条目
  */
 export function getAllMembers({ allPages }) {
-  if (!Array.isArray(allPages)) return []
-
-  const published = allPages.filter(
-    page => page?.type === 'Member' && page?.status === 'Published'
-  )
+  const published = getPublishedTypedPages({ allPages, type: 'Member' })
 
   // 精简成员数据，只保留前端需要的字段，减少 pageProps 体积
   const slim = published.map(m => ({
@@ -1086,8 +1086,7 @@ export function getAllMembers({ allPages }) {
  * 从 allPages 中筛选 type=Event && status=Published 的条目
  */
 export function getAllEvents({ allPages }) {
-  if (!Array.isArray(allPages)) return []
-  return allPages
-    .filter(page => page?.type === 'Event' && page?.status === 'Published')
-    .sort((a, b) => (b?.publishDate ?? 0) - (a?.publishDate ?? 0))
+  return sortTypedPagesByPublishDate(
+    getPublishedTypedPages({ allPages, type: 'Event' })
+  )
 }

--- a/lib/site/typedCollections.js
+++ b/lib/site/typedCollections.js
@@ -1,0 +1,21 @@
+export function getTypedPages({ allPages, type, status } = {}) {
+  if (!Array.isArray(allPages) || !type) return []
+
+  return allPages.filter(page => {
+    if (page?.type !== type) return false
+    if (status === undefined) return true
+    return page?.status === status
+  })
+}
+
+export function getPublishedTypedPages({ allPages, type } = {}) {
+  return getTypedPages({ allPages, type, status: 'Published' })
+}
+
+export function sortTypedPagesByPublishDate(items) {
+  if (!Array.isArray(items)) return []
+
+  return [...items].sort(
+    (a, b) => (b?.publishDate ?? 0) - (a?.publishDate ?? 0)
+  )
+}


### PR DESCRIPTION
## Summary
- add small typed collection helpers for filtering pages by content type/status
- add a publish-date sorter that does not mutate its input
- reuse the helpers in Member and Event collection exports

## Why
This keeps the existing Member/Event support lightweight while giving future community-style content types a shared filtering path instead of repeating type/status checks in each collection getter.

## Not included
- no new routes or UI
- no theme-specific changes
- no IGNAI-specific content or branding

## Tests
- PATH="/Users/mac/qianzhu Vault/project/IGN AI 官网/node_modules/.bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/Library/Apple/usr/bin:/Users/mac/.codex/tmp/arg0/codex-arg0dM9zvp:/opt/homebrew/opt/openjdk@17/bin:/Users/mac/.local/bin:/Users/mac/.bun/bin:/Users/mac/.npm-global/bin:/Users/mac/.cargo/bin:/Users/mac/.orbstack/bin:/Applications/Codex.app/Contents/Resources" yarn test __tests__/lib/site/typedCollections.test.js --runInBand
- PATH="/Users/mac/qianzhu Vault/project/IGN AI 官网/node_modules/.bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/Library/Apple/usr/bin:/Users/mac/.codex/tmp/arg0/codex-arg0dM9zvp:/opt/homebrew/opt/openjdk@17/bin:/Users/mac/.local/bin:/Users/mac/.bun/bin:/Users/mac/.npm-global/bin:/Users/mac/.cargo/bin:/Users/mac/.orbstack/bin:/Applications/Codex.app/Contents/Resources" yarn lint --file lib/site/typedCollections.js --file lib/db/SiteDataApi.js --file __tests__/lib/site/typedCollections.test.js