### PR TITLE
fix(heo): prevent music player from overlapping footer

### DIFF
--- a/themes/heo/components/Footer.js
+++ b/themes/heo/components/Footer.js
@@ -11,6 +11,8 @@ const Footer = () => {
   const BEI_AN = siteConfig('BEI_AN')
   const BEI_AN_LINK = siteConfig('BEI_AN_LINK')
   const BIO = siteConfig('BIO')
+  const reserveMusicPlayerSpace =
+    siteConfig('MUSIC_PLAYER') && siteConfig('MUSIC_PLAYER_VISIBLE')
   return (
     <footer className='relative flex-shrink-0 bg-[var(--heo-color-card)] dark:bg-[var(--heo-color-bg-dark)] justify-center text-center m-auto w-full leading-6  text-gray-600 dark:text-gray-100 text-sm'>
       {/* 颜色过度区 */}
@@ -29,14 +31,19 @@ const Footer = () => {
       {/* 底部页面信息 */}
       <div
         id='footer-bottom'
-        className='w-full h-20 flex flex-col p-3 lg:flex-row justify-between px-6 items-center bg-[#f1f3f7] dark:bg-[#21232A] border-t dark:border-t-[#3D3D3F]'>
+        className='w-full min-h-20 flex flex-col p-3 lg:flex-row justify-between px-6 items-center bg-[#f1f3f7] dark:bg-[#21232A] border-t dark:border-t-[#3D3D3F]'
+        style={{
+          paddingBottom: reserveMusicPlayerSpace ? '5rem' : undefined
+        }}
+      >
         <div id='footer-bottom-left' className='text-center lg:text-start'>
           <PoweredBy />
           <div className='flex gap-x-1'>
             <CopyRightDate />
             <a
               href={'/about'}
-              className='underline font-semibold dark:text-gray-300 '>
+              className='underline font-semibold dark:text-gray-300 '
+            >
               {siteConfig('AUTHOR')}
             </a>
             {BIO && <span className='mx-1'> | {BIO}</span>}

--- a/themes/heo/components/Footer.js
+++ b/themes/heo/components/Footer.js
@@ -31,10 +31,9 @@ const Footer = () => {
       {/* 底部页面信息 */}
       <div
         id='footer-bottom'
-        className='w-full min-h-20 flex flex-col p-3 lg:flex-row justify-between px-6 items-center bg-[#f1f3f7] dark:bg-[#21232A] border-t dark:border-t-[#3D3D3F]'
-        style={{
-          paddingBottom: reserveMusicPlayerSpace ? '5rem' : undefined
-        }}
+        className={`w-full min-h-20 flex flex-col p-3 lg:flex-row justify-between px-6 items-center bg-[#f1f3f7] dark:bg-[#21232A] border-t dark:border-t-[#3D3D3F] ${
+          reserveMusicPlayerSpace ? 'pb-20' : ''
+        }`}
       >
         <div id='footer-bottom-left' className='text-center lg:text-start'>
           <PoweredBy />


### PR DESCRIPTION
## 已知问题

HEO 主题开启音乐播放器后，播放器使用固定定位显示在页面底部。

`footer-bottom` 原先使用固定高度 `h-20`，没有为播放器预留空间。当页面滚动到底部时，播放器会遮挡 Footer 中的版权、作者和版本信息。

Fixes #4289

## 解决方案

1. 根据 `MUSIC_PLAYER` 和 `MUSIC_PLAYER_VISIBLE` 判断播放器是否启用并显示。
2. 将 Footer 的固定高度 `h-20` 调整为最小高度 `min-h-20`，允许 Footer 根据内容自然增高。
3. 播放器显示时，为 Footer 增加 `5rem` 的底部内边距，为固定播放器预留显示空间。
4. 播放器未显示时不增加额外底部空间。

## 改动收益

- 避免音乐播放器遮挡 Footer 信息。
- 播放器关闭时不会产生多余空白。
- 支持 Footer 内容换行和自然增高。

## 具体改动

### `themes/heo/components/Footer.js`

- 新增音乐播放器显示状态判断。
- 将 `h-20` 修改为 `min-h-20`。
- 根据播放器状态动态设置 Footer 的 `padding-bottom`。

## 测试确认

- [x] HEO 主题本地开发环境测试通过
- [x] 音乐播放器展开时 Footer 信息未被遮挡
- [x] 音乐播放器收起时 Footer 显示正常
- [x] 音乐播放器关闭时没有多余底部空白
- [x] `git diff --check` 通过
- [x] `yarn lint` 通过
- [x] `yarn type-check` 通过
- [x] `yarn build` 通过

## 修复前

<img width="423" height="129" alt="修复前" src="https://github.com/user-attachments/assets/12b63512-6975-43ea-9ca9-32f2996615d1" />

## 修复后

<img width="941" height="177" alt="修复后-开启音乐播放器时" src="https://github.com/user-attachments/assets/99485166-4013-4141-8f91-5bb59690aa28" />

<img width="924" height="332" alt="修复后-关闭音乐播放器时" src="https://github.com/user-attachments/assets/37dd8a81-6f0a-4acf-a0e2-4e1690de5c97" />


## 用户文档（`docs/user-guide/`）

- [x] 不适用（无文档改动）