### PR TITLE
fix(starter): use fourth feature button text

### DIFF
--- a/__tests__/themes/starter/Features.test.js
+++ b/__tests__/themes/starter/Features.test.js
@@ -1,4 +1,4 @@
-import { renderToStaticMarkup } from 'react-dom/server'
+import { renderToStaticMarkup } from 'react-dom/server.node'
 import { Features } from '@/themes/starter/components/Features'
 import { starterConfig } from '@/themes/starter/config'
 

--- a/__tests__/themes/starter/Features.test.js
+++ b/__tests__/themes/starter/Features.test.js
@@ -1,0 +1,40 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import { Features } from '@/themes/starter/components/Features'
+import { starterConfig } from '@/themes/starter/config'
+
+jest.mock('@/themes/starter/config', () => ({
+  starterConfig: jest.fn()
+}))
+
+jest.mock('@/components/SmartLink', () => ({
+  __esModule: true,
+  default: ({ children, href, ...props }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  )
+}))
+
+describe('starter Features', () => {
+  beforeEach(() => {
+    const config = {
+      STARTER_FEATURE_3_BUTTON_TEXT: 'Third action',
+      STARTER_FEATURE_3_BUTTON_URL: '/third',
+      STARTER_FEATURE_4_BUTTON_TEXT: 'Fourth action',
+      STARTER_FEATURE_4_BUTTON_URL: '/fourth'
+    }
+
+    starterConfig.mockImplementation((key, defaultValue) => {
+      return config[key] ?? defaultValue ?? ''
+    })
+  })
+
+  it('renders independent text and links for the third and fourth features', () => {
+    const html = renderToStaticMarkup(<Features />)
+
+    expect(html).toContain('href="/third"')
+    expect(html).toContain('>Third action</a>')
+    expect(html).toContain('href="/fourth"')
+    expect(html).toContain('>Fourth action</a>')
+  })
+})

--- a/themes/starter/components/Features.js
+++ b/themes/starter/components/Features.js
@@ -102,7 +102,7 @@ export const Features = () => {
                 <SmartLink
                   href={starterConfig('STARTER_FEATURE_4_BUTTON_URL', '')}
                   className='text-base font-medium text-dark hover:text-primary dark:text-white dark:hover:text-primary'>
-                  {starterConfig('STARTER_FEATURE_3_BUTTON_TEXT')}
+                  {starterConfig('STARTER_FEATURE_4_BUTTON_TEXT')}
                 </SmartLink>
               </div>
             </div>


### PR DESCRIPTION
关联 Issue：Fixes #3591

## 已知问题

Starter 首页第 4 个特性卡片错误读取 `STARTER_FEATURE_3_BUTTON_TEXT`，因此第 3、4 个按钮始终显示相同文案。

## 解决方案

- 第 4 个按钮改为读取 `STARTER_FEATURE_4_BUTTON_TEXT`
- 增加组件回归测试，分别配置第 3、4 个按钮的文本和链接

## 改动收益

Starter 的四个特性按钮可以独立配置，避免复制粘贴回归。

## 测试确认

- [x] `yarn test __tests__/themes/starter/Features.test.js --runInBand --env=node`
- [x] 相关文件 ESLint 通过
- [x] 不适用（无用户文档改动）
- [ ] 生产环境构建测试（改动仅涉及一个配置键和回归测试）