### PR TITLE
fix: guard category/tag static paths（修复分类/标签静态路径空值崩溃）

### DIFF
--- a/pages/category/[category]/index.js
+++ b/pages/category/[category]/index.js
@@ -62,9 +62,10 @@ export async function getStaticProps({ params: { category }, locale }) {
 export async function getStaticPaths() {
   const from = 'category-paths'
   const { categoryOptions } = await fetchGlobalAllData({ from })
+  const categories = Array.isArray(categoryOptions) ? categoryOptions : []
   return {
-    paths: Object.keys(categoryOptions).map(category => ({
-      params: { category: categoryOptions[category]?.name }
+    paths: categories.map(category => ({
+      params: { category: category?.name }
     })),
     fallback: true
   }

--- a/pages/tag/[tag]/index.js
+++ b/pages/tag/[tag]/index.js
@@ -60,6 +60,9 @@ export async function getStaticProps({ params: { tag }, locale }) {
  * @param tags
  */
 function getTagNames(tags) {
+  if (!Array.isArray(tags)) {
+    return []
+  }
   const tagNames = []
   tags.forEach(tag => {
     tagNames.push(tag.name)
@@ -73,8 +76,8 @@ export async function getStaticPaths() {
   const tagNames = getTagNames(tagOptions)
 
   return {
-    paths: Object.keys(tagNames).map(index => ({
-      params: { tag: tagNames[index] }
+    paths: tagNames.map(tag => ({
+      params: { tag }
     })),
     fallback: true
   }


### PR DESCRIPTION
## 摘要 / Summary

- 为分类页 `getStaticPaths` 增加空值守卫：当 `categoryOptions` 不是数组时，降级为空数组。
- 为标签页 `getStaticPaths` 增加空值守卫：当 `tagOptions` 不是数组时，降级为空数组。
- 将 `Object.keys(array).map(...)` 改为直接数组 `map(...)`，语义更清晰。

- Guard category static path generation when `categoryOptions` is not an array.
- Guard tag static path generation when `tagOptions` is not an array.
- Replace `Object.keys(array).map(...)` with direct array mapping for category and tag paths.

## 原因 / Why

当前分类页和标签页的 `getStaticPaths` 在对应 Notion 选项数据缺失、为空或不是数组时，可能在构建阶段抛错。  
这个修复在数据不可用时返回空路径列表，同时保留现有 `fallback: true` 行为，避免构建期崩溃。

`getStaticPaths` for category and tag routes can currently throw during build when the corresponding Notion option data is missing, empty, or not an array.  
This fix returns an empty path list in that case while keeping the existing `fallback: true` behavior, avoiding a build-time crash.

## 验证 / Validation

- `corepack yarn test --runInBand --watchAll=false --silent`
  - 24 个测试套件通过 / 24 test suites passed
  - 145 个测试用例通过 / 145 tests passed
- `NODE_OPTIONS=--max-old-space-size=8192 corepack yarn build`
  - 已在当前 upstream main 分支上构建通过 / completed successfully against the current upstream main branch

## 范围 / Scope

本 PR 只修改：

- `pages/category/[category]/index.js`
- `pages/tag/[tag]/index.js`

不改变分类 / 标签静态路径生成之外的行为。

This PR only changes:

- `pages/category/[category]/index.js`
- `pages/tag/[tag]/index.js`

No behavior outside category/tag static path generation is changed.
