### PR TITLE
fix: handle comma-separated Notion multi-select filters

### DIFF
--- a/__tests__/lib/notion-data-format.test.js
+++ b/__tests__/lib/notion-data-format.test.js
@@ -353,6 +353,160 @@ describe('Notion data format compatibility', () => {
     ])
   })
 
+  it('matches multi-select contains filters when values are comma-separated', () => {
+    const blockMap = {
+      block: {
+        tech_page: {
+          value: {
+            id: 'tech_page',
+            type: 'page',
+            properties: {
+              tags: [['Tech,Life']]
+            }
+          }
+        },
+        life_page: {
+          value: {
+            id: 'life_page',
+            type: 'page',
+            properties: {
+              tags: [['Life']]
+            }
+          }
+        }
+      },
+      collection: {
+        collection_1: {
+          value: {
+            schema: {
+              tags: { name: 'Tags', type: 'multi_select' }
+            }
+          }
+        }
+      },
+      collection_view: {
+        view_1: {
+          value: {
+            value: {
+              id: 'view_1',
+              page_sort: ['tech_page', 'life_page'],
+              format: {
+                collection_pointer: { id: 'collection_1' },
+                property_filters: [
+                  {
+                    filter: {
+                      property: 'tags',
+                      filter: {
+                        operator: 'multi_select_contains',
+                        value: { type: 'exact', value: 'Tech' }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      collection_query: {
+        collection_1: {
+          view_1: {
+            collection_group_results: {
+              blockIds: ['tech_page', 'life_page']
+            }
+          }
+        }
+      }
+    }
+
+    filterCollectionViewData(blockMap)
+
+    expect(
+      blockMap.collection_query.collection_1.view_1.collection_group_results
+        .blockIds
+    ).toEqual(['tech_page'])
+    expect(blockMap.collection_view.view_1.value.value.page_sort).toEqual([
+      'tech_page'
+    ])
+  })
+
+  it('matches multi-select does-not-contain filters when values are comma-separated', () => {
+    const blockMap = {
+      block: {
+        tech_page: {
+          value: {
+            id: 'tech_page',
+            type: 'page',
+            properties: {
+              tags: [['Tech,Life']]
+            }
+          }
+        },
+        life_page: {
+          value: {
+            id: 'life_page',
+            type: 'page',
+            properties: {
+              tags: [['Life']]
+            }
+          }
+        }
+      },
+      collection: {
+        collection_1: {
+          value: {
+            schema: {
+              tags: { name: 'Tags', type: 'multi_select' }
+            }
+          }
+        }
+      },
+      collection_view: {
+        view_1: {
+          value: {
+            value: {
+              id: 'view_1',
+              page_sort: ['tech_page', 'life_page'],
+              format: {
+                collection_pointer: { id: 'collection_1' },
+                property_filters: [
+                  {
+                    filter: {
+                      property: 'tags',
+                      filter: {
+                        operator: 'multi_select_does_not_contain',
+                        value: { type: 'exact', value: 'Tech' }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      collection_query: {
+        collection_1: {
+          view_1: {
+            collection_group_results: {
+              blockIds: ['tech_page', 'life_page']
+            }
+          }
+        }
+      }
+    }
+
+    filterCollectionViewData(blockMap)
+
+    expect(
+      blockMap.collection_query.collection_1.view_1.collection_group_results
+        .blockIds
+    ).toEqual(['life_page'])
+    expect(blockMap.collection_view.view_1.value.value.page_sort).toEqual([
+      'life_page'
+    ])
+  })
+
   it('normalizes reducerResults collection group data for gallery rendering', () => {
     const blockMap = {
       block: {

--- a/lib/db/notion/filterCollectionViewData.js
+++ b/lib/db/notion/filterCollectionViewData.js
@@ -287,6 +287,22 @@ function getExpectedValues(value, propertySchema) {
 }
 
 function expandPropertyValues(values, propertySchema) {
+  if (propertySchema?.type === 'multi_select') {
+    return [
+      ...new Set(
+        values.flatMap(value => {
+          const text = String(value)
+          const parts = text
+            .split(',')
+            .map(item => item.trim())
+            .filter(Boolean)
+
+          return parts.length > 1 ? [text, ...parts] : [text]
+        })
+      )
+    ]
+  }
+
   if (propertySchema?.type !== 'status') return values
 
   const groupValues = propertySchema.groups


### PR DESCRIPTION
## Summary
- split comma-separated Notion multi-select values before collection view filter matching
- keep the split scoped to `multi_select` schema fields so text filters are unchanged
- add regression coverage for `multi_select_contains` and `multi_select_does_not_contain`

## Root cause
Some Notion payloads encode multi-select tags as a single plain text value like `Tech,Life`. The collection filter matcher compared exact values only, so `contains Tech` missed the page and `does_not_contain Tech` could incorrectly keep it.

## Checks
- `npx jest __tests__/lib/notion-data-format.test.js --runInBand --env=node`
- `npx eslint lib\db\notion\filterCollectionViewData.js __tests__\lib\notion-data-format.test.js`
- `git diff --check`