### PR TITLE
fix: stabilize Notion PDF previews

### DIFF
--- a/__tests__/lib/db/notion/getPostBlocks.test.js
+++ b/__tests__/lib/db/notion/getPostBlocks.test.js
@@ -4,7 +4,11 @@ jest.mock('notion-utils', () => ({
   getBlockValue: jest.fn(entry => entry?.value?.value || entry?.value || entry)
 }))
 
-import { formatNotionBlock } from '@/lib/db/notion/getPostBlocks'
+import {
+  formatNotionBlock,
+  hasExpiredSignedUrls,
+  preferStablePdfSignedUrls
+} from '@/lib/db/notion/getPostBlocks'
 import {
   isExternalVideoEmbedUrl,
   isAppleMusicEmbedUrl,
@@ -192,5 +196,77 @@ describe('formatNotionBlock', () => {
     })
 
     expect(formatted['hosted-video'].value.type).toBe('video')
+  })
+
+  it('rewrites newer Notion pdf file URLs to signed URLs', () => {
+    const formatted = formatNotionBlock({
+      pdf: {
+        value: {
+          id: 'pdf-block',
+          type: 'pdf',
+          properties: {
+            source: [[
+              'https://prod-files-secure.s3.us-west-2.amazonaws.com/space/file.pdf'
+            ]]
+          }
+        }
+      }
+    })
+
+    expect(formatted.pdf.value.properties.source[0][0]).toBe(
+      'https://notion.so/signed/https%3A%2F%2Fprod-files-secure.s3.us-west-2.amazonaws.com%2Fspace%2Ffile.pdf?table=block&id=pdf-block'
+    )
+  })
+
+  it('does not rewrite lookalike Notion file URLs', () => {
+    const url = 'https://evil.example/secure.notion-static.com/file.pdf'
+    const formatted = formatNotionBlock({
+      pdf: {
+        value: {
+          id: 'pdf-block',
+          type: 'pdf',
+          properties: {
+            source: [[url]]
+          }
+        }
+      }
+    })
+
+    expect(formatted.pdf.value.properties.source[0][0]).toBe(url)
+  })
+
+  it('detects expired cached Notion signed URLs', () => {
+    expect(
+      hasExpiredSignedUrls({
+        signed_urls: {
+          pdf: 'https://file.notion.so/f/file.pdf?expirationTimestamp=1'
+        }
+      })
+    ).toBe(true)
+  })
+
+  it('uses stable Notion signed entry for pdf preview URLs', () => {
+    const recordMap = {
+      signed_urls: {
+        pdf: 'https://file.notion.so/f/file.pdf?expirationTimestamp=1'
+      },
+      block: {
+        pdf: {
+          value: {
+            id: 'pdf',
+            type: 'pdf',
+            properties: {
+              source: [['https://prod-files-secure.s3.us-west-2.amazonaws.com/file.pdf']]
+            }
+          }
+        }
+      }
+    }
+
+    preferStablePdfSignedUrls(recordMap)
+
+    expect(recordMap.signed_urls.pdf).toBe(
+      'https://notion.so/signed/https%3A%2F%2Fprod-files-secure.s3.us-west-2.amazonaws.com%2Ffile.pdf?table=block&id=pdf'
+    )
   })
 })

--- a/components/Pdf.js
+++ b/components/Pdf.js
@@ -1,14 +1,11 @@
-/**
- * 渲染pdf
- * 直接用googledocs预览pdf
- * @param {*} file
- * @returns
- */
 export function Pdf({ file }) {
-  const src =
-    'https://docs.google.com/viewer?embedded=true&url=' +
-    encodeURIComponent(file)
+  if (!file) return null
+
   return (
-    <embed src={src} type='application/pdf' width='100%' height='100%'></embed>
+    <object data={file} type='application/pdf' width='100%' height='100%'>
+      <a href={file} target='_blank' rel='noopener noreferrer'>
+        打开 PDF
+      </a>
+    </object>
   )
 }

--- a/lib/db/notion/getPostBlocks.js
+++ b/lib/db/notion/getPostBlocks.js
@@ -1,6 +1,7 @@
 import {
   getDataFromCache,
-  getOrSetDataWithCache
+  getOrSetDataWithCache,
+  setDataToCache
 
 } from '@/lib/cache/cache_manager'
 import { deepClone, delay } from '../../utils'
@@ -74,7 +75,116 @@ export async function fetchNotionPageBlocks(id, from = undefined, options = {}) 
     return null
   }
 
+  if (hasExpiredSignedUrls(pageBlock)) {
+    await refreshSignedUrls(pageBlock, cacheKey)
+  }
+  preferStablePdfSignedUrls(pageBlock)
+
   return pageBlock
+}
+
+export function hasExpiredSignedUrls(recordMap, bufferMs = 10 * 60 * 1000) {
+  const signedUrls = Object.values(recordMap?.signed_urls || {})
+  const now = Date.now()
+
+  return signedUrls.some(url => {
+    try {
+      const expires = Number(new URL(url).searchParams.get('expirationTimestamp'))
+      return Number.isFinite(expires) && expires <= now + bufferMs
+    } catch {
+      return false
+    }
+  })
+}
+
+async function refreshSignedUrls(recordMap, cacheKey) {
+  const files = getNotionFileInstances(recordMap)
+  if (!files.length) return
+
+  try {
+    const { signedUrls } = await notionAPI.getSignedFileUrls(files)
+    if (!signedUrls?.length) return
+
+    recordMap.signed_urls = recordMap.signed_urls || {}
+    files.forEach((file, index) => {
+      const signedUrl = signedUrls[index]
+      if (signedUrl) {
+        recordMap.signed_urls[file.permissionRecord.id] = signedUrl
+      }
+    })
+    await setDataToCache(cacheKey, recordMap, null)
+  } catch (err) {
+    console.warn('[Notion signed URLs] refresh failed:', err)
+  }
+}
+
+function getNotionFileInstances(recordMap) {
+  return Object.values(recordMap?.block || {}).flatMap(entry => {
+    const block = getBlockValue(entry)
+    if (!block || !['pdf', 'audio', 'image', 'video', 'file', 'page'].includes(block.type)) {
+      return []
+    }
+
+    const source =
+      block.type === 'page'
+        ? block.format?.page_cover
+        : block.properties?.source?.[0]?.[0]
+    const url = getNotionFileSource(source)
+
+    return url
+      ? [{
+          permissionRecord: {
+            table: 'block',
+            id: block.id
+          },
+          url
+        }]
+      : []
+  })
+}
+
+function getNotionFileSource(source) {
+  if (!source) return null
+
+  if (source.includes('notion.so/signed/')) {
+    try {
+      return decodeURIComponent(new URL(source).pathname.replace(/^\/signed\//, ''))
+    } catch {
+      return source
+    }
+  }
+
+  return (
+    isNotionHostedFileUrl(source) ||
+    source.includes('attachment:')
+  )
+    ? source
+    : null
+}
+
+function isNotionHostedFileUrl(source) {
+  try {
+    const hostname = new URL(source).hostname
+    return (
+      hostname === 'secure.notion-static.com' ||
+      /^prod-files-secure(?:-[a-z0-9]+)?\.s3[.-]/.test(hostname)
+    )
+  } catch {
+    return false
+  }
+}
+
+export function preferStablePdfSignedUrls(recordMap) {
+  Object.values(recordMap?.block || {}).forEach(entry => {
+    const block = getBlockValue(entry)
+    const source = block?.properties?.source?.[0]?.[0]
+    if (block?.type !== 'pdf' || !source) return
+
+    recordMap.signed_urls = recordMap.signed_urls || {}
+    recordMap.signed_urls[block.id] = source.includes('notion.so/signed/')
+      ? source
+      : `https://notion.so/signed/${encodeURIComponent(source)}?table=block&id=${block.id}`
+  })
 }
 
 /**
@@ -287,6 +397,7 @@ export function formatNotionBlock(block) {
       ['file', 'pdf', 'video', 'audio'].includes(b?.value?.type) &&
       b?.value?.properties?.source?.[0][0] &&
       (b?.value?.properties?.source?.[0][0]?.startsWith('attachment') ||
+        isNotionHostedFileUrl(b?.value?.properties?.source?.[0][0]) ||
         b?.value?.properties?.source?.[0][0].indexOf('amazonaws.com') > 0)
     ) {
       const oldUrl = b?.value?.properties?.source?.[0][0]


### PR DESCRIPTION
## Summary

- replace the Google Docs PDF viewer fallback with native browser PDF embedding
- rewrite newer Notion file URLs such as `prod-files-secure` and `secure.notion-static` through Notion's signed entrypoint
- refresh expired cached Notion signed URLs and keep PDF preview URLs on the stable `notion.so/signed/...` entrypoint so static exports do not bake short-lived `file.notion.so` URLs

## Root Cause

Notion PDF blocks can now arrive as newer file URLs. Cached `file.notion.so` signed URLs expire, and PDF.js cannot reliably fetch Notion files because the response does not include a usable cross-origin header. Google Docs Viewer avoided some browser rendering problems but introduced another external dependency and still fails for some Notion URLs.

## Validation

- `jest __tests__/lib/db/notion/getPostBlocks.test.js --runInBand`
- `next lint --file components/Pdf.js --file lib/db/notion/getPostBlocks.js --file __tests__/lib/db/notion/getPostBlocks.test.js`
- manually verified the stable `notion.so/signed/...` entrypoint returns `206 application/pdf` with a `%PDF-1.4` header
