### PR TITLE
fix: render Claude homepage README from Notion

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -15,6 +15,164 @@ import { checkDataFromAlgolia } from '@/lib/plugins/algolia'
 import pLimit from 'p-limit'
 import { adapterNotionBlockMap } from '@/lib/utils/notion.util'
 
+const normalizeBlockId = value => String(value || '').replace(/-/g, '').toLowerCase()
+
+const escapeHtml = value =>
+  String(value || '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+
+const renderRichText = richText => {
+  if (!Array.isArray(richText)) return ''
+
+  return richText
+    .map(segment => {
+      if (!Array.isArray(segment)) return escapeHtml(segment)
+
+      let text = escapeHtml(segment[0])
+      const decorations = Array.isArray(segment[1]) ? segment[1] : []
+
+      decorations.forEach(decoration => {
+        if (!Array.isArray(decoration)) return
+        const [type, value] = decoration
+        if (type === 'b') text = `<strong>${text}</strong>`
+        if (type === 'i') text = `<em>${text}</em>`
+        if (type === 's') text = `<del>${text}</del>`
+        if (type === '_') text = `<u>${text}</u>`
+        if (type === 'c') text = `<code>${text}</code>`
+        if (type === 'a' && value) {
+          text = `<a href="${escapeHtml(value)}" target="_blank" rel="noopener noreferrer">${text}</a>`
+        }
+      })
+
+      return text
+    })
+    .join('')
+}
+
+const getBlockValue = entry => entry?.value || entry || null
+
+const findBlockValue = (blocks, id) => {
+  if (!blocks || !id) return null
+  if (blocks[id]) return getBlockValue(blocks[id])
+
+  const targetId = normalizeBlockId(id)
+  const matchedKey = Object.keys(blocks).find(key => normalizeBlockId(key) === targetId)
+  return matchedKey ? getBlockValue(blocks[matchedKey]) : null
+}
+
+const renderNotionBlocksToHtml = (blockMap, rootId) => {
+  const blocks = blockMap?.block
+  if (!blocks) return ''
+
+  const root = findBlockValue(blocks, rootId)
+  const rootContent = Array.isArray(root?.content)
+    ? root.content
+    : Object.values(blocks)
+        .map(getBlockValue)
+        .find(block => block?.type === 'page' && Array.isArray(block.content))
+        ?.content
+
+  if (!Array.isArray(rootContent)) return ''
+
+  const renderChildren = content => {
+    if (!Array.isArray(content)) return ''
+
+    let html = ''
+    let listType = null
+    let listItems = []
+
+    const flushList = () => {
+      if (!listType || listItems.length === 0) return
+      const tag = listType === 'numbered_list' ? 'ol' : 'ul'
+      html += `<${tag}>${listItems.join('')}</${tag}>`
+      listType = null
+      listItems = []
+    }
+
+    content.forEach(blockId => {
+      const block = findBlockValue(blocks, blockId)
+      if (!block) return
+
+      const type = block.type
+      const title = renderRichText(block.properties?.title)
+      const childrenHtml = renderChildren(block.content)
+
+      if (type === 'bulleted_list' || type === 'numbered_list') {
+        if (listType && listType !== type) flushList()
+        listType = type
+        listItems.push(`<li>${title}${childrenHtml}</li>`)
+        return
+      }
+
+      flushList()
+
+      if (type === 'header') html += `<h1>${title}</h1>${childrenHtml}`
+      else if (type === 'sub_header') html += `<h2>${title}</h2>${childrenHtml}`
+      else if (type === 'sub_sub_header') html += `<h3>${title}</h3>${childrenHtml}`
+      else if (type === 'quote') html += `<blockquote>${title}${childrenHtml}</blockquote>`
+      else if (type === 'callout') html += `<blockquote>${title}${childrenHtml}</blockquote>`
+      else if (type === 'divider') html += '<hr />'
+      else if (type === 'code') html += `<pre><code>${escapeHtml(block.properties?.title?.map(item => item?.[0] || '').join('') || '')}</code></pre>`
+      else if (type === 'image') {
+        const source = block.properties?.source?.[0]?.[0]
+        const caption = renderRichText(block.properties?.caption)
+        if (source) {
+          html += `<figure><img src="${escapeHtml(source)}" alt="${caption.replace(/<[^>]*>/g, '')}" />${caption ? `<figcaption>${caption}</figcaption>` : ''}</figure>`
+        }
+        html += childrenHtml
+      } else if (type === 'text' || type === 'toggle') {
+        if (title) html += `<p>${title}</p>`
+        html += childrenHtml
+      } else {
+        if (title) html += `<p>${title}</p>`
+        html += childrenHtml
+      }
+    })
+
+    flushList()
+    return html
+  }
+
+  return renderChildren(rootContent)
+}
+
+async function getClaudeReadmePage(allPages) {
+  const readmePage = allPages?.find(page => {
+    const slug = String(page?.slug || '').replace(/^\/+|\/+$/g, '').toLowerCase()
+    return page?.status === 'Published' && slug === 'readme.md'
+  })
+
+  if (!readmePage) return null
+
+  try {
+    const rawBlockMap = await getPostBlocks(readmePage.id, 'claude-readme', {
+      cacheVersion: readmePage.lastEditedDate
+    })
+    const adaptedBlockMap = adapterNotionBlockMap(rawBlockMap)
+    const blockMap = {
+      ...adaptedBlockMap,
+      block: formatNotionBlock(adaptedBlockMap.block)
+    }
+
+    return {
+      ...readmePage,
+      readmeHtml: renderNotionBlocksToHtml(blockMap, readmePage.id),
+      excerpt: readmePage.summary || readmePage.description || ''
+    }
+  } catch (error) {
+    console.warn('[Claude README] Failed to load README page:', error)
+    return {
+      ...readmePage,
+      readmeHtml: '',
+      excerpt: readmePage.summary || readmePage.description || ''
+    }
+  }
+}
+
 /**
  * 首页布局
  * @param {*} props
@@ -49,6 +207,12 @@ export async function getStaticProps(req) {
       })
     )
   }
+
+  const theme = siteConfig('THEME', BLOG.THEME, props?.NOTION_CONFIG)
+  if (theme === 'claude') {
+    props.readmePage = await getClaudeReadmePage(props.allPages)
+  }
+
   const POST_PREVIEW_LINES = siteConfig(
     'POST_PREVIEW_LINES',
     8,


### PR DESCRIPTION
> 尽量按此模板PR内容，或粘贴相关的ISSUE链接。

## 已知问题

1. (示例)版本号管理不规范
   - 版本号直接写在环境变量中，容易出错
   - 多处维护版本号，可能不一致

## 解决方案

1. (示例)将版本号管理从 `.env.local` 迁移到 `package.json`
   - 统一从 `package.json` 读取版本号
   - 使用 IIFE 优雅处理版本号获取逻辑
   - 保持向后兼容，支持环境变量覆盖

## 改动收益

1. (示例)更规范的版本管理
   - 统一从 `package.json` 读取
   - 保持与 npm 生态一致
   - 减少人为错误

## 具体改动

1. （示例）`blog.config.js`
   - 移除原有的静态版本号配置
   - 在文件末尾添加动态版本号获取逻辑
   - 保持向后兼容，优先使用环境变量
   - 添加错误处理和默认值

## 测试确认

- [ ] 本地开发环境测试通过
- [ ] 生产环境构建测试通过
- [ ] （如适用）版本号正确显示
- [ ] （如适用）环境变量配置正常工作

## 用户文档（`docs/user-guide/`）

若本 PR **未** 修改 `docs/user-guide/`、`docs/developer/` 中与站长相关的说明，可勾选「不适用」并跳过本节。

- [ ] 不适用（无文档改动）
- [ ] 已按 [维护工作流](https://github.com/notionnext-org/NotionNext/blob/main/docs/user-guide/MAINTENANCE_WORKFLOW.md) 自检
- [ ] 路径符合 `docs/user-guide/` 目录约定
- [ ] 已更新 [user-guide/README.md](https://github.com/notionnext-org/NotionNext/blob/main/docs/user-guide/README.md)（新增/移动文章时）
- [ ] 已更新 [ARTICLE_INDEX.md](https://github.com/notionnext-org/NotionNext/blob/main/docs/user-guide/ARTICLE_INDEX.md)（新 slug 或路径变更时）
- [ ] 环境变量名与 `conf/*.config.js` 一致（若文档涉及配置）
- [ ] 示例中无真实 Token、`.env`、私有 ID
- [ ] 保留或更新了「原文链接」（若源自 docs.tangly1024.com）

文档说明（可选）：对应官方 slug / URL、是否与功能 PR 配套
