### PR TITLE
fix(notion): 修复菜单跳转 Category Mapping Page 404

### DIFF
--- a/__tests__/lib/db/SiteDataApi.customMenu.test.js
+++ b/__tests__/lib/db/SiteDataApi.customMenu.test.js
@@ -1,0 +1,125 @@
+/**
+ * @jest-environment node
+ */
+
+import {
+  getCustomMenu,
+  getSourcePageSlugs
+} from '@/lib/db/notion/getCustomMenu'
+
+describe('getCustomMenu', () => {
+  it('uses the generated page href when a menu targets the page source slug', () => {
+    const collectionData = [
+      {
+        id: 'page-pending',
+        type: 'Page',
+        status: 'Published',
+        slug: 'pending'
+      },
+      {
+        id: 'page-contact',
+        type: 'Page',
+        status: 'Published',
+        slug: 'contact'
+      },
+      {
+        id: 'menu-pending',
+        type: 'Menu',
+        status: 'Published',
+        title: 'Pending',
+        slug: 'pending',
+        href: '/pending'
+      },
+      {
+        id: 'menu-more',
+        type: 'Menu',
+        status: 'Published',
+        title: 'More',
+        slug: '#',
+        href: '#'
+      },
+      {
+        id: 'submenu-contact',
+        type: 'SubMenu',
+        status: 'Published',
+        title: 'Contact',
+        slug: '/contact',
+        href: '/contact'
+      }
+    ]
+    const sourcePageSlugs = getSourcePageSlugs(collectionData)
+    collectionData[0].slug = 'pending/2026/07/29/pending'
+    collectionData[0].href = '/pending/2026/07/29/pending'
+    collectionData[1].slug = 'contact/2026/07/29/contact'
+    collectionData[1].href = '/contact/2026/07/29/contact.html'
+
+    const menus = getCustomMenu({ collectionData, sourcePageSlugs })
+
+    expect(menus[0].href).toBe('/pending/2026/07/29/pending')
+    expect(menus[1].href).toBe('#')
+    expect(menus[1].subMenus[0].href).toBe('/contact/2026/07/29/contact.html')
+  })
+
+  it('keeps unmatched and external menu links unchanged', () => {
+    const collectionData = [
+      {
+        id: 'menu-archive',
+        type: 'Menu',
+        status: 'Published',
+        title: 'Archive',
+        slug: '/archive',
+        href: '/archive'
+      },
+      {
+        id: 'menu-external',
+        type: 'Menu',
+        status: 'Published',
+        title: 'External',
+        slug: 'https://example.com',
+        href: 'https://example.com'
+      }
+    ]
+
+    const menus = getCustomMenu({
+      collectionData,
+      sourcePageSlugs: new Map()
+    })
+
+    expect(menus.map(menu => menu.href)).toEqual([
+      '/archive',
+      'https://example.com'
+    ])
+  })
+
+  it('does not guess when multiple pages shared the same source slug', () => {
+    const collectionData = [
+      {
+        id: 'page-one',
+        type: 'Page',
+        status: 'Published',
+        slug: 'guide'
+      },
+      {
+        id: 'page-two',
+        type: 'Page',
+        status: 'Published',
+        slug: 'guide'
+      },
+      {
+        id: 'menu-guide',
+        type: 'Menu',
+        status: 'Published',
+        title: 'Guide',
+        slug: 'guide',
+        href: '/guide'
+      }
+    ]
+    const sourcePageSlugs = getSourcePageSlugs(collectionData)
+    collectionData[0].href = '/manual/guide'
+    collectionData[1].href = '/docs/guide'
+
+    const menus = getCustomMenu({ collectionData, sourcePageSlugs })
+
+    expect(menus[0].href).toBe('/guide')
+  })
+})

--- a/lib/db/SiteDataApi.js
+++ b/lib/db/SiteDataApi.js
@@ -8,6 +8,10 @@ import getPageProperties, {
   adjustPageProperties
 } from '@/lib/db/notion/getPageProperties'
 import {
+  getCustomMenu,
+  getSourcePageSlugs
+} from '@/lib/db/notion/getCustomMenu'
+import {
   fetchInBatches,
   fetchNotionPageBlocks,
   formatNotionBlock
@@ -569,6 +573,7 @@ async function convertNotionToSiteData(
       })
     )
   }
+  const sourcePageSlugs = getSourcePageSlugs(collectionData)
   collectionData.forEach(element => adjustPageProperties(element, NOTION_CONFIG))
 
   const officialMembers = await fetchMembersFromOfficialAPI({
@@ -622,7 +627,7 @@ async function convertNotionToSiteData(
   const tagSchemaOptions = getTagOptions(schema)
   const tagOptions = getAllTags({ allPages, tagOptions: tagSchemaOptions ?? [], NOTION_CONFIG }) ?? null
   const customNav = getCustomNav({ allPages: collectionData.filter(post => post?.type === 'Page' && post.status === 'Published') })
-  const customMenu = getCustomMenu({ collectionData, NOTION_CONFIG })
+  const customMenu = getCustomMenu({ collectionData, sourcePageSlugs })
   const latestPosts = getLatestPosts({
     allPages,
     from,
@@ -832,33 +837,6 @@ function getCustomNav({ allPages }) {
     })
   }
   return customNav
-}
-
-function getCustomMenu({ collectionData, NOTION_CONFIG }) {
-  const menuPages = collectionData.filter(
-    post =>
-      post.status === 'Published' &&
-      (post?.type === 'Menu' || post?.type === 'SubMenu')
-  )
-  const menus = []
-  if (menuPages && menuPages.length > 0) {
-    menuPages.forEach(e => {
-      e.show = true
-      if (e.type === 'Menu') {
-        menus.push(e)
-      } else if (e.type === 'SubMenu') {
-        const parentMenu = menus[menus.length - 1]
-        if (parentMenu) {
-          if (parentMenu.subMenus) {
-            parentMenu.subMenus.push(e)
-          } else {
-            parentMenu.subMenus = [e]
-          }
-        }
-      }
-    })
-  }
-  return menus
 }
 
 function getTagOptions(schema) {

--- a/lib/db/notion/getCustomMenu.js
+++ b/lib/db/notion/getCustomMenu.js
@@ -1,0 +1,86 @@
+function normalizeSourceSlug(slug) {
+  if (typeof slug !== 'string') {
+    return ''
+  }
+
+  const normalized = slug.trim()
+  if (
+    !normalized ||
+    normalized === '#' ||
+    /^(?:[a-z][a-z\d+.-]*:|\/\/)/i.test(normalized)
+  ) {
+    return ''
+  }
+
+  return normalized.replace(/^\/+|\/+$/g, '')
+}
+
+export function getSourcePageSlugs(collectionData) {
+  return new Map(
+    collectionData
+      .filter(page => page?.type === 'Page' && page?.slug)
+      .map(page => [page.id, page.slug])
+  )
+}
+
+function getPageHrefBySourceSlug(collectionData, sourcePageSlugs) {
+  const pageHrefBySourceSlug = new Map()
+  const ambiguousSlugs = new Set()
+
+  collectionData.forEach(page => {
+    if (page?.type !== 'Page' || page?.status !== 'Published' || !page?.href) {
+      return
+    }
+
+    const sourceSlug = normalizeSourceSlug(sourcePageSlugs?.get(page.id))
+    if (!sourceSlug || ambiguousSlugs.has(sourceSlug)) {
+      return
+    }
+
+    const existingHref = pageHrefBySourceSlug.get(sourceSlug)
+    if (existingHref && existingHref !== page.href) {
+      pageHrefBySourceSlug.delete(sourceSlug)
+      ambiguousSlugs.add(sourceSlug)
+      return
+    }
+
+    pageHrefBySourceSlug.set(sourceSlug, page.href)
+  })
+
+  return pageHrefBySourceSlug
+}
+
+export function getCustomMenu({ collectionData, sourcePageSlugs }) {
+  const pageHrefBySourceSlug = getPageHrefBySourceSlug(
+    collectionData,
+    sourcePageSlugs
+  )
+  const menuPages = collectionData.filter(
+    post =>
+      post.status === 'Published' &&
+      (post?.type === 'Menu' || post?.type === 'SubMenu')
+  )
+  const menus = []
+  if (menuPages && menuPages.length > 0) {
+    menuPages.forEach(e => {
+      e.show = true
+      const sourceSlug = normalizeSourceSlug(e.slug)
+      if (sourceSlug && pageHrefBySourceSlug.has(sourceSlug)) {
+        e.href = pageHrefBySourceSlug.get(sourceSlug)
+      }
+      if (e.type === 'Menu') {
+        menus.push(e)
+      } else if (e.type === 'SubMenu') {
+        const parentMenu = menus[menus.length - 1]
+        if (parentMenu) {
+          if (parentMenu.subMenus) {
+            parentMenu.subMenus.push(e)
+          } else {
+            parentMenu.subMenus = [e]
+          }
+        }
+      }
+    })
+  }
+  return menus
+}


### PR DESCRIPTION
## 已知问题

启用 `POST_URL_PREFIX_MAPPING_CATEGORY` 后，Page 会在站点数据生成阶段得到带分类与日期前缀的最终路由；但指向该 Page 原始 Slug 的 Menu / SubMenu 仍保留旧路径，因此点击后进入 404。

Fixes #4336

## 解决方案

1. 在 Page 应用 Category Mapping 前保留其原始 Slug。
2. 生成自定义菜单时，用原始 Slug 将 Menu / SubMenu 与已发布 Page 做精确匹配。
3. 仅在匹配唯一时，把菜单链接更新为 Page 的最终 `href`，因此会同时继承分类前缀、日期前缀和伪静态 `.html`。
4. 外链、未匹配菜单以及原始 Slug 冲突的页面保持原行为，不做猜测。

## 改动收益

- Menu 与 SubMenu 会跟随目标 Page 的最终路由，不再因 Category Mapping 进入 404。
- 修复位于共享数据层，所有主题都能获得一致结果。
- 不新增配置、不改变 Page 路由生成规则，也不影响外部链接。

## 具体改动

1. `lib/db/SiteDataApi.js`
   - 在调整 Page 路由前保存原始 Slug；
   - 使用提取后的菜单生成函数。
2. `lib/db/notion/getCustomMenu.js`
   - 封装既有菜单层级逻辑；
   - 增加“原始 Page Slug → 最终 href”的唯一匹配。
3. `__tests__/lib/db/SiteDataApi.customMenu.test.js`
   - 覆盖 Menu、SubMenu、伪静态后缀、外链、未匹配与重复 Slug 场景。

## 风险与兼容性评估

- 风险等级：中低。
- 仅匹配 `Published` Page，且要求原始 Slug 唯一；有歧义时保留菜单原链接。
- 现有菜单层级、`show`、`target` 和外链行为不变。
- 无依赖升级、数据迁移或配置默认值变化。

## 测试确认

- [x] `yarn test __tests__/lib/db/SiteDataApi.customMenu.test.js __tests__/lib/db/notion/getPageProperties.test.js --runInBand`（2 suites / 4 tests）
- [x] `yarn test --runInBand`（36 suites / 197 tests）
- [x] `yarn type-check`
- [x] `yarn lint`（退出码 0；仅有 `main` 已存在的 warnings）
- [x] `yarn build`（61 个静态页面生成完成）
- [x] `yarn deps:check-lockfile`
- [x] `git diff --check`

## 用户文档（`docs/user-guide/` / `docs/developer/`）

- [x] 不适用：本次恢复 Menu / SubMenu 指向 Page 的既有语义，不新增站长配置、环境变量或部署步骤。