### PR TITLE
ci: let Wrangler upload Pages functions

### DIFF
--- a/.github/workflows/deploy-docs-site.yml
+++ b/.github/workflows/deploy-docs-site.yml
@@ -49,9 +49,6 @@ jobs:
           VITE_DOCS_CHAT_API: /api/docs-chat
         run: yarn docs:site:build
 
-      - name: Build Pages Functions
-        run: npx wrangler pages functions build functions --outfile .vitepress/dist/_worker.js --output-routes-path .vitepress/dist/_routes.json --project-directory .
-
       - name: Set Pages project name
         run: echo "CF_PAGES_PROJECT=${{ vars.CLOUDFLARE_PAGES_PROJECT_NAME || 'notionnext-docs' }}" >> "$GITHUB_ENV"
 


### PR DESCRIPTION
## Summary

- remove the explicit `wrangler pages functions build` step
- let `wrangler pages deploy .vitepress/dist` handle the repository `functions/` directory directly

## Why

The deploy workflow generated `.vitepress/dist/_worker.js` with multipart form-data content, which Cloudflare then tried to parse as JavaScript and rejected. Wrangler Pages deploy supports uploading a project with a root `functions/` directory directly.

## Verification

- `git diff --check -- .github/workflows/deploy-docs-site.yml`
- locally reproduced that the removed build step writes multipart `Content-Disposition` content to `_worker.js`