### PR TITLE
chore(share buttons): add tips for mouse hover

### DIFF
--- a/components/ShareButtons.js
+++ b/components/ShareButtons.js
@@ -173,7 +173,8 @@ const ShareButtons = ({ post }) => {
         aria-label={service}
         key={service}
         onClick={() => openShareWindow(shareLink)}
-        className={`${BASE_BUTTON_CLASS} ${bgClass}`}>
+        className={`${BASE_BUTTON_CLASS} ${bgClass}`}
+        title={service}>
         <i className={`${iconClass} text-sm`} />
       </button>
     )
@@ -213,7 +214,8 @@ const ShareButtons = ({ post }) => {
             return (
               <button
                 key={singleService}
-                className='cursor-pointer bg-blue-600 text-white rounded-full mx-1'>
+                className='cursor-pointer bg-blue-600 text-white rounded-full mx-1'
+                title={singleService}>
                 <a
                   target='_blank'
                   rel='noreferrer'
@@ -230,7 +232,8 @@ const ShareButtons = ({ post }) => {
                 onMouseLeave={closePopover}
                 aria-label={singleService}
                 key={singleService}
-                className='cursor-pointer bg-green-600 text-white rounded-full mx-1'>
+                className='cursor-pointer bg-green-600 text-white rounded-full mx-1'
+                title={singleService}>
                 <div id='wechat-button'>
                   <i className='fab fa-weixin w-8' />
                 </div>
@@ -256,7 +259,8 @@ const ShareButtons = ({ post }) => {
               <button
                 aria-label={singleService}
                 key={singleService}
-                className='cursor-pointer bg-yellow-500 text-white rounded-full mx-1'>
+                className='cursor-pointer bg-yellow-500 text-white rounded-full mx-1'
+                title={singleService}>
                 <div alt={locale.COMMON.URL_COPIED} onClick={copyUrl}>
                   <i className='fas fa-link w-8' />
                 </div>
@@ -268,7 +272,8 @@ const ShareButtons = ({ post }) => {
                 aria-label={singleService}
                 key={singleService}
                 onClick={() => openRedirectShare('https://link.csdn.net/?target=')}
-                className='cursor-pointer rounded-full mx-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500'>
+                className='cursor-pointer rounded-full mx-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500'
+                title={singleService}>
                 <div className='w-8 h-8 rounded-full items-center justify-center'
                   style={{backgroundColor: '#ff6a00'}}>
                   <Image
@@ -289,7 +294,8 @@ const ShareButtons = ({ post }) => {
                 aria-label={singleService}
                 key={singleService}
                 onClick={() => openRedirectShare('https://link.juejin.cn/?target=')}
-                className='cursor-pointer rounded-full mx-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500'>
+                className='cursor-pointer rounded-full mx-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500'
+                title={singleService}>  
                 <div className='w-8 h-8 rounded-full flex items-center justify-center'
                      style={{ backgroundColor: '#5dade2' }}>
                   <Image


### PR DESCRIPTION
## 已知问题 Background

1. There are so many shared buttons and some of them are unfamiliar to some users. And there is no further way to know about what are these. 

<img width="1228" height="139" alt="image" src="https://github.com/user-attachments/assets/b42448eb-5abc-420a-b6bd-466e6e6bbe70" />

## 解决方案 Proposal

1. Simple and easy: add tips for these buttons when mouse hovering.

## 改动收益 Benifit

1. More info on the page and more user-friendly. 

## 具体改动 File-level scope

1. Add `title` attributes for these button components in [ShareButtons.js](https://github.com/notionnext-org/NotionNext/pull/4212/changes#diff-b15b3aab1eb0c1cd936f2c5640139de08aacc65e77646d3895096dd634f24c0c).

## 测试确认

- [x] 本地开发环境测试通过
- [x] 生产环境构建测试通过

Below is a gif from production env: 
<img width="906" height="132" alt="20260625-2356-53 9126610" src="https://github.com/user-attachments/assets/bb062bab-d05a-4530-8e9d-04603c5ce92d" />

## 其他考虑 Consideration
Right now I only keep it simple, all the words are lower cases. 

1. Do we need more standard name for these icons like `LinkedIn`, instead of `linked`; `QQ `instead of `qq`, etc?
2. Do we need bilingual support? (both english and chinese)


## 用户文档（`docs/user-guide/`）

若本 PR **未** 修改 `docs/user-guide/`、`docs/developer/` 中与站长相关的说明，可勾选「不适用」并跳过本节。

- [X] 不适用（无文档改动）
- [ ] 已按 [维护工作流](https://github.com/notionnext-org/NotionNext/blob/main/docs/user-guide/MAINTENANCE_WORKFLOW.md) 自检
- [ ] 路径符合 `docs/user-guide/` 目录约定
- [ ] 已更新 [user-guide/README.md](https://github.com/notionnext-org/NotionNext/blob/main/docs/user-guide/README.md)（新增/移动文章时）
- [ ] 已更新 [ARTICLE_INDEX.md](https://github.com/notionnext-org/NotionNext/blob/main/docs/user-guide/ARTICLE_INDEX.md)（新 slug 或路径变更时）
- [ ] 环境变量名与 `conf/*.config.js` 一致（若文档涉及配置）
- [ ] 示例中无真实 Token、`.env`、私有 ID
- [ ] 保留或更新了「原文链接」（若源自 docs.tangly1024.com）