### PR TITLE
fix: render external video player embeds

### DIFF
--- a/__tests__/lib/db/notion/getPostBlocks.test.js
+++ b/__tests__/lib/db/notion/getPostBlocks.test.js
@@ -6,6 +6,7 @@ jest.mock('notion-utils', () => ({
 
 import { formatNotionBlock } from '@/lib/db/notion/getPostBlocks'
 import {
+  isExternalVideoEmbedUrl,
   isAppleMusicEmbedUrl,
   normalizeExternalMediaBlock
 } from '@/lib/db/notion/normalizeExternalMediaBlock'
@@ -40,6 +41,22 @@ describe('formatNotionBlock', () => {
     expect(blockValue.type).toBe('embed')
   })
 
+  it('rewrites external video player pages to embeds directly', () => {
+    const url =
+      'https://www.happinessrailway.com/dplayer.htm?n=https%3A%2F%2Fvip.lz-cdn16.com%2F20230312%2F12364_a86fbcc4%2Findex.m3u8'
+    const blockValue = {
+      type: 'video',
+      properties: {
+        source: [[url]]
+      }
+    }
+
+    expect(isExternalVideoEmbedUrl(url)).toBe(true)
+    normalizeExternalMediaBlock(blockValue)
+
+    expect(blockValue.type).toBe('embed')
+  })
+
   it('leaves non-matching video blocks unchanged during direct normalization', () => {
     const blockValue = {
       type: 'video',
@@ -69,6 +86,24 @@ describe('formatNotionBlock', () => {
     })
 
     expect(formatted['apple-music-song'].value.type).toBe('embed')
+  })
+
+  it('normalizes external video player pages from video blocks to embed blocks', () => {
+    const formatted = formatNotionBlock({
+      'external-player': {
+        value: {
+          id: 'external-player',
+          type: 'video',
+          properties: {
+            source: [[
+              'https://www.happinessrailway.com/dplayer.htm?n=https%3A%2F%2Fvip.lz-cdn16.com%2F20230312%2F12364_a86fbcc4%2Findex.m3u8'
+            ]]
+          }
+        }
+      }
+    })
+
+    expect(formatted['external-player'].value.type).toBe('embed')
   })
 
   it('relinks synced block content children to the original parent', () => {

--- a/lib/db/notion/normalizeExternalMediaBlock.js
+++ b/lib/db/notion/normalizeExternalMediaBlock.js
@@ -6,11 +6,20 @@ export function normalizeExternalMediaBlock(blockValue) {
 
   // Apple Music single-track embeds can arrive as `video` blocks from Notion.
   // react-notion-x treats unknown `video` sources as native <video>, which breaks playback.
-  if (isAppleMusicEmbedUrl(source)) {
+  if (isAppleMusicEmbedUrl(source) || isExternalVideoEmbedUrl(source)) {
     blockValue.type = 'embed'
   }
 }
 
 export function isAppleMusicEmbedUrl(url) {
   return /^https:\/\/embed\.music\.apple\.com\/.+\/song\//i.test(url)
+}
+
+export function isExternalVideoEmbedUrl(url) {
+  try {
+    const { protocol, pathname } = new URL(url)
+    return /^https?:$/.test(protocol) && /\.html?$/i.test(pathname)
+  } catch {
+    return false
+  }
 }


### PR DESCRIPTION
## What changed

- Normalize external HTML video player pages from Notion `video` blocks into `embed` blocks.
- Keep regular hosted video files as native `video` blocks.
- Add focused coverage for the DPlayer-style URL reported in #3497.

## Why

Notion can render external player pages inside embeds, but `react-notion-x` treats some of those sources as native video elements when they arrive as `video` blocks. A `.htm/.html` player page is not a native video asset, so the browser fails to play it as `<video>`.

Fixes #3497.

## Validation

- `NODE_PATH=E:\Workspace\NotionNext\node_modules E:\Workspace\NotionNext\node_modules\.bin\jest.cmd __tests__/lib/db/notion/getPostBlocks.test.js --runInBand`