### PR TITLE
fix: hexo theme aos refresh

### DIFF
--- a/components/AOSAnimation.js
+++ b/components/AOSAnimation.js
@@ -1,21 +1,5 @@
 import { loadExternalResource } from '@/lib/utils'
-import { useRouter } from 'next/router'
 import { useEffect } from 'react'
-// import AOS from 'aos'
-
-const refreshAOS = () => {
-  if (!window.AOS) return
-
-  if (window.AOS.refreshHard) {
-    window.AOS.refreshHard()
-  } else if (window.AOS.refresh) {
-    window.AOS.refresh()
-  }
-}
-
-const refreshAOSAfterPaint = () => {
-  window.requestAnimationFrame(refreshAOS)
-}
 
 /**
  * 加载滚动动画
@@ -23,7 +7,6 @@ const refreshAOSAfterPaint = () => {
  * https://michalsnik.github.io/aos/
  */
 export default function AOSAnimation() {
-  const router = useRouter()
   const initAOS = () => {
     if (
       window.matchMedia &&
@@ -38,12 +21,10 @@ export default function AOSAnimation() {
     ]).then(() => {
       if (window.AOS) {
         window.AOS.init({
-          disableMutationObserver: true,
           debounceDelay: 100,
           throttleDelay: 120,
           once: true
         })
-        refreshAOSAfterPaint()
       }
     })
   }
@@ -55,17 +36,6 @@ export default function AOSAnimation() {
     const id = window.setTimeout(initAOS, 2000)
     return () => window.clearTimeout(id)
   }, [])
-
-  useEffect(() => {
-    const handleRouteChangeComplete = () => {
-      refreshAOSAfterPaint()
-    }
-
-    router.events.on('routeChangeComplete', handleRouteChangeComplete)
-    return () => {
-      router.events.off('routeChangeComplete', handleRouteChangeComplete)
-    }
-  }, [router.events])
 
   return null
 }


### PR DESCRIPTION
## 已知问题

1. #4252 

核心问题：disableMutationObserver: true 关掉了 AOS 自带的 DOM 变化监听，之后所有代码都在用 router.events 手动模拟"内容变了要重新扫描"这件事——但 Next.js 的 routeChangeComplete 和主题里两层 next/dynamic 异步挂载的时机对不上（这正是 bug 根因），所以还是会漏刷新。

## 解决方案

* 把 disableMutationObserver: true 去掉。

与其继续加时机补丁，不如把 disableMutationObserver 去掉，让 AOS 自己的 MutationObserver 接管"检测新 [data-aos] 节点"这件事。
不再依赖"猜时机"，因为不管新卡片是路由切换后同步渲染还是被 next/dynamic 延迟挂载，MutationObserver 都能捕捉到。

MutationObserver 唯一的代价是 c36d4b2f 提到的性能问题（频繁 DOM mutation 时可能触发额外扫描），但 AOS 内部这个 observer 本身有 debounce（debounceDelay: 100）。

请审核这个改动是否符合 c36d4b2f 的目的。

## 改动收益

关于 AOS 的动画可以正常执行。无论是点击页面内路由跳转还是通过浏览器跳转。

## 具体改动

1. `components/AOSAnimation.js`
   - 移除 72690b61/ ab52f6b2 中引入的新补丁代码
   - 保留 c36d4b2f 的代码基础上，移除 `disableMutationObserver: true`

## 测试确认

- [X] 本地开发环境测试通过
- [ ] 生产环境构建测试通过

## 用户文档（`docs/user-guide/`）

若本 PR **未** 修改 `docs/user-guide/`、`docs/developer/` 中与站长相关的说明，可勾选「不适用」并跳过本节。

- [X] 不适用（无文档改动）
- [ ] 已按 [维护工作流](https://github.com/notionnext-org/NotionNext/blob/main/docs/user-guide/MAINTENANCE_WORKFLOW.md) 自检
- [ ] 路径符合 `docs/user-guide/` 目录约定
- [ ] 已更新 [user-guide/README.md](https://github.com/notionnext-org/NotionNext/blob/main/docs/user-guide/README.md)（新增/移动文章时）
- [ ] 已更新 [ARTICLE_INDEX.md](https://github.com/notionnext-org/NotionNext/blob/main/docs/user-guide/ARTICLE_INDEX.md)（新 slug 或路径变更时）
- [ ] 环境变量名与 `conf/*.config.js` 一致（若文档涉及配置）
- [ ] 示例中无真实 Token、`.env`、私有 ID
- [ ] 保留或更新了「原文链接」（若源自 docs.tangly1024.com）

文档说明（可选）：对应官方 slug / URL、是否与功能 PR 配套
