### PR TITLE
fix: sort collection date properties

### DIFF
--- a/__tests__/lib/notion-data-format.test.js
+++ b/__tests__/lib/notion-data-format.test.js
@@ -967,6 +967,145 @@ describe('Notion data format compatibility', () => {
     ])
   })
 
+  it('sorts embedded collection results from query2 date sorts', () => {
+    const blockMap = {
+      block: {
+        later_page: {
+          value: {
+            id: 'later_page',
+            type: 'page',
+            properties: {
+              date: [['‣', [['d', { start_date: '2026-07-18' }]]]]
+            }
+          }
+        },
+        earlier_page: {
+          value: {
+            id: 'earlier_page',
+            type: 'page',
+            properties: {
+              date: [['‣', [['d', { start_date: '2026-07-01' }]]]]
+            }
+          }
+        }
+      },
+      collection: {
+        collection_1: {
+          value: {
+            schema: {
+              date: { name: 'Date', type: 'date' }
+            }
+          }
+        }
+      },
+      collection_view: {
+        view_1: {
+          value: {
+            value: {
+              id: 'view_1',
+              page_sort: ['later_page', 'earlier_page'],
+              format: {
+                collection_pointer: { id: 'collection_1' }
+              },
+              query2: {
+                sort: [{ property: 'Date', direction: 'ascending' }]
+              }
+            }
+          }
+        }
+      },
+      collection_query: {
+        collection_1: {
+          view_1: {
+            collection_group_results: {
+              blockIds: ['later_page', 'earlier_page']
+            }
+          }
+        }
+      }
+    }
+
+    filterCollectionViewData(blockMap)
+
+    expect(
+      blockMap.collection_query.collection_1.view_1.collection_group_results
+        .blockIds
+    ).toEqual(['earlier_page', 'later_page'])
+    expect(blockMap.collection_view.view_1.value.value.page_sort).toEqual([
+      'earlier_page',
+      'later_page'
+    ])
+  })
+
+  it('sorts embedded collection date results by time on the same day', () => {
+    const blockMap = {
+      block: {
+        evening_page: {
+          value: {
+            id: 'evening_page',
+            type: 'page',
+            properties: {
+              date: [
+                ['‣', [['d', { start_date: '2026-07-18', start_time: '18:00' }]]]
+              ]
+            }
+          }
+        },
+        morning_page: {
+          value: {
+            id: 'morning_page',
+            type: 'page',
+            properties: {
+              date: [
+                ['‣', [['d', { start_date: '2026-07-18', start_time: '09:00' }]]]
+              ]
+            }
+          }
+        }
+      },
+      collection: {
+        collection_1: {
+          value: {
+            schema: {
+              date: { name: 'Date', type: 'date' }
+            }
+          }
+        }
+      },
+      collection_view: {
+        view_1: {
+          value: {
+            value: {
+              id: 'view_1',
+              format: {
+                collection_pointer: { id: 'collection_1' }
+              },
+              query2: {
+                sort: [{ property: 'date', direction: 'ascending' }]
+              }
+            }
+          }
+        }
+      },
+      collection_query: {
+        collection_1: {
+          view_1: {
+            collection_group_results: {
+              blockIds: ['evening_page', 'morning_page']
+            }
+          }
+        }
+      }
+    }
+
+    filterCollectionViewData(blockMap)
+
+    expect(
+      blockMap.collection_query.collection_1.view_1.collection_group_results
+        .blockIds
+    ).toEqual(['morning_page', 'evening_page'])
+  })
+
   it('inherits sibling filters for embedded collection views without filters', () => {
     const blockMap = {
       block: {

--- a/lib/db/notion/filterCollectionViewData.js
+++ b/lib/db/notion/filterCollectionViewData.js
@@ -253,10 +253,12 @@ function getSchemaPropertyId(schema, property) {
 }
 
 function getSortValue(block, propertyId, propertySchema) {
-  return expandPropertyValues(
-    getPropertyValues(block?.properties?.[propertyId]),
-    propertySchema
-  )[0]
+  const values = getPropertyValues(block?.properties?.[propertyId])
+  if (propertySchema?.type === 'date') {
+    return values.map(normalizeDateTime).find(Boolean)
+  }
+
+  return expandPropertyValues(values, propertySchema)[0]
 }
 
 function comparePropertyValues(left, right, propertySchema) {
@@ -276,7 +278,7 @@ function comparePropertyValues(left, right, propertySchema) {
   }
 
   if (propertySchema?.type === 'date') {
-    return normalizeDate(left).localeCompare(normalizeDate(right))
+    return normalizeDateTime(left).localeCompare(normalizeDateTime(right))
   }
 
   return String(left).localeCompare(String(right), undefined, {
@@ -374,6 +376,10 @@ function getPropertyValues(property) {
 
     item?.[1]?.forEach(decoration => {
       const metadata = decoration?.[1]
+      if (metadata?.start_date && metadata?.start_time) {
+        values.push(`${metadata.start_date} ${metadata.start_time}`)
+      }
+
       ;[
         metadata?.id,
         metadata?.page_id,
@@ -407,6 +413,11 @@ function getExpectedValues(value, propertySchema) {
 }
 
 function expandPropertyValues(values, propertySchema) {
+  if (propertySchema?.type === 'date') {
+    const dates = values.map(normalizeDate).filter(Boolean)
+    return dates.length > 0 ? [...new Set(dates)] : values
+  }
+
   if (propertySchema?.type === 'multi_select') {
     return [
       ...new Set(
@@ -461,7 +472,17 @@ function toNumber(value) {
 
 function normalizeDate(value) {
   if (!value) return ''
-  return String(value).slice(0, 10)
+  return String(value).match(/\d{4}-\d{2}-\d{2}/)?.[0] || ''
+}
+
+function normalizeDateTime(value) {
+  if (!value) return ''
+  const text = String(value)
+  const date = normalizeDate(text)
+  const time = text.match(/(\d{1,2}):(\d{2})(?::(\d{2}))?/)
+  return date && time
+    ? `${date}T${time[1].padStart(2, '0')}:${time[2]}:${time[3] || '00'}`
+    : date
 }
 
 function getRecordById(record, id) {


### PR DESCRIPTION
## Summary
- normalize Notion date property values before collection sorting
- keep the existing collection view sorting path instead of adding gallery-specific logic
- add a regression test for rich-text date tokens with placeholder text

## Root cause
Date properties can include a placeholder token before the real start_date metadata. The sorter read the first expanded value, so date comparisons were equal and the original block order was preserved.

## Test
- NODE_PATH=E:\Workspace\NotionNext\node_modules E:\Workspace\NotionNext\node_modules\.bin\jest.cmd __tests__/lib/notion-data-format.test.js --runInBand

Closes #4288