### PR TITLE
fix: preserve empty selected view results

### DIFF
--- a/__tests__/lib/notion-data-format.test.js
+++ b/__tests__/lib/notion-data-format.test.js
@@ -114,6 +114,34 @@ describe('Notion data format compatibility', () => {
     expect(pageIds).not.toContain('hidden_page')
   })
 
+  it('does not fall back to page_sort when the selected view query is empty', () => {
+    const pageIds = getAllPageIds(
+      {
+        collection_1: {
+          view_1: {
+            collection_group_results: {
+              blockIds: []
+            }
+          }
+        }
+      },
+      'collection_1',
+      {
+        view_1: {
+          value: {
+            value: {
+              page_sort: ['filtered_out_page']
+            }
+          }
+        }
+      },
+      ['view_1'],
+      {}
+    )
+
+    expect(pageIds).toEqual([])
+  })
+
   it('matches selected view query when collection ids use different uuid formats', () => {
     const pageIds = getAllPageIds(
       {

--- a/lib/db/notion/getAllPageIds.js
+++ b/lib/db/notion/getAllPageIds.js
@@ -14,7 +14,7 @@ export default function getAllPageIds(
   // Collect query results from the selected view first.
   // These respect Notion's view-level filters (e.g., "show only 2026 entries").
   const viewQuery = getRecordById(collectionQuery, collectionId)
-  let hasQueryResults = false
+  let hasQueryData = false
   if (viewQuery) {
     const selectedViewData = getRecordById(viewQuery, targetViewId)
     // When a target view is specified, only use that view's results.
@@ -24,6 +24,7 @@ export default function getAllPageIds(
       : targetViewId
         ? []
         : Object.values(viewQuery)
+    hasQueryData = queryData.length > 0
     queryData.forEach(viewData => {
       ;[
         viewData?.collection_group_results?.blockIds,
@@ -32,16 +33,15 @@ export default function getAllPageIds(
       ].forEach(ids => {
         if (Array.isArray(ids) && ids.length > 0) {
           ids.forEach(id => pageSet.add(id))
-          hasQueryResults = true
         }
       })
     })
   }
 
-  // Only use page_sort when no query results exist (fallback for legacy payloads).
+  // Only use page_sort when no query data exists (fallback for legacy payloads).
   // page_sort returns all pages in the view regardless of filters, so merging it
   // with filtered query results would bypass the filter — see #4127.
-  if (!hasQueryResults) {
+  if (!hasQueryData) {
     const selectedCollectionView = getRecordById(collectionView, targetViewId)
     const pageSort = selectedCollectionView?.value?.value?.page_sort
     if (Array.isArray(pageSort) && pageSort.length > 0) {


### PR DESCRIPTION
## 已知问题

1. Empty selected Notion collection view queries can fall back to `page_sort`.
   - This is a follow-up to #4127 and commit 6b24adc9a6e19963229fa27dfd695cd7ea618060.
   - The original fix correctly prefers selected view query results over `page_sort` so view filters are respected.
   - The remaining edge case is that an empty filtered query, such as `blockIds: []`, is treated as "no query results" and falls back to `page_sort`.
   - `page_sort` can contain pages that were filtered out by the selected view, so the empty result can incorrectly become non-empty again.

## 解决方案

1. Track whether selected query data exists separately from whether it contains page IDs.
   - Empty query data is still valid filtered query data.
   - Only fall back to `page_sort` when no query data is available at all.

## 改动收益

1. Preserve view-level filters when the filtered result is empty.
   - Prevents hidden or filtered pages from reappearing through `page_sort`.
   - Keeps the existing legacy fallback for payloads without query data.

## 具体改动

1. `lib/db/notion/getAllPageIds.js`
   - Rename the guard from `hasQueryResults` to `hasQueryData`.
   - Set the guard when query data is present, even if `blockIds` is empty.

2. `__tests__/lib/notion-data-format.test.js`
   - Add a regression test for an empty selected view query with a non-empty `page_sort` fallback.

## 测试确认

- [x] 本地开发环境测试通过
- [ ] 生产环境构建测试通过
- [x] `yarn lint` passed with existing warnings
- [x] `yarn type-check` passed
- [x] `yarn jest __tests__/lib/notion-data-format.test.js --runInBand` passed
- [x] `yarn test --runInBand` passed

## 用户文档（`docs/user-guide/`）

- [x] 不适用（无文档改动）
