### PR TITLE
fix(claude): keep sidebar height with Adsense

### DIFF
--- a/themes/claude/index.js
+++ b/themes/claude/index.js
@@ -113,15 +113,18 @@ const LayoutBase = props => {
     <ThemeGlobalSimple.Provider value={{ searchModal }}>
       <div
         id='theme-claude'
-        className={`${siteConfig('FONT_STYLE')} ${isHomePage ? 'claude-page-home' : 'claude-page-subpage'} h-screen flex flex-col overflow-hidden`}>
+        className={`${siteConfig('FONT_STYLE')} ${isHomePage ? 'claude-page-home' : 'claude-page-subpage'} flex flex-col overflow-hidden`}
+        style={{ height: '100vh', minHeight: '100vh' }}>
         <Style />
 
         {siteConfig('SIMPLE_TOP_BAR', null, CONFIG) && <TopBar {...props} />}
 
-        <div className='flex flex-1 overflow-hidden'>
+        <div className='flex flex-1 overflow-hidden' style={{ height: '100vh' }}>
           {/* ====== LEFT SIDEBAR — 导航栏 (桌面端) ====== */}
           {/* 使用 SidebarContent (React.memo) 避免客户端导航时重新加载侧边栏 */}
-          <div className='claude-sidebar hidden md:flex md:flex-col md:flex-shrink-0 md:w-[296px] lg:w-[320px] h-full overflow-y-auto overflow-x-hidden'>
+          <div
+            className='claude-sidebar hidden md:flex md:flex-col md:flex-shrink-0 md:w-[296px] lg:w-[320px] overflow-y-auto overflow-x-hidden'
+            style={{ height: '100%' }}>
             <SidebarContent customNav={props.customNav} customMenu={props.customMenu} />
           </div>
 
@@ -129,7 +132,8 @@ const LayoutBase = props => {
           <div className='flex-1 overflow-hidden flex justify-center'>
             <div
               id='container-inner'
-              className='h-full w-full max-w-3xl lg:max-w-4xl xl:max-w-5xl 2xl:max-w-6xl px-5 md:px-8 overflow-y-auto scroll-hidden'>
+              className='w-full max-w-3xl lg:max-w-4xl xl:max-w-5xl 2xl:max-w-6xl px-5 md:px-8 overflow-y-auto scroll-hidden'
+              style={{ height: '100%' }}>
 
               {/* 移动端导航 */}
               <div className='md:hidden pt-4'>
@@ -158,7 +162,9 @@ const LayoutBase = props => {
 
           {/* ====== RIGHT SIDEBAR — 目录 (桌面端，仅文章页) ====== */}
           {tocEnable && hasToc && (
-            <div className='hidden lg:flex lg:flex-col lg:flex-shrink-0 lg:w-[240px] h-full overflow-hidden pt-16 pr-8 pl-2'>
+            <div
+              className='hidden lg:flex lg:flex-col lg:flex-shrink-0 lg:w-[240px] overflow-hidden pt-16 pr-8 pl-2'
+              style={{ height: '100%' }}>
               <Catalog post={props.post} />
             </div>
           )}


### PR DESCRIPTION
## Summary
- keep the Claude theme shell on a fixed viewport height
- preserve left sidebar, content scroller, and TOC heights when Adsense injects inline height styles

## Validation
- git diff --check -- themes/claude/index.js
- npx next lint --file themes/claude/index.js passed in the main checkout before creating the clean worktree

Fixes #4245