### PR TITLE
fix(seo): remove incorrect theme microdata

### DIFF
--- a/__tests__/components/SEO.test.js
+++ b/__tests__/components/SEO.test.js
@@ -1,0 +1,62 @@
+import { generateStructuredData } from '@/components/SEO'
+
+describe('SEO structured data', () => {
+  const siteInfo = {
+    title: 'Example Blog',
+    description: 'Example description',
+    icon: '/logo.png'
+  }
+
+  it('generates BlogPosting data for published articles', () => {
+    const data = generateStructuredData(
+      {
+        type: 'Post',
+        title: 'Structured data in NotionNext',
+        description: 'A test article',
+        publishTime: '2026-07-01T00:00:00.000Z',
+        modifiedTime: '2026-07-02T00:00:00.000Z',
+        tags: ['notion', 'seo'],
+        category: 'Engineering'
+      },
+      siteInfo,
+      'https://example.com/article/structured-data',
+      'https://example.com/cover.png',
+      'Example Author',
+      'https://example.com'
+    )
+
+    expect(data).toMatchObject({
+      '@context': 'https://schema.org',
+      '@type': 'BlogPosting',
+      headline: 'Structured data in NotionNext',
+      url: 'https://example.com/article/structured-data',
+      datePublished: '2026-07-01T00:00:00.000Z',
+      dateModified: '2026-07-02T00:00:00.000Z',
+      keywords: 'notion, seo',
+      articleSection: 'Engineering',
+      mainEntityOfPage: {
+        '@type': 'WebPage',
+        '@id': 'https://example.com/article/structured-data'
+      }
+    })
+    expect(data.publisher.logo.url).toBe('https://example.com/logo.png')
+  })
+
+  it('generates WebSite data for non-article pages', () => {
+    const data = generateStructuredData(
+      { type: 'Page' },
+      siteInfo,
+      'https://example.com/about',
+      'https://example.com/cover.png',
+      'Example Author',
+      'https://example.com'
+    )
+
+    expect(data).toMatchObject({
+      '@context': 'https://schema.org',
+      '@type': 'WebSite',
+      name: 'Example Blog',
+      url: 'https://example.com'
+    })
+  })
+})

--- a/components/SEO.js
+++ b/components/SEO.js
@@ -259,7 +259,7 @@ const SEO = props => {
  * @param {*} author
  * @returns
  */
-const generateStructuredData = (
+export const generateStructuredData = (
   meta,
   siteInfo,
   url,

--- a/themes/commerce/index.js
+++ b/themes/commerce/index.js
@@ -273,10 +273,7 @@ const LayoutSlug = props => {
 
             <hr className='border-2 border-[#D2232A]' />
 
-            <article
-              itemScope
-              itemType='https://schema.org/Movie'
-              className='subpixel-antialiased overflow-y-hidden'>
+            <article className='subpixel-antialiased overflow-y-hidden'>
               {/* Notion文章主体 */}
               <section className='px-5 justify-center mx-auto max-w-2xl lg:max-w-full'>
                 {post && <NotionPage post={post} />}

--- a/themes/fukasawa/components/ArticleDetail.js
+++ b/themes/fukasawa/components/ArticleDetail.js
@@ -38,10 +38,7 @@ export default function ArticleDetail(props) {
         </div>
       )}
 
-      <article
-        itemScope
-        itemType='https://schema.org/Movie'
-        className='subpixel-antialiased overflow-y-hidden py-10 px-5 lg:pt-24 md:px-32  dark:border-gray-700 bg-white dark:bg-hexo-black-gray'>
+      <article className='subpixel-antialiased overflow-y-hidden py-10 px-5 lg:pt-24 md:px-32  dark:border-gray-700 bg-white dark:bg-hexo-black-gray'>
         <header>
           {/* 文章Title */}
           <div className='font-bold text-4xl text-black dark:text-white'>

--- a/themes/heo/index.js
+++ b/themes/heo/index.js
@@ -302,10 +302,7 @@ const LayoutSlug = props => {
         {!lock && post && (
           <div className='mx-auto md:w-full md:px-5'>
             {/* 文章主体 */}
-            <article
-              id='article-wrapper'
-              itemScope
-              itemType='https://schema.org/Movie'>
+            <article id='article-wrapper'>
               {/* Notion文章主体 */}
               <section
                 className='wow fadeInUp p-5 justify-center mx-auto'

--- a/themes/hexo/index.js
+++ b/themes/hexo/index.js
@@ -304,8 +304,6 @@ const LayoutSlug = props => {
           <div className='overflow-x-auto flex-grow mx-auto md:w-full md:px-5 '>
             <article
               id='article-wrapper'
-              itemScope
-              itemType='https://schema.org/Movie'
               className='subpixel-antialiased overflow-y-hidden'>
               {/* Notion文章主体 */}
               <section className='px-5 justify-center mx-auto max-w-2xl lg:max-w-full'>

--- a/themes/matery/index.js
+++ b/themes/matery/index.js
@@ -267,7 +267,7 @@ const LayoutSlug = props => {
               )}
 
               <div className='lg:px-10 subpixel-antialiased'>
-                <article id='article-wrapper' itemScope>
+                <article id='article-wrapper'>
                   {/* Notion文章主体 */}
                   <section
                     data-wow-delay='.1s'

--- a/themes/next/components/ArticleDetail.js
+++ b/themes/next/components/ArticleDetail.js
@@ -36,10 +36,7 @@ export default function ArticleDetail(props) {
 
   return (
     <div className='shadow md:hover:shadow-2xl overflow-x-auto flex-grow mx-auto w-screen md:w-full '>
-      <div
-        itemScope
-        itemType='https://schema.org/Movie'
-        className='overflow-y-hidden py-10 px-4 lg:pt-24 md:px-24  dark:border-gray-700 bg-white dark:bg-hexo-black-gray'>
+      <div className='overflow-y-hidden py-10 px-4 lg:pt-24 md:px-24  dark:border-gray-700 bg-white dark:bg-hexo-black-gray'>
         {showArticleInfo && (
           <header {...aosProps}>
             {/* 头图 */}


### PR DESCRIPTION
关联 Issue：Fixes #3231

## 已知问题

多个主题仍在文章容器上声明 `schema.org/Movie` 或孤立的 `itemScope`，与公共 SEO 组件生成的 `BlogPosting` JSON-LD 冲突。

## 解决方案

- 移除 Commerce、Fukasawa、Heo、Hexo、Matery、NexT 中错误或不完整的主题级 Microdata
- 保留语义化 `<article>` 标签
- 继续由公共 SEO 组件统一生成 `BlogPosting` / `WebSite` JSON-LD
- 为两类结构化数据增加回归测试

## 改动收益

避免搜索引擎收到错误的 Movie 类型或重复结构化数据，并让所有主题使用同一套 SEO 输出。

## 测试确认

- [x] `yarn test __tests__/components/SEO.test.js --runInBand --env=node`
- [x] `schema.org/Movie` / `itemScope` 残留检查通过
- [x] 相关文件 ESLint 无新增错误（Hexo、Matery 各有一条既有 Hook 依赖警告）
- [x] 不适用（无用户文档改动）
- [ ] 生产环境构建测试（改动为结构化元数据清理和纯函数测试）