### PR TITLE
fix: refresh AOS after initial load

### DIFF
--- a/components/AOSAnimation.js
+++ b/components/AOSAnimation.js
@@ -13,6 +13,10 @@ const refreshAOS = () => {
   }
 }
 
+const refreshAOSAfterPaint = () => {
+  window.requestAnimationFrame(refreshAOS)
+}
+
 /**
  * 加载滚动动画
  * 改从外部CDN读取
@@ -39,6 +43,7 @@ export default function AOSAnimation() {
           throttleDelay: 120,
           once: true
         })
+        refreshAOSAfterPaint()
       }
     })
   }
@@ -53,7 +58,7 @@ export default function AOSAnimation() {
 
   useEffect(() => {
     const handleRouteChangeComplete = () => {
-      window.requestAnimationFrame(refreshAOS)
+      refreshAOSAfterPaint()
     }
 
     router.events.on('routeChangeComplete', handleRouteChangeComplete)


### PR DESCRIPTION
## Summary

- refresh AOS once after the initial `AOS.init()` path
- reuse the same after-paint refresh helper for route changes

## Checks

- `node --check components\AOSAnimation.js`
- `git diff --check`

Note: `yarn lint --file components/AOSAnimation.js` could not run in this worktree because `next` is not available in `node_modules/.bin`.
