### PR TITLE
ci: fix docs Cloudflare deploy command

### DIFF
--- a/.github/workflows/deploy-docs-site.yml
+++ b/.github/workflows/deploy-docs-site.yml
@@ -56,9 +56,7 @@ jobs:
         run: echo "CF_PAGES_PROJECT=${{ vars.CLOUDFLARE_PAGES_PROJECT_NAME || 'notionnext-docs' }}" >> "$GITHUB_ENV"
 
       - name: Deploy to Cloudflare Pages
-        uses: cloudflare/wrangler-action@v3
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          wranglerVersion: "4"
-          command: pages deploy .vitepress/dist --project-name=${{ env.CF_PAGES_PROJECT }}
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: npx wrangler@4 pages deploy .vitepress/dist --project-name=${{ env.CF_PAGES_PROJECT }} --commit-dirty=true


### PR DESCRIPTION
## Summary

- replace `cloudflare/wrangler-action` with a direct `npx wrangler@4 pages deploy` command
- pass Cloudflare credentials through standard Wrangler environment variables
- add `--commit-dirty=true` so generated docs artifacts do not block deployment

## Why

The docs deployment for #4324 built VitePress successfully but failed during Cloudflare Pages deploy. `wrangler-action` installed Wrangler into the checkout and the final deploy failed while parsing `_worker.js`.

## Verification

- `git diff --check -- .github/workflows/deploy-docs-site.yml`