### PR TITLE
样式：修复菜单中下拉按钮的位置

### DIFF
--- a/themes/commerce/components/MenuItemDrop.js
+++ b/themes/commerce/components/MenuItemDrop.js
@@ -27,7 +27,6 @@ export const MenuItemDrop = ({ link }) => {
           target={link?.target}
           className={`${selected && 'border-b-2 border-[#D2232A]'} h-full flex space-x-1 whitespace-nowrap items-center font-sans menu-link pl-2 pr-4  dark:text-gray-200 no-underline tracking-widest pb-1`}>
           {link?.icon && <i className={link?.icon} />} <div>{link?.name}</div>
-          {/* {hasSubMenu && <i className='px-2 fa fa-angle-down'></i>} */}
         </SmartLink>
       )}
 

--- a/themes/example/components/MenuItemDrop.js
+++ b/themes/example/components/MenuItemDrop.js
@@ -19,7 +19,6 @@ export const MenuItemDrop = ({ link }) => {
         <div className='rounded px-2 md:pl-0 md:mr-3 my-4 md:pr-3 text-gray-700 dark:text-gray-200 no-underline md:border-r border-gray-light'>
           <SmartLink href={link?.href} target={link?.target}>
             {link?.icon && <i className={link?.icon} />} {link?.name}
-            {hasSubMenu && <i className='px-2 fa fa-angle-down'></i>}
           </SmartLink>
         </div>
       )}
@@ -28,7 +27,7 @@ export const MenuItemDrop = ({ link }) => {
         <div className='rounded px-2 md:pl-0 md:mr-3 my-4 md:pr-3 text-gray-700 dark:text-gray-200 no-underline md:border-r border-gray-light'>
           {link?.icon && <i className={link?.icon} />} {link?.name}
           <i
-            className={`px-2 fas fa-chevron-down duration-500 transition-all ${show ? ' rotate-180' : ''}`}></i>
+            className={`ml-2 fas fa-chevron-down duration-500 transition-all ${show ? ' rotate-180' : ''}`}></i>
         </div>
       )}
 

--- a/themes/gitbook/components/MenuItemDrop.js
+++ b/themes/gitbook/components/MenuItemDrop.js
@@ -44,7 +44,7 @@ export const MenuItemDrop = ({ link }) => {
               {link?.icon && <i className={link?.icon} />} {link?.name}
               {hasSubMenu && (
                 <i
-                  className={`px-2 fas fa-chevron-down duration-500 transition-all ${show ? ' rotate-180' : ''}`}></i>
+                  className={`ml-2 fas fa-chevron-down duration-500 transition-all ${show ? ' rotate-180' : ''}`}></i>
               )}
             </div>
           </div>

--- a/themes/hexo/components/MenuItemDrop.js
+++ b/themes/hexo/components/MenuItemDrop.js
@@ -23,7 +23,6 @@ export const MenuItemDrop = ({ link }) => {
           target={link?.target}
           className=' menu-link pl-2 pr-4 no-underline tracking-widest block'>
           {link?.icon && <i className={link?.icon} />} {link?.name}
-          {hasSubMenu && <i className='px-2 fa fa-angle-down'></i>}
         </SmartLink>
       )}
 
@@ -32,7 +31,7 @@ export const MenuItemDrop = ({ link }) => {
           <div className='cursor-pointer menu-link pl-2 pr-4 no-underline tracking-widest relative'>
             {link?.icon && <i className={link?.icon} />} {link?.name}
             <i
-              className={`mx-2 fa fa-angle-down duration-300  ${show ? 'rotate-180' : 'rotate-0'}`}></i>
+              className={`ml-2 fa fa-angle-down duration-300  ${show ? 'rotate-180' : 'rotate-0'}`}></i>
             {/* 主菜单下方的安全区域 */}
             {show && (
               <div className='absolute w-full h-3 -bottom-1 left-0 bg-transparent z-30'></div>

--- a/themes/magzine/components/MenuItemDrop.js
+++ b/themes/magzine/components/MenuItemDrop.js
@@ -30,7 +30,7 @@ export const MenuItemDrop = ({ link }) => {
           <div className='items-center flex'>
             {link?.icon && <i className={`${link?.icon} pr-2`} />} {link?.name}
             <i
-              className={`px-1 fas fa-chevron-down duration-500 transition-all ${show ? ' rotate-180' : ''}`}></i>
+              className={`ml-1 fas fa-chevron-down duration-500 transition-all ${show ? ' rotate-180' : ''}`}></i>
           </div>
         </div>
       )}

--- a/themes/matery/components/MenuItemDrop.js
+++ b/themes/matery/components/MenuItemDrop.js
@@ -22,7 +22,6 @@ export const MenuItemDrop = ({ link }) => {
           target={link?.target}
           className=' menu-link pl-2 pr-4  no-underline tracking-widest pb-1'>
           {link?.icon && <i className={link?.icon} />} {link?.name}
-          {hasSubMenu && <i className='px-2 fa fa-angle-down'></i>}
         </SmartLink>
       )}
 
@@ -31,7 +30,7 @@ export const MenuItemDrop = ({ link }) => {
           <div className='cursor-pointer  menu-link pl-2 pr-4  no-underline tracking-widest pb-1 relative'>
             {link?.icon && <i className={link?.icon} />} {link?.name}
             <i
-              className={`px-2 fa fa-angle-down duration-300  ${show ? 'rotate-180' : 'rotate-0'}`}></i>
+              className={`ml-2 fa fa-angle-down duration-300  ${show ? 'rotate-180' : 'rotate-0'}`}></i>
             {/* 主菜单下方的安全区域 */}
             {show && (
               <div className='absolute w-full h-3 -bottom-1 left-0 bg-transparent z-30'></div>

--- a/themes/medium/components/MenuItemDrop.js
+++ b/themes/medium/components/MenuItemDrop.js
@@ -31,7 +31,7 @@ export const MenuItemDrop = ({ link }) => {
             {link?.icon && <i className={link?.icon} />} {link?.name}
             {hasSubMenu && (
               <i
-                className={`px-2 fas fa-chevron-down duration-500 transition-all ${show ? ' rotate-180' : ''}`}></i>
+                className={`ml-2 fas fa-chevron-down duration-500 transition-all ${show ? ' rotate-180' : ''}`}></i>
             )}
           </div>
         </div>

--- a/themes/movie/components/MenuItemDrop.js
+++ b/themes/movie/components/MenuItemDrop.js
@@ -19,7 +19,6 @@ export const MenuItemDrop = ({ link }) => {
           target={link?.target}
           className='select-none menu-link pl-2 pr-4 no-underline tracking-widest pb-1 hover:font-bold'>
           {link?.icon && <i className={link?.icon} />} {link?.name}
-          {hasSubMenu && <i className='px-2 fa fa-angle-down'></i>}
         </SmartLink>
       )}
 
@@ -28,7 +27,7 @@ export const MenuItemDrop = ({ link }) => {
           <div className='cursor-pointer menu-link pl-2 pr-4  no-underline tracking-widest pb-1 hover:font-bold'>
             {link?.icon && <i className={link?.icon} />} {link?.name}
             <i
-              className={`px-2 fa fa-angle-down duration-300  ${show ? 'rotate-180' : 'rotate-0'}`}></i>
+              className={`ml-2 fa fa-angle-down duration-300  ${show ? 'rotate-180' : 'rotate-0'}`}></i>
           </div>
         </>
       )}

--- a/themes/nav/components/MenuItemDrop.js
+++ b/themes/nav/components/MenuItemDrop.js
@@ -31,7 +31,7 @@ export const MenuItemDrop = ({ link }) => {
             {link?.icon && <i className={link?.icon} />} {link?.name}
             {hasSubMenu && (
               <i
-                className={`px-2 fas fa-chevron-down duration-500 transition-all ${show ? ' rotate-180' : ''}`}></i>
+                className={`ml-2 fas fa-chevron-down duration-500 transition-all ${show ? ' rotate-180' : ''}`}></i>
             )}
           </div>
         </div>

--- a/themes/nobelium/components/MenuItemDrop.js
+++ b/themes/nobelium/components/MenuItemDrop.js
@@ -29,7 +29,7 @@ export const MenuItemDrop = ({ link }) => {
           <div className='block text-black dark:text-gray-50 nav'>
             {link?.icon && <i className={link?.icon} />} {link?.name}
             <i
-              className={`px-2 fas fa-chevron-down duration-500 transition-all ${show ? ' rotate-180' : ''}`}></i>
+              className={`ml-2 fas fa-chevron-down duration-500 transition-all ${show ? ' rotate-180' : ''}`}></i>
           </div>
         )}
 

--- a/themes/photo/components/MenuItemDrop.js
+++ b/themes/photo/components/MenuItemDrop.js
@@ -19,7 +19,6 @@ export const MenuItemDrop = ({ link }) => {
           target={link?.target}
           className='select-none menu-link pl-2 pr-4 no-underline tracking-widest pb-1 hover:font-bold'>
           {link?.icon && <i className={link?.icon} />} {link?.name}
-          {hasSubMenu && <i className='px-2 fa fa-angle-down'></i>}
         </SmartLink>
       )}
 

--- a/themes/plog/components/MenuItemDrop.js
+++ b/themes/plog/components/MenuItemDrop.js
@@ -26,7 +26,7 @@ export const MenuItemDrop = ({ link }) => {
         <div className='block text-black dark:text-gray-50 nav'>
           {link?.icon && <i className={link?.icon} />} {link?.name}
           <i
-            className={`px-2 fas fa-chevron-down duration-500 transition-all ${show ? ' rotate-180' : ''}`}></i>
+            className={`ml-2 fas fa-chevron-down duration-500 transition-all ${show ? ' rotate-180' : ''}`}></i>
         </div>
       )}
 

--- a/themes/simple/components/MenuItemDrop.js
+++ b/themes/simple/components/MenuItemDrop.js
@@ -24,7 +24,6 @@ export const MenuItemDrop = ({ link }) => {
             </span>
           )}
           {link?.name}
-          {hasSubMenu && <i className='px-2 fa fa-angle-down'></i>}
         </SmartLink>
       )}
 
@@ -38,7 +37,7 @@ export const MenuItemDrop = ({ link }) => {
             )}{' '}
             {link?.name}
             <i
-              className={`px-2 fas fa-chevron-down duration-500 transition-all ${show ? ' rotate-180' : ''}`}></i>
+              className={`ml-2 fas fa-chevron-down duration-500 transition-all ${show ? ' rotate-180' : ''}`}></i>
           </div>
         </>
       )}

--- a/themes/thoughtlite/components/MenuItemDrop.js
+++ b/themes/thoughtlite/components/MenuItemDrop.js
@@ -127,7 +127,7 @@ export const MenuItemDrop = ({ link, variant = 'default' }) => {
         <div className={linkBox}>
           {link?.icon && <i className={link?.icon} />} {link?.name}
           <i
-            className={`px-2 fas fa-chevron-down duration-500 transition-all ${show ? ' rotate-180' : ''}`}></i>
+            className={`ml-2 fas fa-chevron-down duration-500 transition-all ${show ? ' rotate-180' : ''}`}></i>
         </div>
       )}
 


### PR DESCRIPTION
style(menu-chevon-down): fix styling of chevon down icon

## 已知问题

菜单中下拉按钮（箭头）动画后，位置移动

## 解决方案

参考 #4279，修改 CSS 保证 menu 文字按钮的箭头图标位置在动画前后不变

## 改动收益

优化视觉体验


## 具体改动

改动范围仅限于菜单中下拉按钮，包括fa-chevron-down 和 fa-angle-down，仅限于进行180 度动画的元素。
有的样式中没有导航菜单，但是有组件，这些组件也一并修改了。
涉及到的样式包括：
commerce
example
gitbook
hexo
magzine
matery
medium
movie
nav
nobelium
photo
plog
simple
thoughtlite

1.  将 padding 改为 margin-left
2.  删除下拉按钮相关无效CSS 代码

修复后
<img width="272" height="270" alt="20260722-0216-30 1385017" src="https://github.com/user-attachments/assets/5e8caf5d-da44-4ef5-a930-8758e95ca12c" />

修复前
<img width="246" height="280" alt="20260722-0217-28 8447254" src="https://github.com/user-attachments/assets/36a8a360-34cc-4c42-aa8f-0e17bc47d560" />


## 测试确认

- [x] 本地开发环境测试通过
- [x] 生产环境构建测试通过
- [ ] （如适用）版本号正确显示
- [ ] （如适用）环境变量配置正常工作

## 用户文档（`docs/user-guide/` / `docs/developer/`）

如果本 PR 新增或修改了站长会使用的功能、主题配置、环境变量、Notion Config 键、插件开关、部署步骤、默认行为或可见 UI 交互，请同步更新 `docs/user-guide/` 或 `docs/developer/` 中对应说明，并在下方勾选已完成项。

只有纯内部重构、测试、CI、依赖维护、拼写修正等不改变站长使用方式的改动，才可以勾选「不适用」。

- [x] 不适用（无文档改动）
- [ ] 已按 [维护工作流](https://github.com/notionnext-org/NotionNext/blob/main/docs/user-guide/MAINTENANCE_WORKFLOW.md) 自检
- [ ] 路径符合 `docs/user-guide/` 目录约定
- [ ] 已更新 [user-guide/README.md](https://github.com/notionnext-org/NotionNext/blob/main/docs/user-guide/README.md)（新增/移动文章时）
- [ ] 已更新 [ARTICLE_INDEX.md](https://github.com/notionnext-org/NotionNext/blob/main/docs/user-guide/ARTICLE_INDEX.md)（新 slug 或路径变更时）
- [ ] 环境变量名与 `conf/*.config.js` 一致（若文档涉及配置）
- [ ] 示例中无真实 Token、`.env`、私有 ID
- [ ] 保留或更新了「原文链接」（若源自 docs.tangly1024.com）

文档说明（可选）：对应官方 slug / URL、是否与功能 PR 配套
