### PR TITLE
fix: support Notion reducer collection results

### DIFF
--- a/__tests__/lib/notion-data-format.test.js
+++ b/__tests__/lib/notion-data-format.test.js
@@ -114,6 +114,61 @@ describe('Notion data format compatibility', () => {
     expect(pageIds).not.toContain('hidden_page')
   })
 
+  it('extracts page ids from reducerResults collection group data', () => {
+    const pageIds = getAllPageIds(
+      {
+        collection_1: {
+          view_1: {
+            reducerResults: {
+              collection_group_results: {
+                blockIds: ['page_1', 'page_2']
+              }
+            }
+          }
+        }
+      },
+      'collection_1',
+      {},
+      ['view_1'],
+      {}
+    )
+
+    expect(pageIds).toEqual(['page_1', 'page_2'])
+  })
+
+  it('does not merge reducerResults when collection group results are explicitly empty', () => {
+    const pageIds = getAllPageIds(
+      {
+        collection_1: {
+          view_1: {
+            collection_group_results: {
+              blockIds: []
+            },
+            reducerResults: {
+              collection_group_results: {
+                blockIds: ['filtered_out_page']
+              }
+            }
+          }
+        }
+      },
+      'collection_1',
+      {
+        view_1: {
+          value: {
+            value: {
+              page_sort: ['filtered_out_page']
+            }
+          }
+        }
+      },
+      ['view_1'],
+      {}
+    )
+
+    expect(pageIds).toEqual([])
+  })
+
   it('does not fall back to page_sort when the selected view query is empty', () => {
     const pageIds = getAllPageIds(
       {
@@ -296,6 +351,133 @@ describe('Notion data format compatibility', () => {
     expect(blockMap.collection_view.view_1.value.value.page_sort).toEqual([
       'published_page'
     ])
+  })
+
+  it('normalizes reducerResults collection group data for gallery rendering', () => {
+    const blockMap = {
+      block: {
+        page_1: {
+          value: {
+            id: 'page_1',
+            type: 'page',
+            properties: {
+              title: [['Gallery item']]
+            }
+          }
+        }
+      },
+      collection: {
+        collection_1: {
+          value: {
+            schema: {
+              title: { name: 'title', type: 'title' }
+            }
+          }
+        }
+      },
+      collection_view: {
+        view_1: {
+          value: {
+            value: {
+              id: 'view_1',
+              type: 'gallery',
+              format: {
+                collection_pointer: { id: 'collection_1' },
+                gallery_cover: { type: 'page_content' }
+              }
+            }
+          }
+        }
+      },
+      collection_query: {
+        collection_1: {
+          view_1: {
+            reducerResults: {
+              collection_group_results: {
+                blockIds: ['page_1'],
+                hasMore: false,
+                type: 'results'
+              }
+            }
+          }
+        }
+      }
+    }
+
+    filterCollectionViewData(blockMap)
+
+    expect(
+      blockMap.collection_query.collection_1.view_1.collection_group_results
+        .blockIds
+    ).toEqual(['page_1'])
+  })
+
+  it('does not replace existing collection group results with reducerResults', () => {
+    const blockMap = {
+      block: {
+        visible_page: {
+          value: {
+            id: 'visible_page',
+            type: 'page',
+            properties: {
+              title: [['Visible']]
+            }
+          }
+        },
+        reducer_only_page: {
+          value: {
+            id: 'reducer_only_page',
+            type: 'page',
+            properties: {
+              title: [['Reducer only']]
+            }
+          }
+        }
+      },
+      collection: {
+        collection_1: {
+          value: {
+            schema: {
+              title: { name: 'title', type: 'title' }
+            }
+          }
+        }
+      },
+      collection_view: {
+        view_1: {
+          value: {
+            value: {
+              id: 'view_1',
+              type: 'gallery',
+              format: {
+                collection_pointer: { id: 'collection_1' }
+              }
+            }
+          }
+        }
+      },
+      collection_query: {
+        collection_1: {
+          view_1: {
+            collection_group_results: {
+              blockIds: ['visible_page']
+            },
+            reducerResults: {
+              collection_group_results: {
+                blockIds: ['reducer_only_page']
+              }
+            }
+          }
+        }
+      }
+    }
+
+    filterCollectionViewData(blockMap)
+
+    expect(
+      blockMap.collection_query.collection_1.view_1.collection_group_results
+        .blockIds
+    ).toEqual(['visible_page'])
   })
 
   it('matches localized Notion status values through status groups', () => {

--- a/lib/db/notion/filterCollectionViewData.js
+++ b/lib/db/notion/filterCollectionViewData.js
@@ -1,6 +1,8 @@
 function filterCollectionViewData(blockMap) {
   if (!blockMap?.collection_view || !blockMap?.collection_query) return
 
+  normalizeCollectionQueryResults(blockMap.collection_query)
+
   const inheritedFilters = getInheritedCollectionViewFilters(blockMap)
 
   Object.values(blockMap.collection_view).forEach(entry => {
@@ -27,6 +29,20 @@ function filterCollectionViewData(blockMap) {
         return matchesCollectionFilter(block, filter, schema)
       })
     }
+  })
+}
+
+function normalizeCollectionQueryResults(collectionQuery) {
+  Object.values(collectionQuery || {}).forEach(collectionViews => {
+    Object.values(collectionViews || {}).forEach(viewData => {
+      if (!viewData || typeof viewData !== 'object') return
+
+      const reducerGroupResults =
+        viewData.reducerResults?.collection_group_results
+      if (!viewData.collection_group_results && reducerGroupResults) {
+        viewData.collection_group_results = reducerGroupResults
+      }
+    })
   })
 }
 

--- a/lib/db/notion/getAllPageIds.js
+++ b/lib/db/notion/getAllPageIds.js
@@ -26,8 +26,11 @@ export default function getAllPageIds(
         : Object.values(viewQuery)
     hasQueryData = queryData.length > 0
     queryData.forEach(viewData => {
+      const collectionGroupBlockIds =
+        viewData?.collection_group_results?.blockIds ??
+        viewData?.reducerResults?.collection_group_results?.blockIds
       ;[
-        viewData?.collection_group_results?.blockIds,
+        collectionGroupBlockIds,
         viewData?.results?.blockIds,
         viewData?.blockIds
       ].forEach(ids => {


### PR DESCRIPTION
﻿## Summary

Fixes Gallery rendering when Notion collection query results are returned under `reducerResults.collection_group_results` instead of the legacy `collection_group_results` shape.

## Root Cause

`react-notion-x` reads Gallery/List/Table block IDs from `collectionData.collection_group_results.blockIds`, but newer Notion payloads can put the same result under `reducerResults.collection_group_results.blockIds`. In that case the collection view renders as empty even though Notion has data.

## Changes

- Read reducer collection-group results when collecting site page IDs.
- Normalize reducer collection-group results before sending embedded collection record maps to the renderer.
- Add regression tests for reducer fallback, explicit empty results, and non-overwrite behavior.

## Validation

- `npx jest __tests__/lib/notion-data-format.test.js --runInBand --env=node`
- `npx eslint lib/db/notion/getAllPageIds.js lib/db/notion/filterCollectionViewData.js __tests__/lib/notion-data-format.test.js`
- `git diff --check`
