### PR TITLE
fix: sort select options by Notion option order

### DIFF
--- a/__tests__/lib/notion-data-format.test.js
+++ b/__tests__/lib/notion-data-format.test.js
@@ -1106,6 +1106,83 @@ describe('Notion data format compatibility', () => {
     ).toEqual(['morning_page', 'evening_page'])
   })
 
+  it('sorts embedded collection results from query2 select sorts by option order', () => {
+    const blockMap = {
+      block: {
+        cherry_page: {
+          value: {
+            id: 'cherry_page',
+            type: 'page',
+            properties: {
+              category: [['樱桃']]
+            }
+          }
+        },
+        apple_page: {
+          value: {
+            id: 'apple_page',
+            type: 'page',
+            properties: {
+              category: [['苹果']]
+            }
+          }
+        }
+      },
+      collection: {
+        collection_1: {
+          value: {
+            schema: {
+              category: {
+                name: 'Category',
+                type: 'select',
+                options: [
+                  { id: 'option_apple', name: '苹果', value: '苹果' },
+                  { id: 'option_cherry', name: '樱桃', value: '樱桃' }
+                ]
+              }
+            }
+          }
+        }
+      },
+      collection_view: {
+        view_1: {
+          value: {
+            value: {
+              id: 'view_1',
+              page_sort: ['cherry_page', 'apple_page'],
+              format: {
+                collection_pointer: { id: 'collection_1' }
+              },
+              query2: {
+                sort: [{ property: 'Category', direction: 'ascending' }]
+              }
+            }
+          }
+        }
+      },
+      collection_query: {
+        collection_1: {
+          view_1: {
+            collection_group_results: {
+              blockIds: ['cherry_page', 'apple_page']
+            }
+          }
+        }
+      }
+    }
+
+    filterCollectionViewData(blockMap)
+
+    expect(
+      blockMap.collection_query.collection_1.view_1.collection_group_results
+        .blockIds
+    ).toEqual(['apple_page', 'cherry_page'])
+    expect(blockMap.collection_view.view_1.value.value.page_sort).toEqual([
+      'apple_page',
+      'cherry_page'
+    ])
+  })
+
   it('inherits sibling filters for embedded collection views without filters', () => {
     const blockMap = {
       block: {

--- a/lib/db/notion/filterCollectionViewData.js
+++ b/lib/db/notion/filterCollectionViewData.js
@@ -269,6 +269,14 @@ function comparePropertyValues(left, right, propertySchema) {
     return leftEmpty ? 1 : -1
   }
 
+  if (propertySchema?.type === 'select' || propertySchema?.type === 'status') {
+    const leftIndex = getOptionOrder(left, propertySchema)
+    const rightIndex = getOptionOrder(right, propertySchema)
+    if (leftIndex !== null && rightIndex !== null && leftIndex !== rightIndex) {
+      return leftIndex - rightIndex
+    }
+  }
+
   if (propertySchema?.type === 'number') {
     const leftNumber = toNumber(left)
     const rightNumber = toNumber(right)
@@ -468,6 +476,14 @@ function toBoolean(value) {
 function toNumber(value) {
   const number = Number(value)
   return Number.isNaN(number) ? null : number
+}
+
+function getOptionOrder(value, propertySchema) {
+  const options = propertySchema?.options || []
+  const index = options.findIndex(option => {
+    return option?.value === value || option?.name === value || option?.id === value
+  })
+  return index === -1 ? null : index
 }
 
 function normalizeDate(value) {


### PR DESCRIPTION
Fixes issue #4292 by sorting select/status values using the schema option order instead of raw string comparison, which keeps Chinese Select ordering aligned with Notion.

Validation:
- npx jest --runInBand --watchAll=false __tests__/lib/notion-data-format.test.js