### PR TITLE
fix(notion): 遵循 Gallery 图标与标题可见性

### DIFF
--- a/__tests__/components/NotionCollectionGallery.test.js
+++ b/__tests__/components/NotionCollectionGallery.test.js
@@ -5,7 +5,11 @@ const renderGalleryScript = `
   const { renderToStaticMarkup } = await import('react-dom/server')
   const { NotionRenderer } = await import('react-notion-x')
   const { Collection } = await import('react-notion-x/build/third-party/collection')
-  const createRecordMap = showPageIcon => ({
+  const createRecordMap = ({
+    showPageIcon,
+    titleVisible,
+    legacyTitleVisible
+  }) => ({
     block: {
       collection_view: {
         value: { id: 'collection_view', type: 'collection_view',
@@ -28,11 +32,17 @@ const renderGalleryScript = `
         value: { id: 'gallery_view', type: 'gallery',
           format: {
             collection_pointer: { id: 'collection' },
-            show_page_icon: showPageIcon,
+            ...(showPageIcon === undefined ? {} : { show_page_icon: showPageIcon }),
+            ...(legacyTitleVisible === undefined
+              ? {}
+              : { gallery_title_visible: legacyTitleVisible }),
             gallery_cover: { type: 'none' },
             gallery_cover_size: 'medium',
             gallery_cover_aspect: 'cover',
-            gallery_properties: []
+            gallery_properties:
+              titleVisible === undefined
+                ? []
+                : [{ property: 'title', visible: titleVisible }]
           } }
       }
     },
@@ -43,20 +53,22 @@ const renderGalleryScript = `
     },
     signed_urls: {}
   })
-  const renderGallery = showPageIcon =>
+  const renderGallery = options =>
     renderToStaticMarkup(
       React.createElement(NotionRenderer, {
-        recordMap: createRecordMap(showPageIcon),
+        recordMap: createRecordMap(options),
         components: { Collection }
       })
     )
   process.stdout.write(JSON.stringify({
-    hidden: renderGallery(false),
-    visible: renderGallery(true)
+    hidden: renderGallery({ titleVisible: false }),
+    titleVisible: renderGallery({ titleVisible: true }),
+    enabled: renderGallery({ showPageIcon: true, titleVisible: true }),
+    legacy: renderGallery({ legacyTitleVisible: true })
   }))
 `
 
-describe('Notion Gallery page icon setting', () => {
+describe('Notion Gallery visibility settings', () => {
   const result = JSON.parse(
     execFileSync(process.execPath, [
       '--input-type=module',
@@ -65,14 +77,27 @@ describe('Notion Gallery page icon setting', () => {
     ])
   )
 
-  it('adds the page-icon hiding class when Notion disables icons', () => {
+  it('hides omitted page icons and an explicitly hidden title', () => {
     expect(result.hidden).toContain(
-      'notion-gallery notion-gallery-hide-page-icons'
+      'notion-gallery notion-gallery-hide-page-icons notion-gallery-hide-titles'
     )
   })
 
-  it('keeps page icons visible when Notion enables icons', () => {
-    expect(result.visible).toContain('class="notion-gallery"')
-    expect(result.visible).not.toContain('notion-gallery-hide-page-icons')
+  it('keeps a visible title while the omitted page-icon setting stays hidden', () => {
+    expect(result.titleVisible).toContain(
+      'notion-gallery notion-gallery-hide-page-icons'
+    )
+    expect(result.titleVisible).not.toContain('notion-gallery-hide-titles')
+  })
+
+  it('keeps page icons visible when Notion explicitly enables them', () => {
+    expect(result.enabled).toContain('class="notion-gallery"')
+    expect(result.enabled).not.toContain('notion-gallery-hide-page-icons')
+    expect(result.enabled).not.toContain('notion-gallery-hide-titles')
+  })
+
+  it('preserves legacy Gallery data without the page-icon setting', () => {
+    expect(result.legacy).toContain('class="notion-gallery"')
+    expect(result.legacy).not.toContain('notion-gallery-hide-page-icons')
   })
 })

--- a/patches/react-notion-x+7.10.0.patch
+++ b/patches/react-notion-x+7.10.0.patch
@@ -1,15 +1,31 @@
 diff --git a/node_modules/react-notion-x/build/third-party/collection.js b/node_modules/react-notion-x/build/third-party/collection.js
-index 97e229d..64344de 100644
+index 97e229d..9d2e9f3 100644
 --- a/node_modules/react-notion-x/build/third-party/collection.js
 +++ b/node_modules/react-notion-x/build/third-party/collection.js
-@@ -5877,7 +5877,10 @@ function Gallery({
+@@ -5870,14 +5870,26 @@ function Gallery({
+     gallery_cover = { type: "none" },
+     gallery_cover_size = "medium",
+     gallery_cover_aspect = "cover",
++    gallery_properties,
++    gallery_title_visible,
++    show_page_icon,
+     inline_collection_first_load_limit
+   } = collectionView.format || {};
++  const titleProperty = gallery_properties == null ? void 0 : gallery_properties.find(
++    (property) => property.property === "title"
++  );
++  const shouldHidePageIcons = show_page_icon === false || show_page_icon == null && gallery_title_visible == null;
++  const shouldHideTitle = titleProperty ? titleProperty.visible === false : gallery_title_visible === false;
+   const [isExpanded, setIsExpanded] = React19.useState(false);
+   const loadLimit = inline_collection_first_load_limit == null ? void 0 : inline_collection_first_load_limit.limit;
    const shouldLimit = typeof loadLimit === "number";
    const showLoadMore = shouldLimit && !isExpanded && ((blockIds == null ? void 0 : blockIds.length) || 0) > loadLimit;
    const visibleBlockIds = showLoadMore ? blockIds == null ? void 0 : blockIds.slice(0, loadLimit) : blockIds;
 -  return /* @__PURE__ */ jsxs17("div", { className: "notion-gallery", children: [
 +  return /* @__PURE__ */ jsxs17("div", { className: cs(
 +    "notion-gallery",
-+    collectionView.format && collectionView.format.show_page_icon === false && "notion-gallery-hide-page-icons"
++    shouldHidePageIcons && "notion-gallery-hide-page-icons",
++    shouldHideTitle && "notion-gallery-hide-titles"
 +  ), children: [
      /* @__PURE__ */ jsx54("div", { className: "notion-gallery-view", children: /* @__PURE__ */ jsx54(
        "div",

--- a/styles/notion.css
+++ b/styles/notion.css
@@ -2203,6 +2203,13 @@ figure.notion-asset-wrapper.notion-asset-wrapper-video > div {
   display: none;
 }
 
+/* Respect the Gallery title property's visibility setting. */
+.notion-gallery-hide-titles
+  .notion-collection-card-body
+  > .notion-collection-card-property:first-child {
+  display: none;
+}
+
 /* Dark mode: database property tags (select / multi_select) text readability */
 html.dark .notion-property-select-item,
 html.dark .notion-property-status-item,


### PR DESCRIPTION
## 已知问题

#4316 已让 Gallery 在 `show_page_icon === false` 时隐藏页面图标，但 #4334 的实际回归样例使用了 Notion 当前的数据形态：

1. 关闭“显示页面图标”时，`show_page_icon` 会被省略，而不是固定返回 `false`；
2. Title 可见性记录在 `gallery_properties` 的 `visible` 字段中，当前渲染仍会无条件输出 Title。

因此，原测试里人工构造的 `show_page_icon: false` 可以通过，但实际 Gallery 仍显示页面图标和被隐藏的 Title。

Fixes #4334

## 解决方案

1. 扩展现有 `react-notion-x@7.10.0` 补丁：
   - 当前 Gallery 数据省略 `show_page_icon` 时按关闭处理；
   - 显式 `show_page_icon: true` 时保留页面图标；
   - 对仍包含 `gallery_title_visible` 的旧数据保持原有图标行为。
2. 从 `gallery_properties` 读取 Title 的 `visible` 状态；旧数据则回退到 `gallery_title_visible`。
3. 为隐藏 Title 增加 Gallery 内部专用 class 和限定样式，不影响其它 Collection 视图或页面正文。
4. 将回归测试改为覆盖真实的“字段省略”形态，并覆盖 Title 隐藏、Title 可见、显式开启图标和旧数据兼容四种状态。

## 改动收益

1. Gallery 的页面图标和 Title 与 Notion 当前视图配置保持一致。
2. 修复限定为 3 个文件、63 行新增和 15 行删除，不升级依赖、不改数据层。
3. 样式选择器只作用于 Gallery 卡片，不影响 Table、List、Board 或普通页面标题。

## 具体改动

1. `patches/react-notion-x+7.10.0.patch`
   - 兼容当前与旧版 Gallery 可见性字段；
   - 为隐藏图标和隐藏 Title 添加隔离 class。
2. `styles/notion.css`
   - 隐藏 Gallery 卡片中的 Title 属性容器。
3. `__tests__/components/NotionCollectionGallery.test.js`
   - 覆盖当前字段省略形态、显式开启以及旧数据回退。

## 风险与兼容性评估

- 风险等级：中低。
- 无路由、鉴权、数据迁移、依赖升级或破坏性变更。
- 旧版 `gallery_title_visible` 数据保留原有页面图标行为；当前数据仅在未显式开启图标时隐藏。
- 补丁绑定 `react-notion-x@7.10.0`；未来升级依赖时需要重新检查上游是否已原生支持这些配置。

## 测试确认

- [x] `yarn test __tests__/components/NotionCollectionGallery.test.js --runInBand --watchAll=false`（4/4 通过）
- [x] `yarn test --runInBand --watchAll=false`（35/35 suites，194/194 tests 通过）
- [x] `yarn type-check`
- [x] `yarn lint`（退出码 0；仅有 `main` 已存在的告警，本次文件无新增告警）
- [x] `git diff --check`
- [x] `yarn install --frozen-lockfile --force`（确认 `patch-package` 可重新应用）
- [x] 浏览器样式验收：隐藏状态下图标与 Title 均不可见；Title 可见状态下仅隐藏图标；显式开启时两者均可见

## 用户文档（`docs/user-guide/` / `docs/developer/`）

- [x] 不适用（修复现有 Notion Gallery 配置的渲染行为，无新增站长配置、环境变量或部署步骤）
