### PR TITLE
docs: add 88lin site to Showcase

### DIFF
--- a/docs/user-guide/showcase.md
+++ b/docs/user-guide/showcase.md
@@ -32,6 +32,7 @@
 | --- | --- | --- | --- |
 | [NotionNext 主题预览站](https://preview.tangly1024.com/) | 主题预览 | 多主题 | NotionNext |
 | [Tangly Blog](https://blog.tangly1024.com/) | 个人博客 | 未标注 | tangly1024 |
+| [茉灵智库](https://blog.88lin.eu.org) | 个人博客 | `heo` | [@88lin](https://github.com/88lin) |
 
 ## 推荐格式
 


### PR DESCRIPTION
## Summary

- add the first community-submitted site from Discussion #4319 to the Showcase page

## Verification

- checked https://blog.88lin.eu.org returns HTTP 200
- `git diff --check -- docs/user-guide/showcase.md`