### PR TITLE
fix(heo): make info card avatar blur configurable

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -35,9 +35,11 @@
 - [ ] （如适用）版本号正确显示
 - [ ] （如适用）环境变量配置正常工作
 
-## 用户文档（`docs/user-guide/`）
+## 用户文档（`docs/user-guide/` / `docs/developer/`）
 
-若本 PR **未** 修改 `docs/user-guide/`、`docs/developer/` 中与站长相关的说明，可勾选「不适用」并跳过本节。
+如果本 PR 新增或修改了站长会使用的功能、主题配置、环境变量、Notion Config 键、插件开关、部署步骤、默认行为或可见 UI 交互，请同步更新 `docs/user-guide/` 或 `docs/developer/` 中对应说明，并在下方勾选已完成项。
+
+只有纯内部重构、测试、CI、依赖维护、拼写修正等不改变站长使用方式的改动，才可以勾选「不适用」。
 
 - [ ] 不适用（无文档改动）
 - [ ] 已按 [维护工作流](https://github.com/notionnext-org/NotionNext/blob/main/docs/user-guide/MAINTENANCE_WORKFLOW.md) 自检

--- a/__tests__/themes/heo/InfoCard.test.js
+++ b/__tests__/themes/heo/InfoCard.test.js
@@ -1,4 +1,7 @@
-import { normalizeInfoCardGreetings } from '@/themes/heo/components/InfoCard'
+import {
+  normalizeInfoCardGreetings,
+  shouldUseInfoCardBlurAvatar
+} from '@/themes/heo/components/InfoCard'
 
 describe('heo InfoCard greetings', () => {
   it('keeps configured greeting arrays intact', () => {
@@ -19,5 +22,16 @@ describe('heo InfoCard greetings', () => {
 
   it('treats a plain string as a single greeting', () => {
     expect(normalizeInfoCardGreetings('Hello')).toEqual(['Hello'])
+  })
+})
+
+describe('heo InfoCard avatar blur', () => {
+  it('uses the decorative blur avatar only on slug pages when enabled', () => {
+    expect(shouldUseInfoCardBlurAvatar(true, true)).toBe(true)
+  })
+
+  it('keeps the normal avatar when the option is disabled', () => {
+    expect(shouldUseInfoCardBlurAvatar(true, false)).toBe(false)
+    expect(shouldUseInfoCardBlurAvatar(false, true)).toBe(false)
   })
 })

--- a/docs/developer/CONFIGURATION.en.md
+++ b/docs/developer/CONFIGURATION.en.md
@@ -41,3 +41,5 @@ At minimum update:
 - comment in config file
 - docs or PR description usage notes
 
+Theme-level configs follow the same rule. When adding a `themes/<theme>/config.js` key, update `docs/user-guide/themes/<theme>.md` with the default value, enabled/disabled behavior, and whether Notion Config or environment variables can override it. Do not mark user-visible config changes as "docs not applicable".
+

--- a/docs/developer/CONFIGURATION.md
+++ b/docs/developer/CONFIGURATION.md
@@ -41,3 +41,5 @@
 - `conf/*.config.js` 注释
 - 本目录文档或 PR 描述中的使用说明
 
+主题级配置也遵守同一原则。新增 `themes/<theme>/config.js` 配置项时，请同步更新 `docs/user-guide/themes/<theme>.md`，说明默认值、开启/关闭效果，以及是否支持 Notion Config 或环境变量覆盖。不要把用户可见配置标记为“文档不适用”。
+

--- a/docs/user-guide/development/notion-next-develop-with-ai.md
+++ b/docs/user-guide/development/notion-next-develop-with-ai.md
@@ -153,6 +153,21 @@ firebase会自动分配一个临时网址用于访问调试页面。
 
 ## 保存代码
 
+### 让 AI 同步更新文档
+
+AI 修改代码时，不要只让它改组件或配置文件。凡是新增或修改了站长会使用的功能，都要让 AI 一起检查并更新文档，尤其是：
+
+- 新增 `themes/<theme>/config.js` 配置项；
+- 新增环境变量、Notion Config 配置项或插件开关；
+- 改变部署、构建、缓存、评论、统计、广告等使用方式；
+- 修改主题的外观、交互或默认行为，并且站长需要知道如何开启、关闭或迁移。
+
+可以直接把下面这段话发给 AI：
+
+> 请先判断这次改动是否影响站长使用方式。如果新增或修改了用户可见配置、环境变量、Notion Config 键、主题行为或部署步骤，请同步更新 `docs/user-guide/` 或 `docs/developer/` 中对应文档；不要在 PR 描述中勾选“用户文档不适用”，除非本次改动确实只是内部重构或测试。
+
+例如修改 HEO 主题配置时，优先检查 `docs/user-guide/themes/heo.md`；修改全站配置时，优先检查 `docs/user-guide/config-site.md`、`docs/user-guide/reference/features.md` 和 `docs/developer/CONFIGURATION.md`。
+
 所有的代码需要提交到git仓库才能被保存，这里涉及到git的使用操作，git本身是为大型多人团队协作设计、其功能强大，需要一定的学习。我这里做一个最简单的提交代码的演示。
 
 点击左侧的Source Control图标

--- a/docs/user-guide/development/notionnext-how-to-pr.md
+++ b/docs/user-guide/development/notionnext-how-to-pr.md
@@ -39,6 +39,19 @@
 
 1. 从fork中的分支[创建](https://github.com/tangly1024/NotionNext/compare)到NotionNext的`main`分支的[PR](https://github.com/tangly1024/NotionNext/compare)。
 
+### 4. 提交 PR 前检查用户文档
+
+如果 PR 新增或修改了站长能使用的功能、主题配置、环境变量、Notion Config 配置项、部署步骤或插件开关，请同步更新 `docs/user-guide/` 或 `docs/developer/` 中对应说明。
+
+不要在这类 PR 中勾选“用户文档不适用”。只有纯内部重构、测试修正、依赖维护、拼写修正，且不会改变站长使用方式时，才可以标记为不适用。
+
+常见位置：
+
+- 主题配置：`docs/user-guide/themes/<theme>.md`
+- 全站配置：`docs/user-guide/config-site.md` 或 `docs/user-guide/reference/features.md`
+- 开发者约定：`docs/developer/`
+- 文档维护流程：`docs/user-guide/maintain-docs.md`
+
 ## 原文链接
 
 https://docs.tangly1024.com/article/notionnext-how-to-pr

--- a/docs/user-guide/maintain-docs.md
+++ b/docs/user-guide/maintain-docs.md
@@ -27,6 +27,12 @@
 3. 本地预览：`yarn docs:site:dev`。  
 4. 提交 PR，合并 **`main`** 后由 GitHub Actions 部署。  
 
+## 代码 PR 也要检查文档
+
+代码改动只要影响站长使用方式，就应该同步更新文档。常见场景包括新增或修改主题配置、环境变量、Notion Config 键、插件开关、部署步骤、默认行为和可见 UI 交互。
+
+PR 模板中的“用户文档不适用”只适合内部重构、测试、CI、依赖维护、拼写修正等不改变使用方式的改动。新增用户可配置项时，请至少补充对应主题或配置文档，并在 PR 描述里说明文档位置。
+
 详细检查清单：[MAINTENANCE_WORKFLOW.md](./MAINTENANCE_WORKFLOW.md) · 策略：[DOCUMENTATION_POLICY.md](../DOCUMENTATION_POLICY.md)
 
 ## 部署原理（简述）

--- a/docs/user-guide/themes/heo.md
+++ b/docs/user-guide/themes/heo.md
@@ -224,6 +224,8 @@ INFOCARD_GREETINGS: [
     '🧱 团队小组发动机'
   ],
 ```
+`HEO_INFO_CARD_AVATAR_BLUR` 用于控制文章详情页右侧信息卡头像样式。默认值为 `true`，保留原有的大尺寸模糊装饰头像；设置为 `false` 时，文章页头像会与首页信息卡保持一致，显示为普通小头像。
+
 下方的 Tangly是显示作者名字，在blog.config.js中配置
   1. **公告栏**， 卡牌中间的文字是公告内容
 ![Untitled](/legacy/ad1cf348d91ede21.png)

--- a/themes/heo/components/InfoCard.js
+++ b/themes/heo/components/InfoCard.js
@@ -38,6 +38,10 @@ export function normalizeInfoCardGreetings(value) {
   return [trimmed]
 }
 
+export function shouldUseInfoCardBlurAvatar(isSlugPage, avatarBlurEnabled) {
+  return Boolean(isSlugPage && avatarBlurEnabled)
+}
+
 /**
  * 社交信息卡
  * @param {*} props
@@ -52,6 +56,15 @@ export function InfoCard(props) {
   const icon1 = siteConfig('HEO_INFO_CARD_ICON1', null, CONFIG)
   const url2 = siteConfig('HEO_INFO_CARD_URL2', null, CONFIG)
   const icon2 = siteConfig('HEO_INFO_CARD_ICON2', null, CONFIG)
+  const avatarBlurEnabled = siteConfig(
+    'HEO_INFO_CARD_AVATAR_BLUR',
+    false,
+    CONFIG
+  )
+  const useBlurAvatar = shouldUseInfoCardBlurAvatar(
+    isSlugPage,
+    avatarBlurEnabled
+  )
   return (
     <Card className='wow fadeInUp bg-[var(--heo-color-primary)] dark:bg-[var(--heo-color-accent)] text-[var(--heo-color-primary-text)] flex flex-col w-72 overflow-hidden relative'>
       {/* 信息卡牌第一行 */}
@@ -60,12 +73,16 @@ export function InfoCard(props) {
         <GreetingsWords />
         {/* 头像 */}
         <div
-          className={`${isSlugPage ? 'absolute right-0 -mt-8 -mr-6 hover:opacity-0 hover:scale-150 blur' : 'cursor-pointer'} justify-center items-center flex dark:text-gray-100 transform transitaion-all duration-200`}>
+          className={`${
+            useBlurAvatar
+              ? 'absolute right-0 -mt-8 -mr-6 hover:opacity-0 hover:scale-150 blur'
+              : 'cursor-pointer'
+          } justify-center items-center flex dark:text-gray-100 transform transition-all duration-200`}>
           <LazyImage
             src={siteInfo?.icon}
             className='rounded-full'
-            width={isSlugPage ? 100 : 28}
-            height={isSlugPage ? 100 : 28}
+            width={useBlurAvatar ? 100 : 28}
+            height={useBlurAvatar ? 100 : 28}
             alt={siteConfig('AUTHOR')}
           />
         </div>

--- a/themes/heo/config.js
+++ b/themes/heo/config.js
@@ -4,6 +4,8 @@ const CONFIG = {
 
   HEO_HOME_BANNER_ENABLE: true,
 
+  HEO_INFO_CARD_AVATAR_BLUR: true, // 文章详情页个人资料卡头像样式。true：显示为模糊装饰头像；false：与首页头像保持一致
+
   HEO_COLOR_PRIMARY: '#4f65f0',
   HEO_COLOR_PRIMARY_HOVER: '#4f46e5',
   HEO_COLOR_PRIMARY_TEXT: '#ffffff',


### PR DESCRIPTION
## 已知问题

HEO 主题文章详情页的个人信息卡头像样式被写死
  - 文章页头像会强制使用大尺寸和模糊效果
  - 鼠标悬停时还会触发透明和放大效果
  - 文章页的头像显示方式与首页不一致
  - 用户无法根据自己的需求选择模糊显示或正常显示

Fixes #3518

## 解决方案

1. 新增 `HEO_INFO_CARD_AVATAR_BLUR` 主题配置
   - 设置为 `false` 时，文章页头像与首页保持一致，使用正常显示效果
   - 设置为 `true` 时，保留原有的大尺寸模糊装饰效果
   - 默认设置为 `true`

2. 根据页面类型和用户配置决定头像样式
   - 仅在文章详情页且配置开启时使用模糊头像
   - 首页头像显示逻辑保持不变
   - 关闭配置时，文章页头像尺寸和样式与首页一致

## 改动收益

1. “修复 HEO 主题文章页头像显示异常” Issue

2. 提供更灵活的主题配置

## 具体改动

1. `themes/heo/config.js`
   - 新增 `HEO_INFO_CARD_AVATAR_BLUR` 配置
   - 默认值设置为 `true`
   - 添加配置用途以及可选值说明

2. `themes/heo/components/InfoCard.js`
   - 读取 `HEO_INFO_CARD_AVATAR_BLUR` 配置
   - 根据当前页面和配置计算是否启用模糊头像
   - 开启配置时保留原有的大尺寸模糊效果
   - 关闭配置时使用与首页一致的头像尺寸和样式
   - 修正 `transitaion-all` 为 `transition-all`

## 测试确认

- [x] 本地开发环境测试通过
- [x] 生产环境构建测试通过
- [x] 首页个人信息卡头像正常显示
- [x] 文章页在配置为 `false` 时正常显示头像
- [x] 文章页在配置为 `true` 时显示原有模糊头像
- [x] 切换配置后头像尺寸和样式正确生效
- [x] HEO 主题个人信息卡的其他内容显示正常

## 用户文档（`docs/user-guide/`）

若本 PR **未** 修改 `docs/user-guide/`、`docs/developer/` 中与站长相关的说明，可勾选「不适用」并跳过本节。

- [x] 不适用（无文档改动）