### PR TITLE
fix(notion): 遵循 Gallery 页面图标开关

### DIFF
--- a/__tests__/components/NotionCollectionGallery.test.js
+++ b/__tests__/components/NotionCollectionGallery.test.js
@@ -1,0 +1,78 @@
+import { execFileSync } from 'child_process'
+
+const renderGalleryScript = `
+  const React = (await import('react')).default
+  const { renderToStaticMarkup } = await import('react-dom/server')
+  const { NotionRenderer } = await import('react-notion-x')
+  const { Collection } = await import('react-notion-x/build/third-party/collection')
+  const createRecordMap = showPageIcon => ({
+    block: {
+      collection_view: {
+        value: { id: 'collection_view', type: 'collection_view',
+          collection_id: 'collection', view_ids: ['gallery_view'] }
+      },
+      page: {
+        value: { id: 'page', type: 'page', parent_table: 'collection',
+          properties: { title: [['Gallery item']] },
+          format: { page_icon: '📄' } }
+      }
+    },
+    collection: {
+      collection: {
+        value: { id: 'collection', name: [['Gallery']],
+          schema: { title: { name: 'Name', type: 'title' } } }
+      }
+    },
+    collection_view: {
+      gallery_view: {
+        value: { id: 'gallery_view', type: 'gallery',
+          format: {
+            collection_pointer: { id: 'collection' },
+            show_page_icon: showPageIcon,
+            gallery_cover: { type: 'none' },
+            gallery_cover_size: 'medium',
+            gallery_cover_aspect: 'cover',
+            gallery_properties: []
+          } }
+      }
+    },
+    collection_query: {
+      collection: {
+        gallery_view: { collection_group_results: { blockIds: ['page'] } }
+      }
+    },
+    signed_urls: {}
+  })
+  const renderGallery = showPageIcon =>
+    renderToStaticMarkup(
+      React.createElement(NotionRenderer, {
+        recordMap: createRecordMap(showPageIcon),
+        components: { Collection }
+      })
+    )
+  process.stdout.write(JSON.stringify({
+    hidden: renderGallery(false),
+    visible: renderGallery(true)
+  }))
+`
+
+describe('Notion Gallery page icon setting', () => {
+  const result = JSON.parse(
+    execFileSync(process.execPath, [
+      '--input-type=module',
+      '-e',
+      renderGalleryScript
+    ])
+  )
+
+  it('adds the page-icon hiding class when Notion disables icons', () => {
+    expect(result.hidden).toContain(
+      'notion-gallery notion-gallery-hide-page-icons'
+    )
+  })
+
+  it('keeps page icons visible when Notion enables icons', () => {
+    expect(result.visible).toContain('class="notion-gallery"')
+    expect(result.visible).not.toContain('notion-gallery-hide-page-icons')
+  })
+})

--- a/patches/react-notion-x+7.10.0.patch
+++ b/patches/react-notion-x+7.10.0.patch
@@ -1,0 +1,16 @@
+diff --git a/node_modules/react-notion-x/build/third-party/collection.js b/node_modules/react-notion-x/build/third-party/collection.js
+index 97e229d..64344de 100644
+--- a/node_modules/react-notion-x/build/third-party/collection.js
++++ b/node_modules/react-notion-x/build/third-party/collection.js
+@@ -5877,7 +5877,10 @@ function Gallery({
+   const shouldLimit = typeof loadLimit === "number";
+   const showLoadMore = shouldLimit && !isExpanded && ((blockIds == null ? void 0 : blockIds.length) || 0) > loadLimit;
+   const visibleBlockIds = showLoadMore ? blockIds == null ? void 0 : blockIds.slice(0, loadLimit) : blockIds;
+-  return /* @__PURE__ */ jsxs17("div", { className: "notion-gallery", children: [
++  return /* @__PURE__ */ jsxs17("div", { className: cs(
++    "notion-gallery",
++    collectionView.format && collectionView.format.show_page_icon === false && "notion-gallery-hide-page-icons"
++  ), children: [
+     /* @__PURE__ */ jsx54("div", { className: "notion-gallery-view", children: /* @__PURE__ */ jsx54(
+       "div",
+       {

--- a/styles/notion.css
+++ b/styles/notion.css
@@ -2198,6 +2198,11 @@ figure.notion-asset-wrapper.notion-asset-wrapper-video > div {
   padding: 0 16px;
 }
 
+/* Respect Notion Gallery's "Show page icon" view setting. */
+.notion-gallery-hide-page-icons .notion-page-title-icon {
+  display: none;
+}
+
 /* Dark mode: database property tags (select / multi_select) text readability */
 html.dark .notion-property-select-item,
 html.dark .notion-property-status-item,


### PR DESCRIPTION
## 已知问题

Gallery 视图在 Notion 中关闭“显示页面图标”后，站点仍会在卡片标题前显示页面图标。

原因是当前锁定的 `react-notion-x@7.10.0` 在 Gallery 渲染时会读取封面、尺寸和属性等视图配置，但没有处理 `show_page_icon`。

Fixes #4293

## 解决方案

1. 使用现有 `patch-package` 机制，让 Gallery 在 `show_page_icon === false` 时增加专用 class。
2. 在 `styles/notion.css` 中仅隐藏该 Gallery 内的 `.notion-page-title-icon`。
3. 增加服务端渲染回归测试，同时覆盖关闭和开启页面图标两种状态。

选择精确判断 `=== false`，因此旧数据没有该字段时仍保持当前的显示行为。

## 改动收益

1. Gallery 的页面图标显示与 Notion 视图配置保持一致。
2. 不升级依赖、不改动数据层，也不影响 Table、List、Board 或页面正文中的图标。
3. 修复限定为 3 个文件、99 行新增，便于审查和回滚。

## 具体改动

1. `patches/react-notion-x+7.10.0.patch`
   - 读取 Gallery 的 `show_page_icon` 并增加隔离 class。
2. `styles/notion.css`
   - 仅在隔离 class 下隐藏 Gallery 卡片标题图标。
3. `__tests__/components/NotionCollectionGallery.test.js`
   - 验证关闭时增加隐藏 class，开启时不增加。

## 风险与兼容性评估

- 风险等级：中低。
- 无破坏性变更；未配置 `show_page_icon` 的现有视图行为不变。
- 样式选择器限定在 Gallery 容器内，不影响其它页面图标。
- 补丁绑定 `react-notion-x@7.10.0`；未来升级该依赖时需要重新检查上游是否已经原生支持该配置。

## 测试确认

- [x] `yarn test __tests__/components/NotionCollectionGallery.test.js --runInBand --watchAll=false`（2/2 通过）
- [x] `yarn test --runInBand --watchAll=false`（34/34 suites，191/191 tests 通过）
- [x] `yarn type-check`
- [x] `yarn lint`（退出码 0；仅有 `main` 已存在的告警，本次文件无新增告警）
- [x] `git diff --check`
- [x] `yarn install --frozen-lockfile --force`（确认 `patch-package` 可重新应用）

## 用户文档（`docs/user-guide/` / `docs/developer/`）

- [x] 不适用（修复现有 Notion Gallery 配置的渲染行为，无新增站长配置、环境变量或部署步骤）
