### PR TITLE
feat(matery): Matery主题下，增加可选的便于阅读的UI组件

### DIFF
--- a/__tests__/themes/matery/ReadingHome.test.js
+++ b/__tests__/themes/matery/ReadingHome.test.js
@@ -1,0 +1,86 @@
+import ReadingHome from '@/themes/matery/components/ReadingHome'
+import { render, screen } from '@testing-library/react'
+
+let mockLang = 'en-US'
+
+jest.mock('@/lib/global', () => ({
+  useGlobal: () => ({ lang: mockLang })
+}))
+
+jest.mock('@/lib/config', () => ({
+  siteConfig: key => key === 'ENABLE_RSS'
+}))
+
+jest.mock('@/components/SmartLink', () => ({
+  __esModule: true,
+  default: ({ children, href, ...props }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  )
+}))
+
+jest.mock('@/themes/matery/components/BlogPostCard', () => ({
+  __esModule: true,
+  default: ({ post }) => <article>{post.title}</article>
+}))
+
+describe('Matery reading home', () => {
+  beforeEach(() => {
+    mockLang = 'en-US'
+  })
+
+  test('uses recommended posts as the starting path and removes duplicates', () => {
+    const recommended = post('recommended', 'Recommended article', [
+      { name: 'Recommend' }
+    ])
+    const latest = post('latest', 'Latest article')
+
+    render(
+      <ReadingHome
+        posts={[recommended, latest, post('third', 'Third article')]}
+        latestPosts={[recommended, latest, post('fourth', 'Fourth article')]}
+        categoryOptions={[{ name: 'AI Safety', count: 3 }]}
+      />
+    )
+
+    expect(screen.getByText('Start here')).toBeInTheDocument()
+    expect(screen.getAllByText('Recommended article')).toHaveLength(1)
+    expect(screen.getByText('Latest articles')).toBeInTheDocument()
+    expect(screen.getAllByText('Latest article')).toHaveLength(1)
+    expect(screen.getByRole('link', { name: /AI Safety/ })).toHaveAttribute(
+      'href',
+      '/category/AI%20Safety'
+    )
+    expect(
+      screen.getByRole('link', { name: 'Subscribe via RSS' })
+    ).toHaveAttribute('href', '/rss/feed.xml')
+  })
+
+  test('falls back to the first posts and localizes headings in Chinese', () => {
+    mockLang = 'zh-CN'
+
+    render(
+      <ReadingHome
+        posts={[
+          post('one', '第一篇'),
+          post('two', '第二篇'),
+          post('three', '第三篇'),
+          post('four', '第四篇')
+        ]}
+      />
+    )
+
+    expect(screen.getByText('从这里开始')).toBeInTheDocument()
+    expect(screen.getByText('最新文章')).toBeInTheDocument()
+    expect(screen.getByText('订阅更新')).toBeInTheDocument()
+    expect(screen.getByText('第四篇')).toBeInTheDocument()
+  })
+})
+
+const post = (id, title, tagItems = []) => ({
+  id,
+  href: `/article/${id}`,
+  title,
+  tagItems
+})

--- a/docs/user-guide/themes/matery.md
+++ b/docs/user-guide/themes/matery.md
@@ -14,7 +14,7 @@
 
 - **定位**：卡片式列表与 Material 质感组件。
 - **适用场景**：Material 卡片封面列表
-- **配置前缀**：`MATERY_*`（共 **25** 项，见下方配置表）
+- **配置前缀**：`MATERY_*`（共 **26** 项，见下方配置表）
 - **在线预览**：[preview.tangly1024.com/?theme=matery](https://preview.tangly1024.com/?theme=matery)
 
 ## 适用场景
@@ -44,6 +44,10 @@ MATERY_COLOR_BG: '#f5f5f5'
 
 主题工具中的调色板会展示当前值，并可直接复制配置项到 Notion Config。
 
+### 阅读导向首页
+
+在 Notion Config 中将 `MATERY_HOME_READING_LAYOUT` 设为 `true`，或配置环境变量 `NEXT_PUBLIC_MATERY_HOME_READING_LAYOUT=true`，首页会从单一文章时间流切换为四个阅读入口：推荐文章、分类主题、最新文章与 RSS。推荐文章优先识别 `Featured`、`Recommend`、`Recommended` 或 `推荐` 标签；没有匹配标签时使用前 3 篇文章。默认值为 `false`，原有分页或滚动文章列表保持不变。
+
 <!-- theme-config-table -->
 
 ### 主要配置项
@@ -55,6 +59,7 @@ MATERY_COLOR_BG: '#f5f5f5'
 | `MATERY_HOME_NAV_BUTTONS` | 见 config.js |
 | `MATERY_HOME_NAV_BACKGROUND_IMG_FIXED` | 见 config.js |
 | `MATERY_SHOW_START_READING` | 见 config.js |
+| `MATERY_HOME_READING_LAYOUT` | 使用阅读导向首页：推荐文章、分类入口、最新文章与 RSS |
 | `MATERY_MENU_CATEGORY` | 见 config.js |
 | `MATERY_MENU_TAG` | 见 config.js |
 | `MATERY_MENU_ARCHIVE` | 见 config.js |

--- a/themes/matery/components/ReadingHome.js
+++ b/themes/matery/components/ReadingHome.js
@@ -1,0 +1,202 @@
+import SmartLink from '@/components/SmartLink'
+import { siteConfig } from '@/lib/config'
+import { useGlobal } from '@/lib/global'
+import {
+  IconArrowRight,
+  IconCompass,
+  IconFileText,
+  IconFolder,
+  IconFolders,
+  IconRss
+} from '@tabler/icons-react'
+import BlogPostCard from './BlogPostCard'
+import ReadingSection from './ReadingSection'
+
+const ReadingHome = ({
+  categoryOptions = [],
+  latestPosts = [],
+  posts = [],
+  siteInfo
+}) => {
+  const { lang } = useGlobal()
+  const copy = getCopy(lang)
+  const allPosts = uniquePosts([...latestPosts, ...posts])
+  const recommended = allPosts.filter(hasRecommendTag)
+  const startPosts = (recommended.length > 0 ? recommended : allPosts).slice(
+    0,
+    3
+  )
+  const startIds = new Set(startPosts.map(postIdentity))
+  const latest = allPosts
+    .filter(post => !startIds.has(postIdentity(post)))
+    .slice(0, 6)
+  const topics = categoryOptions.filter(topic => topic?.name).slice(0, 6)
+
+  return (
+    <div className='w-full pb-12'>
+      {startPosts.length > 0 && (
+        <ReadingSection
+          id='start-here'
+          icon={IconCompass}
+          title={copy.startTitle}
+          description={copy.startDescription}
+        >
+          <PostGrid posts={startPosts} siteInfo={siteInfo} />
+        </ReadingSection>
+      )}
+
+      {topics.length > 0 && (
+        <ReadingSection
+          id='topics'
+          icon={IconFolders}
+          title={copy.topicTitle}
+          description={copy.topicDescription}
+          href='/category'
+          linkLabel={copy.allTopics}
+        >
+          <TopicGrid topics={topics} copy={copy} />
+        </ReadingSection>
+      )}
+
+      {latest.length > 0 && (
+        <ReadingSection
+          id='latest'
+          icon={IconFileText}
+          title={copy.latestTitle}
+          description={copy.latestDescription}
+          href='/archive'
+          linkLabel={copy.allArticles}
+        >
+          <PostGrid posts={latest} siteInfo={siteInfo} />
+        </ReadingSection>
+      )}
+
+      {siteConfig('ENABLE_RSS') !== false && (
+        <ReadingSection
+          id='follow'
+          icon={IconRss}
+          title={copy.followTitle}
+          description={copy.followDescription}
+        >
+          <a
+            href='/rss/feed.xml'
+            className='inline-flex items-center gap-2 font-medium text-indigo-700 hover:text-orange-600 dark:text-indigo-300 dark:hover:text-orange-300'
+          >
+            <IconRss aria-hidden='true' size={18} stroke={1.8} />
+            {copy.rssLabel}
+          </a>
+        </ReadingSection>
+      )}
+    </div>
+  )
+}
+
+const PostGrid = ({ posts, siteInfo }) => {
+  return (
+    <div className='grid gap-5 md:grid-cols-2 xl:grid-cols-3'>
+      {posts.map((post, index) => (
+        <BlogPostCard
+          key={postIdentity(post)}
+          index={index}
+          post={post}
+          siteInfo={siteInfo}
+        />
+      ))}
+    </div>
+  )
+}
+
+const TopicGrid = ({ copy, topics }) => {
+  return (
+    <div className='grid gap-4 sm:grid-cols-2 lg:grid-cols-3'>
+      {topics.map(topic => (
+        <SmartLink
+          key={topic.name}
+          href={`/category/${encodeURIComponent(topic.name)}`}
+          className='group flex min-h-28 items-start justify-between gap-4 rounded-xl border border-gray-200 bg-white p-5 shadow-sm transition hover:-translate-y-1 hover:border-indigo-300 hover:shadow-md dark:border-black dark:bg-hexo-black-gray dark:hover:border-indigo-700'
+        >
+          <span className='min-w-0'>
+            <span className='flex items-center gap-2 font-semibold text-gray-950 dark:text-white'>
+              <span className='flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-indigo-100 text-indigo-700 dark:bg-indigo-950 dark:text-indigo-300'>
+                <IconFolder aria-hidden='true' size={16} stroke={1.8} />
+              </span>
+              <span className='break-words'>{topic.name}</span>
+            </span>
+            <span className='mt-3 block text-sm text-gray-500 dark:text-gray-400'>
+              {copy.postCount(topic.count || 0)}
+            </span>
+          </span>
+          <IconArrowRight
+            aria-hidden='true'
+            className='mt-2 shrink-0 opacity-40 transition group-hover:translate-x-1 group-hover:opacity-100'
+            size={17}
+            stroke={1.8}
+          />
+        </SmartLink>
+      ))}
+    </div>
+  )
+}
+
+const hasRecommendTag = post => {
+  const tags = [
+    ...(Array.isArray(post?.tags) ? post.tags : []),
+    ...(Array.isArray(post?.tagItems) ? post.tagItems : [])
+  ].map(tag =>
+    String(tag?.name || tag)
+      .trim()
+      .toLowerCase()
+  )
+  return tags.some(tag =>
+    ['featured', 'recommend', 'recommended', '推荐'].includes(tag)
+  )
+}
+
+const postIdentity = post => post?.id || post?.href
+
+const uniquePosts = posts => {
+  const seen = new Set()
+  return posts.filter(post => {
+    const identity = postIdentity(post)
+    if (!identity || seen.has(identity)) return false
+    seen.add(identity)
+    return true
+  })
+}
+
+const getCopy = lang => {
+  const isChinese = String(lang).toLowerCase().startsWith('zh')
+  if (isChinese) {
+    return {
+      startTitle: '从这里开始',
+      startDescription: '为第一次访问的读者准备的推荐文章。',
+      topicTitle: '按主题探索',
+      topicDescription: '从感兴趣的方向进入，而不是翻阅完整时间流。',
+      allTopics: '全部分类',
+      latestTitle: '最新文章',
+      latestDescription: '最近发布或更新的内容。',
+      allArticles: '文章归档',
+      followTitle: '订阅更新',
+      followDescription: '无需注册账号，通过 RSS 获取新文章。',
+      rssLabel: '订阅 RSS',
+      postCount: count => `${count} 篇文章`
+    }
+  }
+  return {
+    startTitle: 'Start here',
+    startDescription: 'Recommended posts for first-time readers.',
+    topicTitle: 'Explore topics',
+    topicDescription:
+      'Enter through a subject instead of scanning the full timeline.',
+    allTopics: 'All categories',
+    latestTitle: 'Latest articles',
+    latestDescription: 'Recently published or updated writing.',
+    allArticles: 'Article archive',
+    followTitle: 'Follow updates',
+    followDescription: 'Get new posts through RSS without creating an account.',
+    rssLabel: 'Subscribe via RSS',
+    postCount: count => `${count} ${count === 1 ? 'post' : 'posts'}`
+  }
+}
+
+export default ReadingHome

--- a/themes/matery/components/ReadingSection.js
+++ b/themes/matery/components/ReadingSection.js
@@ -1,0 +1,48 @@
+import SmartLink from '@/components/SmartLink'
+import { IconArrowRight } from '@tabler/icons-react'
+
+const ReadingSection = ({
+  children,
+  description,
+  href,
+  icon: Icon,
+  id,
+  linkLabel,
+  title
+}) => {
+  return (
+    <section id={id} className='w-full scroll-mt-24 px-4 py-10'>
+      <header className='mb-6 flex flex-col gap-4 border-b border-gray-200 pb-5 dark:border-gray-800 sm:flex-row sm:items-end sm:justify-between'>
+        <div className='flex min-w-0 items-start gap-3'>
+          {Icon && (
+            <span className='flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-indigo-700 text-white shadow-md'>
+              <Icon aria-hidden='true' size={20} stroke={1.8} />
+            </span>
+          )}
+          <div className='min-w-0'>
+            <h2 className='text-2xl font-semibold text-gray-950 dark:text-white'>
+              {title}
+            </h2>
+            {description && (
+              <p className='mt-1 max-w-2xl text-sm leading-6 text-gray-600 dark:text-gray-400'>
+                {description}
+              </p>
+            )}
+          </div>
+        </div>
+        {href && linkLabel && (
+          <SmartLink
+            href={href}
+            className='inline-flex shrink-0 items-center gap-1 text-sm font-medium text-indigo-700 hover:text-orange-600 dark:text-indigo-300 dark:hover:text-orange-300'
+          >
+            {linkLabel}
+            <IconArrowRight aria-hidden='true' size={17} stroke={1.8} />
+          </SmartLink>
+        )}
+      </header>
+      {children}
+    </section>
+  )
+}
+
+export default ReadingSection

--- a/themes/matery/config.js
+++ b/themes/matery/config.js
@@ -14,6 +14,10 @@ const CONFIG = {
   // 是否显示开始阅读按钮
   MATERY_SHOW_START_READING: true,
 
+  // 使用阅读导向首页：推荐文章、分类入口、最新文章与 RSS
+  MATERY_HOME_READING_LAYOUT:
+    process.env.NEXT_PUBLIC_MATERY_HOME_READING_LAYOUT === 'true',
+
   // 菜单配置
   MATERY_MENU_CATEGORY: true, // 显示分类
   MATERY_MENU_TAG: true, // 显示标签

--- a/themes/matery/index.js
+++ b/themes/matery/index.js
@@ -29,6 +29,7 @@ import Header from './components/Header'
 import Hero from './components/Hero'
 import JumpToCommentButton from './components/JumpToCommentButton'
 import PostHero from './components/PostHero'
+import ReadingHome from './components/ReadingHome'
 import RightFloatButtons from './components/RightFloatButtons'
 import SearchNave from './components/SearchNav'
 import TagItemMiddle from './components/TagItemMiddle'
@@ -133,6 +134,9 @@ const LayoutBase = props => {
  * @returns
  */
 const LayoutIndex = props => {
+  if (siteConfig('MATERY_HOME_READING_LAYOUT', null, CONFIG)) {
+    return <ReadingHome {...props} />
+  }
   return <LayoutPostList {...props} />
 }
 


### PR DESCRIPTION
## 已知情况

1. Matery 首页目前以单一文章时间流为主，新访客缺少清晰的阅读起点、主题入口和订阅入口。
2. 直接替换现有首页会改变所有 Matery 用户的默认行为，不适合作为兼容性更新。

## 解决方案

1. 新增可选配置 `MATERY_HOME_READING_LAYOUT`，默认关闭。
2. 开启后将首页组织为四个阅读入口：
   - Start here：优先选择带有 `Featured`、`Recommend`、`Recommended` 或 `推荐` 标签的文章；无匹配时回退到前 3 篇。
   - Explore topics：复用现有分类数据。
   - Latest articles：展示去重后的最新文章并链接归档。
   - Follow updates：复用现有 RSS feed。
3. 保留现有分页/滚动文章列表作为默认首页，不新增 Notion 字段、路由或依赖。

## 改动收益

1. 帮助第一次访问的读者快速找到推荐内容和主题路径。
2. 在 Matery 视觉语言内增加分类发现与 RSS 订阅入口。
3. 通过 opt-in 开关保持完全向后兼容。

## 具体改动

1. `themes/matery/config.js`、`themes/matery/index.js`
   - 新增默认关闭的主题配置并在首页布局入口进行切换。
2. `themes/matery/components/ReadingHome.js`、`ReadingSection.js`
   - 新增主题内的阅读导向首页、文章去重、推荐标签识别和中英文界面文案。
   - 复用 Matery 的 `BlogPostCard`、现有分类数据和 RSS 路径。
3. `__tests__/themes/matery/ReadingHome.test.js`
   - 覆盖推荐选择、去重、分类链接、RSS、中文本地化和回退行为。
4. `docs/user-guide/themes/matery.md`
   - 补充 Notion Config 与环境变量启用方式、默认行为和推荐标签说明。

## 测试确认

- [x] 本地开发环境测试通过
- [x] 生产环境构建测试通过
- [x] `yarn lint` 通过（仅保留仓库已有 warnings）
- [x] `yarn type-check` 通过
- [x] `yarn test --runInBand` 通过：31 suites / 179 tests
- [x] `NEXT_PUBLIC_MATERY_HOME_READING_LAYOUT=true` 配置正常工作
- [x] 1280px 桌面端与 390px 移动端视觉检查通过，无横向溢出

## 用户文档（`docs/user-guide/` / `docs/developer/`）

- [ ] 不适用（无文档改动）
- [x] 已按 [维护工作流](https://github.com/notionnext-org/NotionNext/blob/main/docs/user-guide/MAINTENANCE_WORKFLOW.md) 自检
- [x] 路径符合 `docs/user-guide/` 目录约定
- [ ] 已更新 [user-guide/README.md](https://github.com/notionnext-org/NotionNext/blob/main/docs/user-guide/README.md)（新增/移动文章时）
- [ ] 已更新 [ARTICLE_INDEX.md](https://github.com/notionnext-org/NotionNext/blob/main/docs/user-guide/ARTICLE_INDEX.md)（新 slug 或路径变更时）
- [x] 环境变量名与主题配置一致（若文档涉及配置）
- [x] 示例中无真实 Token、`.env`、私有 ID
- [ ] 保留或更新了「原文链接」（若源自 docs.tangly1024.com）

文档说明：更新现有 `docs/user-guide/themes/matery.md`，没有新增或移动文章，因此 README、ARTICLE_INDEX 与原文链接项不适用。

## 相关 PR

- #4282：同样采用主题内、范围聚焦的首页卡片 UI 改进方式。
- #4302：涉及 Matery 菜单样式，但与本 PR 的首页布局没有代码重叠。
