### PR TITLE
fix: sync theme count in sidebar navigation

### DIFF
--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -239,7 +239,7 @@ export default defineConfig({
           ]
         },
         {
-          text: '主题（25）',
+          text: `主题（${themeDocLinks.length}）`,
           collapsed: true,
           items: [
             { text: '主题目录', link: '/user-guide/themes/' },


### PR DESCRIPTION
相关 Issue: #4312 

## 已知问题

1. 文档侧边栏主题数量显示与实际主题数量不一致
   - 新增 `opc` 主题后，NotionNext 当前已有 26 个内置主题
   - 主题文档页面已更新显示「内置主题说明文档（26 个）」
   - 但 `.vitepress/config.mts` 中侧边栏标题仍使用硬编码 `主题（25）`
   - 导致官方文档站出现正文与侧边栏主题数量不一致的问题


## 解决方案

1. 将侧边栏主题数量从固定文本改为动态生成
   - 移除 `.vitepress/config.mts` 中 `主题（25）` 的硬编码
   - 改为根据 `themeDocLinks.length` 自动计算当前主题数量
   - 后续新增或删除主题时，侧边栏数量可以自动同步


## 改动收益

1. 避免主题数量维护遗漏
   - 主题数量不再依赖人工修改
   - 保证侧边栏显示与实际主题列表保持一致
   - 降低未来新增主题时出现类似问题的概率


## 具体改动

1. `.vitepress/config.mts`
   - 修改主题侧边栏分组标题生成逻辑
   - 从：`text: '主题（25）',` 调整为：``text: `主题（${themeDocLinks.length}）`,``
   - 使用已有主题文档列表动态生成数量


## 测试确认

- [x] 本地开发环境测试通过
- [x] 本地文档站构建测试通过
- [x] 确认侧边栏主题数量显示正确

## 用户文档（`docs/user-guide/` / `docs/developer/`）

本 PR 仅修改文档站内部侧边栏配置逻辑，不涉及站长使用功能、主题配置、环境变量、Notion Config 键、插件开关、部署步骤或用户可见功能变化。

- [x] 不适用（无文档改动）
- [x] 已按 [维护工作流](https://github.com/notionnext-org/NotionNext/blob/main/docs/user-guide/MAINTENANCE_WORKFLOW.md) 自检
- [x] 路径符合 `docs/user-guide/` 目录约定
- [ ] 已更新 [user-guide/README.md](https://github.com/notionnext-org/NotionNext/blob/main/docs/user-guide/README.md)（新增/移动文章时）
- [ ] 已更新 [ARTICLE_INDEX.md](https://github.com/notionnext-org/NotionNext/blob/main/docs/user-guide/ARTICLE_INDEX.md)（新 slug 或路径变更时）
- [ ] 环境变量名与 `conf/*.config.js` 一致（若文档涉及配置）
- [ ] 示例中无真实 Token、`.env`、私有 ID
- [ ] 保留或更新了「原文链接」（若源自 docs.tangly1024.com）

文档说明：
本 PR 不涉及用户文档内容，仅修复官方文档站侧边栏主题数量动态同步问题。