### PR TITLE
Hexo主题下，首页文章卡片相关UI improvement

### DIFF
--- a/themes/hexo/components/BlogPostCard.js
+++ b/themes/hexo/components/BlogPostCard.js
@@ -31,7 +31,7 @@ const BlogPostCard = ({ index, post, showSummary, siteInfo }) => {
         data-aos-once='false'
         data-aos-anchor-placement='top-bottom'
         id='blog-post-card'
-        className={`group md:h-56 w-full flex justify-between md:flex-row flex-col-reverse ${siteConfig('HEXO_POST_LIST_IMG_CROSSOVER', null, CONFIG) && index % 2 === 1 ? 'md:flex-row-reverse' : ''}
+        className={`group md:h-56 w-full flex justify-between md:flex-row flex-col-reverse shadow-sm ${siteConfig('HEXO_POST_LIST_IMG_CROSSOVER', null, CONFIG) && index % 2 === 1 ? 'md:flex-row-reverse' : ''}
                     overflow-hidden border dark:border-black rounded-xl bg-white dark:bg-hexo-black-gray`}>
         {/* 文字内容 */}
         <BlogPostCardInfo

--- a/themes/hexo/components/BlogPostCardInfo.js
+++ b/themes/hexo/components/BlogPostCardInfo.js
@@ -19,7 +19,7 @@ export const BlogPostCardInfo = ({
 }) => {
   return (
     <article
-      className={`flex flex-col justify-between lg:p-6 p-4  ${showPageCover && !showPreview ? 'md:w-7/12 w-full md:max-h-60' : 'w-full'}`}>
+      className={`flex flex-col justify-between lg:p-8 p-6  ${showPageCover && !showPreview ? 'md:w-7/12 w-full md:max-h-60' : 'w-full'}`}>
       <div>
         <header>
           <h2>
@@ -29,7 +29,7 @@ export const BlogPostCardInfo = ({
               passHref
               className={`line-clamp-2 replace cursor-pointer text-2xl ${
                 showPreview ? 'text-center' : ''
-              } leading-tight font-normal text-gray-600 dark:text-gray-100 hover:text-indigo-700 dark:hover:text-indigo-400`}>
+              } leading-tight font-bold text-gray-600 dark:text-gray-100 hover:text-indigo-700 dark:hover:text-indigo-400`}>
               {siteConfig('POST_TITLE_ICON') && (
                 <NotionIcon icon={post.pageIcon} />
               )}
@@ -61,14 +61,14 @@ export const BlogPostCardInfo = ({
 
         {/* 摘要 */}
         {(!showPreview || showSummary) && !post.results && (
-          <main className='line-clamp-2 replace my-3 text-gray-700  dark:text-gray-300 text-sm font-light leading-7'>
+          <main className='line-clamp-2 replace my-3 text-gray-700  dark:text-gray-300 text-md font-normal'>
             {post.summary}
           </main>
         )}
 
         {/* 搜索结果 */}
         {post.results && (
-          <p className='line-clamp-2 mt-4 text-gray-700 dark:text-gray-300 text-sm font-light leading-7'>
+          <p className='line-clamp-2 mt-4 text-gray-700 dark:text-gray-300 text-sm font-light'>
             {post.results.map((r, index) => (
               <span key={index}>{r}</span>
             ))}

--- a/themes/hexo/components/BlogPostCardInfo.js
+++ b/themes/hexo/components/BlogPostCardInfo.js
@@ -19,7 +19,7 @@ export const BlogPostCardInfo = ({
 }) => {
   return (
     <article
-      className={`flex flex-col justify-between lg:p-8 p-6  ${showPageCover && !showPreview ? 'md:w-7/12 w-full md:max-h-60' : 'w-full'}`}>
+      className={`flex flex-col justify-between lg:p-6 p-4 lg:px-8 px-6 ${showPageCover && !showPreview ? 'md:w-7/12 w-full md:max-h-60' : 'w-full'}`}>
       <div>
         <header>
           <h2>

--- a/themes/hexo/components/Hero.js
+++ b/themes/hexo/components/Hero.js
@@ -18,7 +18,8 @@ const Hero = props => {
   const { siteInfo } = props
   const { locale } = useGlobal()
   const scrollToWrapper = () => {
-    window.scrollTo({ top: wrapperTop, behavior: 'smooth' })
+    const rem = parseFloat(getComputedStyle(document.documentElement).fontSize)
+    window.scrollTo({ top: wrapperTop - 2 * rem, behavior: 'smooth' })
   }
 
   const GREETING_WORDS = siteConfig('GREETING_WORDS').split(',')

--- a/themes/hexo/index.js
+++ b/themes/hexo/index.js
@@ -121,7 +121,7 @@ const LayoutBase = props => {
         {/* 主区块 */}
         <main
           id='wrapper'
-          className={`${siteConfig('HEXO_HOME_BANNER_ENABLE', null, CONFIG) ? '' : 'pt-16'} bg-hexo-background-gray dark:bg-black w-full py-8 md:px-8 lg:px-24 min-h-screen relative`}>
+          className={`${siteConfig('HEXO_HOME_BANNER_ENABLE', null, CONFIG) ? 'pt-0' : 'pt-16'} bg-hexo-background-gray dark:bg-black w-full md:px-8 lg:px-24 min-h-screen relative`}>
           <div
             id='container-inner'
             className={


### PR DESCRIPTION
## 已知问题

Hexo 主页面
1. 页面没有视觉重点， 文章卡片内容不够突出
2. 整个主区块的 y-padding 多余，导致上下不够紧凑

## 解决方案

1. 轻微增加字重字号
3. 轻微增加卡片阴影
4. 调整行间距
5. 调整 padding

## 改动收益

略微提升UI 效果：
1. 页面中文字内容更加突出
2. 文字更加紧凑整齐
3. 页面更加紧凑

## 具体改动

1. 轻微调整卡片字重字号行间距
3. 轻微增加卡片阴影
4. 调整卡片文字左右 padding
5. 调整主区块 `<main id='wrapper' />` 的top bottom padding
6. 调整滚动按钮的 scrollTo 位置。

见截图（顺序 改动前 vs 改动后)

### 整体效果
<img width="2367" height="1687" alt="Screenshot 2026-07-17 234137_compressed" src="https://github.com/user-attachments/assets/2799ed18-de98-4a57-9831-5da5056c89c5" />
<img width="2388" height="1689" alt="image" src="https://github.com/user-attachments/assets/6fb8678a-4bb5-4287-97fc-6d41717ff435" />


### 卡片
<img width="1462" height="539" alt="image" src="https://github.com/user-attachments/assets/3b29f402-76e0-43f2-92f0-74465ddabf6a" />
<img width="1449" height="540" alt="image" src="https://github.com/user-attachments/assets/fad6e76f-f7bf-40a9-882d-935194a9c3ae" />


### padding 部分，未改动取消 Hexo banner 时的padding；未影响主区块内部元素 layout
改动前 padding-top
<img width="1426" height="500" alt="image" src="https://github.com/user-attachments/assets/d217410f-9ef7-417e-b22f-6b0f44b3e008" />
改动后 padding-top
<img width="1418" height="488" alt="image" src="https://github.com/user-attachments/assets/ec061977-40c2-4463-9a9d-8ad3c8764971" />

改动前 padding-bottom
<img width="1998" height="618" alt="image" src="https://github.com/user-attachments/assets/88c9baf7-5438-44f7-9565-6d7c338328f0" />
改动后 padding-bottom
<img width="1991" height="528" alt="image" src="https://github.com/user-attachments/assets/d89a8f0a-f14d-4339-a523-65c1e804fb8a" />


## 测试确认
- [X] 改动范围只有 Hexo 主页 
- [X] 本地开发环境测试通过
- [X] 生产环境构建测试通过
- [ ] （如适用）版本号正确显示
- [ ] （如适用）环境变量配置正常工作

## 用户文档（`docs/user-guide/`）

若本 PR **未** 修改 `docs/user-guide/`、`docs/developer/` 中与站长相关的说明，可勾选「不适用」并跳过本节。

- [x] 不适用（无文档改动）
- [ ] 已按 [维护工作流](https://github.com/notionnext-org/NotionNext/blob/main/docs/user-guide/MAINTENANCE_WORKFLOW.md) 自检
- [ ] 路径符合 `docs/user-guide/` 目录约定
- [ ] 已更新 [user-guide/README.md](https://github.com/notionnext-org/NotionNext/blob/main/docs/user-guide/README.md)（新增/移动文章时）
- [ ] 已更新 [ARTICLE_INDEX.md](https://github.com/notionnext-org/NotionNext/blob/main/docs/user-guide/ARTICLE_INDEX.md)（新 slug 或路径变更时）
- [ ] 环境变量名与 `conf/*.config.js` 一致（若文档涉及配置）
- [ ] 示例中无真实 Token、`.env`、私有 ID
- [ ] 保留或更新了「原文链接」（若源自 docs.tangly1024.com）

文档说明（可选）：对应官方 slug / URL、是否与功能 PR 配套
