### PR TITLE
fix: harden theme console and docs deploy

### DIFF
--- a/.github/workflows/deploy-docs-site.yml
+++ b/.github/workflows/deploy-docs-site.yml
@@ -60,4 +60,5 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          wranglerVersion: "4"
           command: pages deploy .vitepress/dist --project-name=${{ env.CF_PAGES_PROJECT }}

--- a/components/ThemeSwitch.js
+++ b/components/ThemeSwitch.js
@@ -4,7 +4,7 @@ import { useGlobal } from '@/lib/global'
 import { getQueryParam } from '@/lib/utils'
 import { THEMES } from '@/themes/theme'
 import { useRouter } from 'next/router'
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { Draggable } from './Draggable'
 import { Moon, Sun } from './HeroIcons'
 import LazyImage from './LazyImage'
@@ -87,6 +87,7 @@ function PaletteField ({ item, value, copyValue, isHexColor, updateItem, resetIt
 
 function ThemeConsole ({ meta, onClose }) {
   const { updateRuntimeConfigOverride, THEME_CONFIG } = useGlobal()
+  const noticeTimerRef = useRef(null)
   const [values, setValues] = useState({})
   const [palette, setPalette] = useState([])
   const [settingValues, setSettingValues] = useState({})
@@ -100,9 +101,11 @@ function ThemeConsole ({ meta, onClose }) {
   const rootId = meta.rootId || `theme-${meta.id}`
 
   const formatConfigValue = value => {
-    const text = String(value).trim()
     if (typeof value === 'boolean') return value ? 'true' : 'false'
-    return /^-?\d+(\.\d+)?$/.test(text) ? text : `'${text}'`
+    const text = String(value).trim()
+    return /^-?\d+(\.\d+)?$/.test(text)
+      ? text
+      : `'${text.replace(/\\/g, '\\\\').replace(/'/g, "\\'")}'`
   }
 
   const readSettingValue = item => siteConfig(item.key, item.defaultValue, THEME_CONFIG || {})
@@ -146,7 +149,7 @@ function ThemeConsole ({ meta, onClose }) {
   }
 
   const getExportValue = item => {
-    const value = values[item.key] || item.defaultValue
+    const value = values[item.key] ?? item.defaultValue
     if (item.key === 'FUWARI_THEME_COLOR_HUE') return hexToHue(value)
     return value
   }
@@ -171,6 +174,8 @@ function ThemeConsole ({ meta, onClose }) {
     setPalette(declaredPalette)
     setValues(nextValues)
   }, [meta.id, meta.rootId, declaredPalette])
+
+  useEffect(() => () => window.clearTimeout(noticeTimerRef.current), [])
 
   if (!declaredPalette.length && !settings.length) return null
 
@@ -221,8 +226,8 @@ function ThemeConsole ({ meta, onClose }) {
 
   const showNotice = text => {
     setNotice(text)
-    window.clearTimeout(showNotice.timer)
-    showNotice.timer = window.setTimeout(() => setNotice(''), 1800)
+    window.clearTimeout(noticeTimerRef.current)
+    noticeTimerRef.current = window.setTimeout(() => setNotice(''), 1800)
   }
 
   const copyText = async (text, message = '配置已复制到剪贴板') => {


### PR DESCRIPTION
## Summary

- keep theme console import/export interactions from becoming silent failures
- pin Wrangler v4 for VitePress docs deployment so the 4.10.7 docs can publish correctly

## Verification

- `yarn docs:site:build`
- `git diff --check -- .github/workflows/deploy-docs-site.yml`
- checked built docs output no longer contains `4.10.6` in changelog/theme catalog pages
