### PR TITLE
Add optional chaining for message parts in docs-chat API

### DIFF
--- a/functions/api/docs-chat.ts
+++ b/functions/api/docs-chat.ts
@@ -96,7 +96,7 @@ const maxOutputTokens = (value: string | undefined) => {
 }
 
 const textFromMessage = (message?: UIMessage) =>
-  message.parts
+  message?.parts // <-- Add the question mark here
     ?.map(part => (part.type === 'text' ? part.text : ''))
     .join('') || ''
 

--- a/functions/api/docs-chat.ts
+++ b/functions/api/docs-chat.ts
@@ -96,7 +96,7 @@ const maxOutputTokens = (value: string | undefined) => {
 }
 
 const textFromMessage = (message?: UIMessage) =>
-  message?.parts // <-- Add the question mark here
+  message?.parts
     ?.map(part => (part.type === 'text' ? part.text : ''))
     .join('') || ''
 


### PR DESCRIPTION
Added optional chaining to safely access message parts when `message` is undefined, preventing a TypeScript compilation failure during the build process.

在 `textFromMessage` 函式中為 `message.parts` 補上了選用選取（Optional Chaining），以安全處理當 `message` 為空（undefined）時的情況，解決了生產環境打包時的 TypeScript 編譯錯誤。

## 已知问题

1. 在部署時遭遇 TypeScript 型別編譯錯誤
   - `message` 變數被宣告為選填（`message?: UIMessage`），但在讀取 `.parts` 時未先驗證是否存在，導致打包中斷。

## 解决方案

1. 引入選用選取（Optional Chaining）
   - 將 `message.parts` 修改為 `message?.parts`，確保安全存取。

## 改动收益

1. 修復編譯失敗問題
   - 確保專案在 Netlify 或其他平台構建生產環境時能順利通過 TypeScript 檢查並完成部署。

## 具体改动

1. `functions/api/docs-chat.ts`
   - 在 `textFromMessage` 函式中將 `message.parts` 改為 `message?.parts`。

## 测试确认

- [x] 本地开发环境测试通过
- [x] 生产环境构建测试通过

## 用户文档（`docs/user-guide/`）

- [x] 不适用（无文档改动）