### PR TITLE
[codex] fix Fuwari fixed theme hue

### DIFF
--- a/themes/fuwari/components/ThemeColorSwitch.js
+++ b/themes/fuwari/components/ThemeColorSwitch.js
@@ -22,9 +22,15 @@ function normalizeHue(value, fallback) {
   return Math.min(360, Math.max(0, hue))
 }
 
+export function getInitialHue(storedHue, defaultHue, fixed) {
+  if (fixed || !storedHue) return defaultHue
+  return normalizeHue(storedHue, defaultHue)
+}
+
 const ThemeColorSwitch = ({ panelRef, visible = true, onColorChange }) => {
   const enabled = siteConfig('FUWARI_WIDGET_THEME_COLOR_SWITCHER', true, CONFIG)
   const defaultHue = normalizeHue(siteConfig('FUWARI_THEME_COLOR_HUE', 250, CONFIG), 250)
+  const fixed = siteConfig('FUWARI_THEME_COLOR_FIXED', false, CONFIG)
   const [hue, setHue] = useState(defaultHue)
   const color = useMemo(() => hslToHex(hue, 85, 62), [hue])
 
@@ -38,10 +44,10 @@ const ThemeColorSwitch = ({ panelRef, visible = true, onColorChange }) => {
 
   useEffect(() => {
     const stored = localStorage.getItem(STORAGE_HUE_KEY)
-    const initialHue = stored ? normalizeHue(stored, defaultHue) : defaultHue
+    const initialHue = getInitialHue(stored, defaultHue, fixed)
     setHue(initialHue)
     applyColor(hslToHex(initialHue, 85, 62), initialHue)
-  }, [applyColor, defaultHue])
+  }, [applyColor, defaultHue, fixed])
 
   const handleSelect = nextHue => {
     setHue(nextHue)

--- a/themes/fuwari/components/ThemeColorSwitch.test.js
+++ b/themes/fuwari/components/ThemeColorSwitch.test.js
@@ -1,0 +1,13 @@
+/** @jest-environment node */
+
+import { getInitialHue } from './ThemeColorSwitch'
+
+describe('getInitialHue', () => {
+  it('uses configured hue when the Fuwari theme color is fixed', () => {
+    expect(getInitialHue('250', 52, true)).toBe(52)
+  })
+
+  it('keeps the stored hue when the palette is editable', () => {
+    expect(getInitialHue('250', 52, false)).toBe(250)
+  })
+})


### PR DESCRIPTION
﻿## Summary
- Make fixed Fuwari theme color ignore stale `localStorage` hue values.
- Keep stored hue behavior unchanged when the palette remains editable.
- Add a focused test for fixed vs editable initial hue selection.

## Root cause
`ThemeColorSwitch` still initialized from `localStorage` after `FUWARI_THEME_COLOR_FIXED=true` hid the palette button, so an old user-selected hue could overwrite `FUWARI_THEME_COLOR_HUE` after hydration.

## Checks
- `yarn jest themes/fuwari/components/ThemeColorSwitch.test.js --runInBand`
