### PR TITLE
fix(SEO): add canonical URLs and valid social metadata（补全 canonical 与社交媒体 SEO 元数据）

### DIFF
--- a/__tests__/lib/sitemap-utils.test.js
+++ b/__tests__/lib/sitemap-utils.test.js
@@ -1,7 +1,9 @@
 import {
   buildSitemapLoc,
+  createSiteUrl,
   normalizeSitemapBaseUrl,
   normalizeSitemapLocale,
+  normalizeSiteUrl,
   toSitemapDateString
 } from '@/lib/sitemap-utils'
 
@@ -16,6 +18,14 @@ describe('sitemap-utils', () => {
     it('returns empty string for non-string values', () => {
       expect(normalizeSitemapBaseUrl(null)).toBe('')
       expect(normalizeSitemapBaseUrl(undefined)).toBe('')
+    })
+  })
+
+  describe('normalizeSiteUrl', () => {
+    it('shares the same base URL normalization for non-sitemap callers', () => {
+      expect(normalizeSiteUrl(' https://example.com/// ')).toBe(
+        'https://example.com'
+      )
     })
   })
 
@@ -81,6 +91,34 @@ describe('sitemap-utils', () => {
     })
   })
 
+  describe('createSiteUrl', () => {
+    const baseUrl = 'https://example.com'
+
+    it('builds a site URL with exactly one slash', () => {
+      expect(createSiteUrl(`${baseUrl}/`, '/post/hello')).toBe(
+        'https://example.com/post/hello'
+      )
+    })
+
+    it('returns the normalized site URL when slug is empty', () => {
+      expect(createSiteUrl(`${baseUrl}/`, '')).toBe('https://example.com')
+    })
+
+    it('returns null for anchor-only slugs', () => {
+      expect(createSiteUrl(baseUrl, '#')).toBeNull()
+    })
+
+    it('keeps same-host absolute URLs', () => {
+      expect(createSiteUrl(baseUrl, 'https://example.com/about')).toBe(
+        'https://example.com/about'
+      )
+    })
+
+    it('drops cross-host absolute URLs', () => {
+      expect(createSiteUrl(baseUrl, 'https://external.com/about')).toBeNull()
+    })
+  })
+
   describe('toSitemapDateString', () => {
     it('formats valid date to YYYY-MM-DD', () => {
       expect(toSitemapDateString('2026-02-21T12:34:56.000Z')).toBe(
@@ -95,4 +133,3 @@ describe('sitemap-utils', () => {
     })
   })
 })
-

--- a/components/SEO.js
+++ b/components/SEO.js
@@ -1,6 +1,7 @@
 import { siteConfig } from '@/lib/config'
 import { useGlobal } from '@/lib/global'
-import { loadExternalResource } from '@/lib/utils'
+import { createSiteUrl, normalizeSiteUrl } from '@/lib/sitemap-utils'
+import { isHttpLink, loadExternalResource } from '@/lib/utils'
 import Head from 'next/head'
 import { useRouter } from 'next/router'
 import { useEffect } from 'react'
@@ -13,9 +14,11 @@ import { useEffect } from 'react'
 const SEO = props => {
   const { children, siteInfo, post, NOTION_CONFIG } = props
   const PATH = siteConfig('PATH')
-  const LINK = siteConfig('LINK')
+  const LINK = normalizeSiteUrl(
+    siteConfig('LINK', siteInfo?.link, NOTION_CONFIG)
+  )
   const SUB_PATH = siteConfig('SUB_PATH', '')
-  let url = PATH?.length ? `${LINK}/${SUB_PATH}` : LINK
+  let url = PATH?.length ? createSiteUrl(LINK, SUB_PATH) || LINK : LINK
   let image
   const router = useRouter()
   const meta = getSEOMeta(props, router, useGlobal()?.locale)
@@ -53,15 +56,19 @@ const SEO = props => {
     keywords = post?.tags?.join(',')
   }
   if (meta) {
-    url = `${url}/${meta.slug}`
-    image = meta.image || '/bg_image.jpg'
+    url = createSiteUrl(url, meta.slug) || url
+    image = getAbsoluteImageUrl(meta.image || '/bg_image.jpg', LINK)
   }
   const TITLE = siteConfig('TITLE')
   const title = meta?.title || TITLE
   const description = meta?.description || `${siteInfo?.description}`
-  const type = meta?.type || 'website'
-  const lang = siteConfig('LANG').replace('-', '_') // Facebook OpenGraph 要 zh_CN 這樣的格式才抓得到語言
-  const category = meta?.category || KEYWORDS // section 主要是像是 category 這樣的分類，Facebook 用這個來抓連結的分類
+  const type = meta?.type === 'Post' ? 'article' : meta?.type || 'website'
+  const language =
+    router?.locale || siteConfig('LANG', 'zh-CN', NOTION_CONFIG)
+  const lang = String(language).replace('-', '_') // Facebook OpenGraph 要 zh_CN 這樣的格式才抓得到語言
+  const category = Array.isArray(meta?.category)
+    ? meta?.category?.[0]
+    : meta?.category || KEYWORDS // section 主要是像是 category 這樣的分類，Facebook 用這個來抓連結的分類
   const favicon = siteConfig('BLOG_FAVICON')
   const BACKGROUND_DARK = siteConfig('BACKGROUND_DARK', '', NOTION_CONFIG)
 
@@ -102,6 +109,8 @@ const SEO = props => {
   )
 
   const FACEBOOK_PAGE = siteConfig('FACEBOOK_PAGE', null, NOTION_CONFIG)
+  const TWITTER_SITE = siteConfig('TWITTER_SITE', '', NOTION_CONFIG)
+  const TWITTER_CREATOR = siteConfig('TWITTER_CREATOR', '', NOTION_CONFIG)
 
   const AUTHOR = siteConfig('AUTHOR')
   return (
@@ -136,13 +145,14 @@ const SEO = props => {
       )}
 
       {/* 基础SEO元数据 */}
+      <link rel='canonical' href={url} />
       <meta name='keywords' content={keywords} />
       <meta name='description' content={description} />
       <meta name='author' content={AUTHOR} />
       <meta name='generator' content='NotionNext' />
 
       {/* 语言和地区 */}
-      <meta httpEquiv='content-language' content={siteConfig('LANG')} />
+      <meta httpEquiv='content-language' content={language} />
       <meta name='geo.region' content={siteConfig('GEO_REGION', 'CN')} />
       <meta name='geo.country' content={siteConfig('GEO_COUNTRY', 'CN')} />
       {/* Open Graph 元数据 */}
@@ -159,8 +169,10 @@ const SEO = props => {
 
       {/* Twitter Card 元数据 */}
       <meta name='twitter:card' content='summary_large_image' />
-      <meta name='twitter:site' content={siteConfig('TWITTER_SITE', '@NotionNext')} />
-      <meta name='twitter:creator' content={siteConfig('TWITTER_CREATOR', '@NotionNext')} />
+      {TWITTER_SITE && <meta name='twitter:site' content={TWITTER_SITE} />}
+      {TWITTER_CREATOR && (
+        <meta name='twitter:creator' content={TWITTER_CREATOR} />
+      )}
       <meta name='twitter:title' content={title} />
       <meta name='twitter:description' content={description} />
       <meta name='twitter:image' content={image} />
@@ -190,12 +202,21 @@ const SEO = props => {
       {/* 文章特定元数据 */}
       {meta?.type === 'Post' && (
         <>
-          <meta property='article:published_time' content={meta.publishDay} />
-          <meta property='article:modified_time' content={meta.lastEditedDay} />
+          {meta.publishTime && (
+            <meta property='article:published_time' content={meta.publishTime} />
+          )}
+          {meta.modifiedTime && (
+            <meta
+              property='article:modified_time'
+              content={meta.modifiedTime}
+            />
+          )}
           <meta property='article:author' content={AUTHOR} />
           <meta property='article:section' content={category} />
           <meta property='article:tag' content={keywords} />
-          <meta property='article:publisher' content={FACEBOOK_PAGE} />
+          {FACEBOOK_PAGE && (
+            <meta property='article:publisher' content={FACEBOOK_PAGE} />
+          )}
         </>
       )}
 
@@ -203,7 +224,9 @@ const SEO = props => {
       <script
         type='application/ld+json'
         dangerouslySetInnerHTML={{
-          __html: JSON.stringify(generateStructuredData(meta, siteInfo, url, image, AUTHOR))
+          __html: JSON.stringify(
+            generateStructuredData(meta, siteInfo, url, image, AUTHOR, LINK)
+          )
         }}
       />
 
@@ -233,13 +256,20 @@ const SEO = props => {
  * @param {*} author
  * @returns
  */
-const generateStructuredData = (meta, siteInfo, url, image, author) => {
+const generateStructuredData = (
+  meta,
+  siteInfo,
+  url,
+  image,
+  author,
+  siteUrl
+) => {
   const baseData = {
     '@context': 'https://schema.org',
     '@type': 'WebSite',
     name: siteInfo?.title,
     description: siteInfo?.description,
-    url: siteConfig('LINK'),
+    url: siteUrl,
     author: {
       '@type': 'Person',
       name: author
@@ -249,7 +279,7 @@ const generateStructuredData = (meta, siteInfo, url, image, author) => {
       name: siteInfo?.title,
       logo: {
         '@type': 'ImageObject',
-        url: siteInfo?.icon
+        url: getAbsoluteImageUrl(siteInfo?.icon, siteUrl)
       }
     }
   }
@@ -263,8 +293,8 @@ const generateStructuredData = (meta, siteInfo, url, image, author) => {
       description: meta.description,
       image: image,
       url: url,
-      datePublished: meta.publishDay,
-      dateModified: meta.lastEditedDay || meta.publishDay,
+      datePublished: meta.publishTime,
+      dateModified: meta.modifiedTime || meta.publishTime,
       author: {
         '@type': 'Person',
         name: author
@@ -274,7 +304,7 @@ const generateStructuredData = (meta, siteInfo, url, image, author) => {
         name: siteInfo?.title,
         logo: {
           '@type': 'ImageObject',
-          url: siteInfo?.icon
+          url: getAbsoluteImageUrl(siteInfo?.icon, siteUrl)
         }
       },
       mainEntityOfPage: {
@@ -287,6 +317,27 @@ const generateStructuredData = (meta, siteInfo, url, image, author) => {
   }
 
   return baseData
+}
+
+const getAbsoluteImageUrl = (image, siteUrl) => {
+  if (typeof image !== 'string') return ''
+
+  const rawImage = image.trim()
+  if (!rawImage) return ''
+  if (isHttpLink(rawImage) || rawImage.startsWith('data:')) {
+    return rawImage
+  }
+
+  return createSiteUrl(siteUrl, rawImage) || rawImage
+}
+
+const getIsoTime = value => {
+  if (!value) return undefined
+
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return undefined
+
+  return date.toISOString()
 }
 
 /**
@@ -388,6 +439,9 @@ const getSEOMeta = (props, router, locale) => {
         type: 'website'
       }
     default:
+      const category = Array.isArray(post?.category)
+        ? post?.category?.[0]
+        : post?.category
       return {
         title: post
           ? `${post?.title} | ${siteInfo?.title}`
@@ -396,8 +450,14 @@ const getSEOMeta = (props, router, locale) => {
         type: post?.type,
         slug: post?.slug,
         image: post?.pageCoverThumbnail || `${siteInfo?.pageCover}`,
-        category: post?.category?.[0],
-        tags: post?.tags
+        category,
+        tags: post?.tags,
+        publishDay: post?.publishDay,
+        lastEditedDay: post?.lastEditedDay,
+        publishTime:
+          getIsoTime(post?.publishDate) ||
+          getIsoTime(post?.date?.start_date),
+        modifiedTime: getIsoTime(post?.lastEditedTime || post?.lastEditedDate)
       }
   }
 }

--- a/lib/sitemap-utils.js
+++ b/lib/sitemap-utils.js
@@ -66,3 +66,8 @@ export const buildSitemapLoc = ({
 
   return `${normalizedBaseUrl}${normalizedLocale}/${normalizedSlug}`
 }
+
+export const normalizeSiteUrl = normalizeSitemapBaseUrl
+
+export const createSiteUrl = (baseUrl, slug) =>
+  buildSitemapLoc({ baseUrl, slug })


### PR DESCRIPTION
## 摘要 / Summary

- 增加 `<link rel="canonical">`，让页面输出稳定的规范 URL。
- 复用现有 sitemap URL helper，新增薄封装用于非 sitemap 场景，避免 SEO URL 继续手动拼接。
- 将相对 Open Graph / Twitter 图片转换为绝对 URL。
- 将文章页 `og:type` 从原始 Notion 类型 `Post` 映射为合法的 `article`。
- 使用 ISO 8601 输出文章发布时间和更新时间，避免把本地化展示日期写入 OG / JSON-LD。
- 仅在有值时输出文章日期、Facebook publisher 和 Twitter attribution，避免空值或默认 `@NotionNext`。
- 修复 `category` 为字符串时只取首字符的问题。

- Add `<link rel="canonical">` so pages emit a stable canonical URL.
- Reuse the existing sitemap URL helper through a thin wrapper for non-sitemap SEO callers instead of hand-concatenating URLs.
- Convert relative Open Graph / Twitter images to absolute URLs.
- Map article `og:type` from the raw Notion type `Post` to the valid Open Graph value `article`.
- Emit article published and modified times as ISO 8601 values instead of localized display strings.
- Render article dates, Facebook publisher, and Twitter attribution only when values are configured.
- Fix string `category` values so the full value is used instead of the first character.

## 原因 / Why

当前 `components/SEO.js` 里有几类通用 SEO 正确性问题：

- 没有输出 canonical；
- `og:image` / `twitter:image` 可能是相对路径；
- 文章页可能输出非法的 `og:type="Post"`；
- 文章日期为空时仍输出空 meta；
- 文章日期使用本地化展示字符串，可能不是 OG / JSON-LD 要求的 ISO 8601；
- 未配置 Twitter 时默认输出 `@NotionNext`；
- `category` 如果是字符串，会被 `post?.category?.[0]` 取成第一个字符；
- 页面 URL 仍通过模板字符串手动拼接，容易受尾斜杠影响。

`components/SEO.js` currently has several generic SEO correctness issues:

- no canonical link is emitted;
- `og:image` / `twitter:image` can be relative paths;
- article pages can emit invalid `og:type="Post"`;
- empty article date meta tags can be rendered;
- article dates use localized display strings instead of ISO 8601 values required by OG / JSON-LD;
- Twitter metadata defaults to `@NotionNext` when not configured;
- string `category` values are reduced to the first character by `post?.category?.[0]`;
- page URLs are still concatenated with template strings, which is fragile around trailing slashes.

## 实现 / Implementation

- 本 PR 自包含：同时新增共享 helper `normalizeSiteUrl` / `createSiteUrl`（对 sitemap-utils 既有逻辑的薄封装）并在此使用，无需独立的前置 PR。
- 在 `lib/sitemap-utils.js` 中增加 `normalizeSiteUrl` / `createSiteUrl` 薄 helper，委托现有 `normalizeSitemapBaseUrl` / `buildSitemapLoc`，不复制 URL 逻辑。
- 在 `components/SEO.js` 中使用这些 helper 生成 canonical、`og:url`、JSON-LD URL 和绝对图片 URL。
- 在 `components/SEO.js` 中把文章发布时间和更新时间转换为 ISO 8601 后再输出到 OG / JSON-LD。
- 保持官方已有 busuanzi 逻辑不变。
- 不加入任何站点私有 JSON-LD、品牌字段或自定义域名。

- Self-contained: this PR also adds the shared `normalizeSiteUrl` / `createSiteUrl` helpers (thin delegates over the existing sitemap-utils logic) and uses them here; no separate prerequisite PR is required.
- Add thin `normalizeSiteUrl` / `createSiteUrl` helpers in `lib/sitemap-utils.js`, delegating to the existing `normalizeSitemapBaseUrl` / `buildSitemapLoc` implementation.
- Use these helpers in `components/SEO.js` for canonical URLs, `og:url`, JSON-LD URLs, and absolute image URLs.
- Convert article published and modified times to ISO 8601 before emitting them in OG / JSON-LD.
- Keep the existing busuanzi behavior unchanged.
- Do not include any site-specific JSON-LD, branding fields, or custom domains.

## 验证 / Validation

- `git diff --check`
  - 通过 / passed
- `corepack yarn test __tests__/lib/sitemap-utils.test.js --runInBand --watchAll=false --silent`
  - 17 个测试用例通过 / 17 tests passed
- `corepack yarn test --runInBand --watchAll=false --silent`
  - 24 个测试套件通过 / 24 test suites passed
  - 151 个测试用例通过 / 151 tests passed
- `NODE_OPTIONS=--max-old-space-size=8192 corepack yarn build`
  - 已在当前 upstream main 分支上构建通过 / completed successfully against the current upstream main branch

## 范围 / Scope

本 PR 只修改：

- `lib/sitemap-utils.js`
- `__tests__/lib/sitemap-utils.test.js`
- `components/SEO.js`

不包含任何站点私有品牌、域名、作者身份或分析策略。

This PR only changes:

- `lib/sitemap-utils.js`
- `__tests__/lib/sitemap-utils.test.js`
- `components/SEO.js`

It does not include any site-specific branding, domains, author identity, or analytics decisions.
