### PR TITLE
chore(right float area): add tips

### DIFF
--- a/themes/hexo/components/ButtonFloatDarkMode.js
+++ b/themes/hexo/components/ButtonFloatDarkMode.js
@@ -26,6 +26,7 @@ export default function ButtonDarkModeFloat() {
   return (
     <div
       onClick={handleChangeDarkMode}
+      title={`${isDarkMode ? 'Light Mode' : 'Dark Mode'}`}
       className={
         'justify-center items-center w-7 h-7 text-center transform hover:scale-105 duration-200'
       }>

--- a/themes/hexo/components/ButtonJumpToComment.js
+++ b/themes/hexo/components/ButtonJumpToComment.js
@@ -27,7 +27,8 @@ const ButtonJumpToComment = () => {
   return (
     <div
       className='flex space-x-1 items-center justify-center transform hover:scale-105 duration-200 w-7 h-7 text-center'
-      onClick={navToComment}>
+      onClick={navToComment}
+      title='Jump to Comment'>
       <i className='fas fa-comment text-xs' />
     </div>
   )


### PR DESCRIPTION
## 已知问题 Background

1. In `Hexo` theme, there are missing tips for the right float button which the `endspace` theme has.

    `Hexo` theme:
    <img width="90" height="300" alt="20260626-0031-59 9264757" src="https://github.com/user-attachments/assets/c7bcb178-305a-43ed-9061-98224bbab2f9" />
    
    `Endspace` theme:
    <img width="244" height="586" alt="20260626-0033-24 1792445" src="https://github.com/user-attachments/assets/f87dbb62-8c51-40f9-a118-114b6deeca02" />



## 解决方案 Solution

1. Take the `Endspace` theme as example. Follow it

## 改动收益 Benifit

1. More consistent across themes
2. User-friendly

## 具体改动 Scope
Only affect `Hexo` theme. 

1. themes/hexo/components/ButtonFloatDarkMode.js
    add  'Light Mode'  or 'Dark Mode' just like `Endspace` theme.
2. themes/hexo/components/ButtonJumpToComment.js
    add "Jump to Comment" tips. Same as  `Endspace` theme.

## 测试确认

- [X] 本地开发环境测试通过
- [X] 生产环境构建测试通过

## 其他问题 Related issues / Considerations

There are also same issue in themes : fuwari, commerce and matery. 

<img width="1018" height="224" alt="image" src="https://github.com/user-attachments/assets/9ecdc06b-3490-4f63-b713-8b2f28e8e538" />

1. Should I also change `fuwari` and `matery` theme?
2. About the `commerce` theme, the right float button doesn't even show up correctly in the page. 

## 用户文档（`docs/user-guide/`）

若本 PR **未** 修改 `docs/user-guide/`、`docs/developer/` 中与站长相关的说明，可勾选「不适用」并跳过本节。

- [X] 不适用（无文档改动）
- [ ] 已按 [维护工作流](https://github.com/notionnext-org/NotionNext/blob/main/docs/user-guide/MAINTENANCE_WORKFLOW.md) 自检
- [ ] 路径符合 `docs/user-guide/` 目录约定
- [ ] 已更新 [user-guide/README.md](https://github.com/notionnext-org/NotionNext/blob/main/docs/user-guide/README.md)（新增/移动文章时）
- [ ] 已更新 [ARTICLE_INDEX.md](https://github.com/notionnext-org/NotionNext/blob/main/docs/user-guide/ARTICLE_INDEX.md)（新 slug 或路径变更时）
- [ ] 环境变量名与 `conf/*.config.js` 一致（若文档涉及配置）
- [ ] 示例中无真实 Token、`.env`、私有 ID
- [ ] 保留或更新了「原文链接」（若源自 docs.tangly1024.com）

