### PR TITLE
fix(heo): 未解锁前隐藏字数和阅读时长

### DIFF
--- a/__tests__/themes/heo/PostHeader.test.js
+++ b/__tests__/themes/heo/PostHeader.test.js
@@ -1,0 +1,67 @@
+import { renderToStaticMarkup } from 'react-dom/server.node'
+import PostHeader from '@/themes/heo/components/PostHeader'
+
+jest.mock('@/components/LazyImage', () => ({
+  __esModule: true,
+  default: () => <span data-testid='lazy-image' />
+}))
+
+jest.mock('@/components/NotionIcon', () => ({
+  __esModule: true,
+  default: () => <span data-testid='notion-icon' />
+}))
+
+jest.mock('@/components/SmartLink', () => ({
+  __esModule: true,
+  default: ({ children, href, passHref, legacyBehavior, ...props }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  )
+}))
+
+jest.mock('@/components/WordCount', () => ({
+  __esModule: true,
+  default: ({ wordCount, readTime }) => (
+    <span data-testid='word-count'>
+      {wordCount}/{readTime}
+    </span>
+  )
+}))
+
+jest.mock('@/lib/config', () => ({
+  siteConfig: jest.fn(() => false)
+}))
+
+jest.mock('@/themes/heo/components/WavesArea', () => ({
+  __esModule: true,
+  default: () => null
+}))
+
+const post = {
+  title: '受保护文章',
+  type: 'Post',
+  wordCount: 0,
+  readTime: 1,
+  publishDay: '2026-07-25',
+  lastEditedDay: '2026-07-25'
+}
+
+describe('heo PostHeader password metadata', () => {
+  it('hides word count and read time while the article is locked', () => {
+    const html = renderToStaticMarkup(
+      <PostHeader post={post} siteInfo={{}} lock />
+    )
+
+    expect(html).not.toContain('data-testid="word-count"')
+  })
+
+  it('shows word count and read time after the article is unlocked', () => {
+    const html = renderToStaticMarkup(
+      <PostHeader post={post} siteInfo={{}} lock={false} />
+    )
+
+    expect(html).toContain('data-testid="word-count"')
+    expect(html).toContain('0/1')
+  })
+})

--- a/themes/heo/components/PostHeader.js
+++ b/themes/heo/components/PostHeader.js
@@ -12,7 +12,7 @@ import WavesArea from './WavesArea'
  * @param {*} param0
  * @returns
  */
-export default function PostHeader({ post, siteInfo, isDarkMode }) {
+export default function PostHeader({ post, siteInfo, isDarkMode, lock }) {
   if (!post) {
     return <></>
   }
@@ -109,12 +109,14 @@ export default function PostHeader({ post, siteInfo, isDarkMode }) {
           {/* 标题底部补充信息 */}
           <section className='flex-wrap dark:text-gray-200 text-opacity-70 shadow-text-md flex text-sm  justify-center md:justify-start mt-4 text-white font-light leading-8'>
             <div className='flex justify-center '>
-              <div className='mr-2'>
-                <WordCount
-                  wordCount={post.wordCount}
-                  readTime={post.readTime}
-                />
-              </div>
+              {!lock && (
+                <div className='mr-2'>
+                  <WordCount
+                    wordCount={post.wordCount}
+                    readTime={post.readTime}
+                  />
+                </div>
+              )}
               {post?.type !== 'Page' && (
                 <>
                   <SmartLink


### PR DESCRIPTION
## 已知问题

HEO 主题的加密文章在未解锁时仍显示字数和阅读时长。由于正文尚未加载，这两个值会显示为 `0` 和约 `1` 分钟，容易让访问者误解。

Fixes #3417

## 解决方案

复用文章页已经传入 HEO 页头的 `lock` 状态：

- 文章未解锁时隐藏 `WordCount`；
- 密码验证成功、`lock` 变为 `false` 后自动恢复字数和阅读时长；
- 发布时间、更新时间等其它元数据保持现有行为。

## 改动收益

- 不再展示失真的字数和阅读时长；
- 解锁后的正常文章信息不受影响；
- 改动仅限 HEO 主题，不影响其它主题和共享数据层。

## 具体改动

1. `themes/heo/components/PostHeader.js`
   - 接收现有 `lock` 属性；
   - 仅在文章已解锁时渲染 `WordCount`。
2. `__tests__/themes/heo/PostHeader.test.js`
   - 覆盖锁定状态隐藏字数/阅读时长；
   - 覆盖解锁后恢复显示。

## 风险与兼容性

- 风险较低，改动范围限定在 HEO 主题文章页头；
- 未加密文章和已解锁文章的表现保持不变；
- 不包含配置、路由、数据层或依赖改动。

## 测试确认

- [x] `yarn test --runInBand --watchAll=false __tests__/themes/heo/PostHeader.test.js`
- [x] `yarn test --runInBand --watchAll=false`（32 个测试套件、182 个测试全部通过）
- [x] `yarn type-check`
- [x] `yarn lint`（通过；输出仅包含仓库既有告警，本次目标文件无告警）
- [x] `git diff --check`
- [ ] 生产环境构建测试（本次未执行）

## 用户文档

- [x] 不适用：本次仅修复 HEO 已有行为，不新增配置项、部署步骤或用户操作。