### PR TITLE
feat(embed): auto-resize Notion HTML blocks

### DIFF
--- a/__tests__/components/NotionEmbed.test.js
+++ b/__tests__/components/NotionEmbed.test.js
@@ -1,0 +1,162 @@
+import { act, fireEvent, render, screen } from '@testing-library/react'
+import { Script } from 'node:vm'
+import { useNotionContext } from 'react-notion-x'
+import NotionEmbed, {
+  HTML_ARTIFACT_MAX_HEIGHT,
+  HTML_ARTIFACT_MEASURE_MESSAGE,
+  HTML_ARTIFACT_MIN_HEIGHT,
+  HTML_ARTIFACT_RESIZE_MESSAGE,
+  normalizeHtmlArtifactHeight,
+  withHtmlArtifactResizeBridge
+} from '@/components/NotionEmbed'
+
+jest.mock('react-notion-x', () => ({
+  useNotionContext: jest.fn()
+}))
+
+const createHtmlArtifactBlock = (overrides = {}) => ({
+  id: 'html-artifact-1',
+  type: 'embed',
+  format: {
+    embed_variant: 'html_artifact',
+    html_artifact_content:
+      '<!doctype html><html><body><p>Quote</p></body></html>',
+    block_height: 160,
+    ...overrides.format
+  },
+  properties: {
+    source: [['attachment:quote.html']],
+    ...overrides.properties
+  },
+  ...overrides
+})
+
+const dispatchFrameMessage = (frame, data, source = frame.contentWindow) => {
+  act(() => {
+    window.dispatchEvent(new MessageEvent('message', { data, source }))
+  })
+}
+
+describe('NotionEmbed HTML artifact auto height', () => {
+  beforeEach(() => {
+    useNotionContext.mockReturnValue({ recordMap: { signed_urls: {} } })
+  })
+
+  it('injects the resize bridge and applies reported content height', () => {
+    render(<NotionEmbed block={createHtmlArtifactBlock()} />)
+
+    const frame = screen.getByTitle('Notion HTML block')
+    const wrapper = frame.parentElement
+    const srcDoc = frame.getAttribute('srcdoc')
+
+    expect(wrapper).toHaveStyle('height: 160px')
+    expect(frame).toHaveAttribute(
+      'sandbox',
+      'allow-scripts allow-forms allow-popups'
+    )
+    expect(srcDoc).toContain('<p>Quote</p>')
+    expect(srcDoc).toContain('data-notion-next-auto-height')
+    expect(srcDoc).toContain(HTML_ARTIFACT_RESIZE_MESSAGE)
+    expect(srcDoc).toContain(HTML_ARTIFACT_MEASURE_MESSAGE)
+
+    dispatchFrameMessage(frame, {
+      type: HTML_ARTIFACT_RESIZE_MESSAGE,
+      height: 83.2
+    })
+
+    expect(wrapper).toHaveStyle('height: 84px')
+  })
+
+  it('requests a fresh measurement when the iframe loads', () => {
+    render(<NotionEmbed block={createHtmlArtifactBlock()} />)
+
+    const frame = screen.getByTitle('Notion HTML block')
+    const postMessage = jest.spyOn(frame.contentWindow, 'postMessage')
+
+    fireEvent.load(frame)
+
+    expect(postMessage).toHaveBeenCalledWith(
+      { type: HTML_ARTIFACT_MEASURE_MESSAGE },
+      '*'
+    )
+  })
+
+  it('ignores resize messages from other windows or with the wrong type', () => {
+    render(<NotionEmbed block={createHtmlArtifactBlock()} />)
+
+    const frame = screen.getByTitle('Notion HTML block')
+    const wrapper = frame.parentElement
+
+    dispatchFrameMessage(
+      frame,
+      { type: HTML_ARTIFACT_RESIZE_MESSAGE, height: 240 },
+      window
+    )
+    dispatchFrameMessage(frame, { type: 'unrelated-message', height: 240 })
+
+    expect(wrapper).toHaveStyle('height: 160px')
+  })
+
+  it('keeps ordinary iframe embeds unchanged', () => {
+    render(
+      <NotionEmbed
+        block={{
+          id: 'external-embed-1',
+          type: 'embed',
+          format: {
+            display_source: 'https://example.com/widget',
+            block_height: 300
+          }
+        }}
+      />
+    )
+
+    const frame = screen.getByTitle('iframe embed')
+
+    expect(frame).toHaveAttribute('src', 'https://example.com/widget')
+    expect(frame).not.toHaveAttribute('srcdoc')
+    expect(frame).not.toHaveAttribute('sandbox')
+    expect(frame.parentElement).toHaveStyle('height: 300px')
+  })
+})
+
+describe('HTML artifact resize helpers', () => {
+  it('normalizes and clamps reported heights', () => {
+    expect(normalizeHtmlArtifactHeight(0)).toBeNull()
+    expect(normalizeHtmlArtifactHeight('invalid')).toBeNull()
+    expect(normalizeHtmlArtifactHeight(12)).toBe(HTML_ARTIFACT_MIN_HEIGHT)
+    expect(normalizeHtmlArtifactHeight(83.2)).toBe(84)
+    expect(normalizeHtmlArtifactHeight(99999)).toBe(HTML_ARTIFACT_MAX_HEIGHT)
+  })
+
+  it('injects a valid bridge before the closing body tag', () => {
+    expect(withHtmlArtifactResizeBridge(undefined)).toBeUndefined()
+
+    const srcDoc = withHtmlArtifactResizeBridge(
+      '<!doctype html><html><body>Content</body></html>'
+    )
+    const script = srcDoc.match(
+      /<script data-notion-next-auto-height>([\s\S]*?)<\/script>/
+    )?.[1]
+
+    expect(srcDoc).toMatch(
+      /<script data-notion-next-auto-height>[\s\S]*<\/script>\n<\/body><\/html>$/
+    )
+    expect(script).toBeTruthy()
+    expect(() => new Script(script)).not.toThrow()
+  })
+
+  it('falls back to the closing html tag or the end of a fragment', () => {
+    const documentWithoutBody = withHtmlArtifactResizeBridge(
+      '<html><main>Content</main></html>'
+    )
+    const fragment = withHtmlArtifactResizeBridge('<main>Content</main>')
+
+    expect(documentWithoutBody).toMatch(
+      /<script data-notion-next-auto-height>[\s\S]*<\/script>\n<\/html>$/
+    )
+    expect(fragment).toMatch(
+      /^<main>Content<\/main>\n<script data-notion-next-auto-height>/
+    )
+  })
+})

--- a/components/NotionEmbed.js
+++ b/components/NotionEmbed.js
@@ -1,0 +1,224 @@
+import { useEffect, useRef, useState } from 'react'
+import { useNotionContext } from 'react-notion-x'
+
+export const HTML_ARTIFACT_RESIZE_MESSAGE = 'notion-next:html-artifact-resize'
+export const HTML_ARTIFACT_MEASURE_MESSAGE = 'notion-next:html-artifact-measure'
+export const HTML_ARTIFACT_MIN_HEIGHT = 32
+export const HTML_ARTIFACT_MAX_HEIGHT = 4096
+
+const HTML_ARTIFACT_RESIZE_BRIDGE = `<script data-notion-next-auto-height>
+(() => {
+  if (window.__notionNextHtmlArtifactAutoHeight) return
+  window.__notionNextHtmlArtifactAutoHeight = true
+
+  const messageType = ${JSON.stringify(HTML_ARTIFACT_RESIZE_MESSAGE)}
+  const measureMessageType = ${JSON.stringify(HTML_ARTIFACT_MEASURE_MESSAGE)}
+  let frameId = null
+  let lastHeight = 0
+
+  const measure = () => {
+    frameId = null
+    const body = document.body
+    if (!body) return
+
+    const bodyRect = body.getBoundingClientRect()
+    let contentTop = bodyRect.top
+    let contentBottom = bodyRect.bottom
+
+    for (const element of body.children) {
+      const rect = element.getBoundingClientRect()
+      if (rect.width === 0 && rect.height === 0) continue
+      contentTop = Math.min(contentTop, rect.top)
+      contentBottom = Math.max(contentBottom, rect.bottom)
+    }
+
+    const style = window.getComputedStyle(body)
+    const marginTop = Number.parseFloat(style.marginTop) || 0
+    const marginBottom = Number.parseFloat(style.marginBottom) || 0
+    let height = contentBottom - contentTop + marginTop + marginBottom
+
+    if (body.scrollHeight > window.innerHeight + 1) {
+      height = Math.max(height, body.scrollHeight + marginTop + marginBottom)
+    }
+
+    height = Math.ceil(height)
+    if (!Number.isFinite(height) || height <= 0 || height === lastHeight) return
+
+    lastHeight = height
+    window.parent.postMessage({ type: messageType, height }, '*')
+  }
+
+  const scheduleMeasure = () => {
+    if (frameId !== null) return
+    frameId = window.requestAnimationFrame(measure)
+  }
+
+  window.addEventListener('message', event => {
+    if (event.source !== window.parent) return
+    if (event.data?.type !== measureMessageType) return
+    scheduleMeasure()
+  })
+
+  const start = () => {
+    if (!document.body) return
+
+    if (typeof ResizeObserver === 'function') {
+      const resizeObserver = new ResizeObserver(scheduleMeasure)
+      resizeObserver.observe(document.body)
+    }
+
+    if (typeof MutationObserver === 'function') {
+      const mutationObserver = new MutationObserver(scheduleMeasure)
+      mutationObserver.observe(document.body, {
+        childList: true,
+        subtree: true,
+        characterData: true
+      })
+    }
+
+    window.addEventListener('load', scheduleMeasure, true)
+    document.fonts?.ready?.then(scheduleMeasure).catch(() => {})
+    scheduleMeasure()
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', start, { once: true })
+  } else {
+    start()
+  }
+})()
+</script>`
+
+export const withHtmlArtifactResizeBridge = srcDoc => {
+  if (typeof srcDoc !== 'string' || !srcDoc) return srcDoc
+
+  const injectBeforeClosingTag = tagName => {
+    const closingTagPattern = new RegExp(`</${tagName}\\s*>`, 'gi')
+    let closingTagIndex = -1
+
+    for (const match of srcDoc.matchAll(closingTagPattern)) {
+      closingTagIndex = match.index
+    }
+
+    if (closingTagIndex < 0) return null
+    return `${srcDoc.slice(
+      0,
+      closingTagIndex
+    )}${HTML_ARTIFACT_RESIZE_BRIDGE}\n${srcDoc.slice(closingTagIndex)}`
+  }
+
+  const documentWithBridge =
+    injectBeforeClosingTag('body') || injectBeforeClosingTag('html')
+
+  if (documentWithBridge) return documentWithBridge
+  return `${srcDoc}\n${HTML_ARTIFACT_RESIZE_BRIDGE}`
+}
+
+export const normalizeHtmlArtifactHeight = value => {
+  const height = Number(value)
+  if (!Number.isFinite(height) || height <= 0) return null
+
+  return Math.min(
+    HTML_ARTIFACT_MAX_HEIGHT,
+    Math.max(HTML_ARTIFACT_MIN_HEIGHT, Math.ceil(height))
+  )
+}
+
+const getConfiguredHeight = (block, isHtmlArtifact) => {
+  const height = Number(block?.format?.block_height)
+  if (Number.isFinite(height) && height > 0) return height
+  return isHtmlArtifact ? 640 : 480
+}
+
+const NotionEmbed = ({ block }) => {
+  const { recordMap } = useNotionContext()
+  const iframeRef = useRef(null)
+  const source =
+    recordMap?.signed_urls?.[block?.id] ||
+    block?.format?.display_source ||
+    block?.properties?.source?.[0]?.[0]
+  const isHtmlArtifact =
+    block?.type === 'embed' && block?.format?.embed_variant === 'html_artifact'
+  const srcDoc = isHtmlArtifact
+    ? block?.format?.html_artifact_content
+    : undefined
+  const configuredHeight = getConfiguredHeight(block, isHtmlArtifact)
+  const [height, setHeight] = useState(configuredHeight)
+
+  const requestHtmlArtifactHeight = () => {
+    if (!isHtmlArtifact) return
+    iframeRef.current?.contentWindow?.postMessage(
+      { type: HTML_ARTIFACT_MEASURE_MESSAGE },
+      '*'
+    )
+  }
+
+  useEffect(() => {
+    setHeight(configuredHeight)
+  }, [block?.id, configuredHeight])
+
+  // block.id is intentionally excluded: the handler reads the current iframe
+  // ref at message time, and onLoad remeasures whenever its document changes.
+  useEffect(() => {
+    if (!isHtmlArtifact) return
+
+    const handleResizeMessage = event => {
+      if (event.source !== iframeRef.current?.contentWindow) return
+      if (event.data?.type !== HTML_ARTIFACT_RESIZE_MESSAGE) return
+
+      const nextHeight = normalizeHtmlArtifactHeight(event.data.height)
+      if (nextHeight === null) return
+      setHeight(currentHeight =>
+        currentHeight === nextHeight ? currentHeight : nextHeight
+      )
+    }
+
+    window.addEventListener('message', handleResizeMessage)
+    iframeRef.current?.contentWindow?.postMessage(
+      { type: HTML_ARTIFACT_MEASURE_MESSAGE },
+      '*'
+    )
+
+    return () => window.removeEventListener('message', handleResizeMessage)
+  }, [isHtmlArtifact])
+
+  if (
+    !srcDoc &&
+    (typeof source !== 'string' || source.startsWith('attachment:'))
+  ) {
+    return null
+  }
+
+  const title =
+    block?.properties?.title?.[0]?.[0] ||
+    (isHtmlArtifact ? 'Notion HTML block' : 'iframe embed')
+  const resizableSrcDoc = isHtmlArtifact
+    ? withHtmlArtifactResizeBridge(srcDoc)
+    : undefined
+
+  return (
+    <figure className='notion-asset-wrapper notion-asset-wrapper-embed'>
+      <div style={{ height, position: 'relative' }}>
+        <iframe
+          ref={iframeRef}
+          className='notion-asset-object-fit'
+          src={resizableSrcDoc ? undefined : source}
+          srcDoc={resizableSrcDoc}
+          title={title}
+          frameBorder='0'
+          loading='lazy'
+          scrolling='auto'
+          onLoad={requestHtmlArtifactHeight}
+          allowFullScreen={!isHtmlArtifact}
+          sandbox={
+            isHtmlArtifact
+              ? 'allow-scripts allow-forms allow-popups'
+              : undefined
+          }
+        />
+      </div>
+    </figure>
+  )
+}
+
+export default NotionEmbed

--- a/components/NotionPage.js
+++ b/components/NotionPage.js
@@ -1,12 +1,13 @@
 import { siteConfig } from '@/lib/config'
 import { compressImage, mapImgUrl } from '@/lib/db/notion/mapImage'
+import NotionEmbed from '@/components/NotionEmbed'
 import NotionLink from '@/components/NotionLink'
 import { isBrowser, loadExternalResource } from '@/lib/utils'
 import mediumZoom from '@fisch0920/medium-zoom'
 import 'katex/dist/katex.min.css'
 import dynamic from 'next/dynamic'
 import { useEffect, useRef } from 'react'
-import { NotionRenderer, useNotionContext } from 'react-notion-x'
+import { NotionRenderer } from 'react-notion-x'
 
 /**
  * 整个站点的核心组件
@@ -143,49 +144,6 @@ const hasCodeBlock = blockMap => {
     item => item?.value?.type === 'code'
   )
 }
-
-const NotionEmbed = ({ block }) => {
-  const { recordMap } = useNotionContext()
-  const source =
-    recordMap?.signed_urls?.[block?.id] ||
-    block?.format?.display_source ||
-    block?.properties?.source?.[0]?.[0]
-  const isHtmlArtifact =
-    block?.type === 'embed' && block?.format?.embed_variant === 'html_artifact'
-  const srcDoc = isHtmlArtifact
-    ? block?.format?.html_artifact_content
-    : undefined
-
-  if (!srcDoc && (!source || source.startsWith('attachment:'))) return null
-
-  const height = block?.format?.block_height || (isHtmlArtifact ? 640 : 480)
-  const title =
-    block?.properties?.title?.[0]?.[0] ||
-    (isHtmlArtifact ? 'Notion HTML block' : 'iframe embed')
-
-  return (
-    <figure
-      className='notion-asset-wrapper notion-asset-wrapper-embed'
-      >
-      <div style={{ height, position: 'relative' }}>
-        <iframe
-          className='notion-asset-object-fit'
-          src={srcDoc ? undefined : source}
-          srcDoc={srcDoc}
-          title={title}
-          frameBorder='0'
-          loading='lazy'
-          scrolling='auto'
-          allowFullScreen={!isHtmlArtifact}
-          sandbox={
-            isHtmlArtifact ? 'allow-scripts allow-forms allow-popups' : undefined
-          }
-        />
-      </div>
-    </figure>
-  )
-}
-
 
 /**
  * 页面的数据库链接禁止跳转，只能查看

--- a/docs/user-guide/notion/example-article.md
+++ b/docs/user-guide/notion/example-article.md
@@ -264,6 +264,7 @@ Notion 2026 年新增的 HTML Block 可以在 Notion 中通过 Notion AI 生成�
 
 - 在 Notion 页面中插入 HTML Block，使用 Notion AI 生成，或上传一个 `.html` 文件。
 - HTML Block 会被隔离在 iframe 中运行，不会直接注入站点正文 DOM。
+- NotionNext 会在 HTML Block 加载及内容变化时自动调整显示高度；Notion 中设置的块高度仅作为首次加载的初始高度。内容超过 4096px 时 iframe 会保留内部滚动，避免单个区块无限撑长页面。
 - 适合无后端的小工具；需要数据库、登录态、支付等能力时，仍应做成独立应用后再用普通 Embed 嵌入。
 - 为避免页面数据过大，单个 HTML artifact 建议控制在 512KB 以内。
 


### PR DESCRIPTION
## 已知问题

1. Notion HTML Block 当前只使用 Notion 保存的固定 `block_height`
   - HTML artifact 中的异步内容、字体或响应式布局加载后，高度不会随内容变化。
   - 内容较短时会留下大块空白，内容较长时则需要在 iframe 内滚动或被固定高度限制。

## 解决方案

1. 为 `html_artifact` 增加受限的自动高度桥接
   - 将高度测量脚本注入 artifact 文档的 `</body>` 前；缺少 `body` 时回退到 `</html>` 前，HTML 片段则追加到末尾。
   - iframe 内通过 `ResizeObserver`、`MutationObserver`、页面加载及字体加载事件重新测量内容高度。
   - 父页面仅接收来自当前 iframe `contentWindow` 的指定消息，并将高度限制在 `32px` 到 `4096px`。
   - Notion 中的 `block_height` 继续作为首次加载和切换区块时的初始高度。

2. 保持现有 Embed 行为
   - 自动高度只作用于 `embed_variant === 'html_artifact'`。
   - 普通 iframe 的 `src`、高度、全屏能力和现有渲染行为不变。
   - HTML Block 仍使用原有 sandbox 权限。

## 改动收益

1. 动态 HTML 内容可以随实际行数和布局自动适配高度。
2. 减少短内容下方的空白以及长内容的内部滚动。
3. 高度上限可避免异常 artifact 无限撑长页面。

## 具体改动

1. `components/NotionEmbed.js`
   - 提取 Embed 渲染组件并实现 HTML artifact 高度通信。
2. `components/NotionPage.js`
   - 接入独立的 `NotionEmbed` 组件。
3. `__tests__/components/NotionEmbed.test.js`
   - 覆盖桥接注入、加载重测、消息来源校验、高度归一化及普通 iframe 兼容性。
4. `docs/user-guide/notion/example-article.md`
   - 补充 HTML Block 自动高度、初始高度和最大高度说明。

## 风险与兼容性

- 不包含破坏性变更。
- sandbox iframe 没有 `allow-same-origin`，消息目标必须使用 `*`；父页面通过 `event.source` 校验实际发送窗口。
- 超过 `4096px` 的内容保留 iframe 内部滚动，避免单个区块无限增长。

## 测试确认

- [x] `yarn lint`（通过，仅有仓库既有 warning）
- [x] `yarn type-check`
- [x] `yarn test --runInBand`（32 suites，187 tests）
- [x] `yarn docs:site:build`
- [x] `yarn deps:check-lockfile`
- [x] `git diff --check upstream/main...HEAD`
- [x] `yarn build`（本次未重复执行；未修改构建链路）

## 用户文档（`docs/user-guide/` / `docs/developer/`）

- [x] 已更新现有 `docs/user-guide/notion/example-article.md`
- [x] 无新增或移动文章，不需要更新 `README.md` 与 `ARTICLE_INDEX.md`
- [x] 不涉及环境变量、Token、私有 ID 或配置键
