### PR TITLE
fix(matery): 修复右下角悬浮图标居中偏移与点击光标闪烁

### DIFF
--- a/themes/matery/components/FloatDarkModeButton.js
+++ b/themes/matery/components/FloatDarkModeButton.js
@@ -21,9 +21,13 @@ export default function FloatDarkModeButton() {
   }
 
   return (
-        <div className={'justify-center items-center text-center' } onClick={handleChangeDarkMode}>
-            <i id="darkModeButton" className={`${isDarkMode ? 'fa-sun' : 'fa-moon'} fas transform hover:scale-105 duration-200
-                 text-white bg-indigo-700  w-10 h-10  py-2.5 rounded-full dark:bg-black cursor-pointer`} />
-        </div>
+    <div
+      className='flex justify-center items-center text-center select-none'
+      onClick={handleChangeDarkMode}>
+      <i
+        id='darkModeButton'
+        className={`${isDarkMode ? 'fa-sun' : 'fa-moon'} fas transform hover:scale-105 duration-200 text-white bg-indigo-700 w-10 h-10 rounded-full dark:bg-black cursor-pointer flex justify-center items-center`}
+      />
+    </div>
   )
 }

--- a/themes/matery/components/JumpToTopButton.js
+++ b/themes/matery/components/JumpToTopButton.js
@@ -17,13 +17,20 @@ const JumpToTopButton = ({ showPercent = true, percent }) => {
     return <></>
   }
 
-  return <div data-aos="fade-left"
-        data-aos-duration="300"
-        data-aos-anchor-placement="top-center"
-        className={'justify-center items-center text-center'} onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })} >
-        <i id="darkModeButton" title={locale.POST.TOP} className={`fas fa-arrow-up transform hover:scale-105 duration-200 text-white
-        bg-indigo-700 w-10 h-10 rounded-full dark:bg-black cursor-pointer py-2.5`} />
+  return (
+    <div
+      data-aos='fade-left'
+      data-aos-duration='300'
+      data-aos-anchor-placement='top-center'
+      className='flex justify-center items-center text-center select-none'
+      onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}>
+      <i
+        id='jumpToTopButton'
+        title={locale.POST.TOP}
+        className='fas fa-arrow-up transform hover:scale-105 duration-200 text-white bg-indigo-700 w-10 h-10 rounded-full dark:bg-black cursor-pointer flex justify-center items-center'
+      />
     </div>
+  )
 }
 
 export default JumpToTopButton

--- a/themes/matery/components/SocialButton.js
+++ b/themes/matery/components/SocialButton.js
@@ -6,6 +6,14 @@ import { handleEmailClick } from '@/lib/plugins/mailEncrypt'
  * 社交联系方式按钮组 可折叠的组件
  * @returns {JSX.Element}
  * @constructor
+ *
+ * 修复说明：
+ * 1. 容器增加 `items-center`：原代码只有 `flex flex-col`，缺交叉轴居中，
+ *    导致展开后所有图标（含 RSS）在圆形/胶囊背景里横向不居中、明显偏移。
+ * 2. 容器增加 `w-10`：与 FloatDarkModeButton / JumpToTopButton 的 40px 圆形
+ *    保持宽度一致；收起态变成正圆，展开态变成等宽(40px)的胶囊，图标全部居中。
+ * 3. 每个图标改用 `flex justify-center items-center w-10 h-10`（iconWrapperCls）：
+ *    让每个社交图标各自成为 40px 居中单元，按几何中心精确居中，彻底消除偏移。
  */
 const SocialButton = () => {
   const [show, setShow] = useState(false)
@@ -27,13 +35,16 @@ const SocialButton = () => {
 
   const emailIcon = useRef(null)
 
+  // 单个图标的通用样式：40px 圆形容器 + 居中，与其它悬浮按钮一致
+  const iconWrapperCls =
+    'flex justify-center items-center w-10 h-10 hover:bg-indigo-600 dark:hover:bg-gray-800'
 
   return (
-    <div className='flex flex-col transform hover:scale-105 duration-200 text-white text-center bg-indigo-700 rounded-full dark:bg-black cursor-pointer py-2.5'>
+    <div className='flex flex-col items-center w-10 transform hover:scale-105 duration-200 text-white text-center bg-indigo-700 rounded-full dark:bg-black cursor-pointer overflow-hidden select-none'>
       {!show && (
         <i
           onClick={toggleShow}
-          className='transform hover:scale-125 duration-150 fas fa-user py-0.5'
+          className='transform hover:scale-125 duration-150 fas fa-user flex justify-center items-center w-10 h-10'
         />
       )}
       {show && (
@@ -43,8 +54,9 @@ const SocialButton = () => {
               target='_blank'
               rel='noreferrer'
               title={'github'}
-              href={CONTACT_GITHUB}>
-              <i className='transform hover:scale-125 duration-150 fab fa-github ' />
+              href={CONTACT_GITHUB}
+              className={iconWrapperCls}>
+              <i className='transform hover:scale-125 duration-150 fab fa-github' />
             </a>
           )}
           {CONTACT_ORCID && (
@@ -52,8 +64,9 @@ const SocialButton = () => {
               target='_blank'
               rel='noreferrer'
               title={'ORCID'}
-              href={CONTACT_ORCID}>
-              <i className='transform hover:scale-125 duration-150 fab fa-orcid ' />
+              href={CONTACT_ORCID}
+              className={iconWrapperCls}>
+              <i className='transform hover:scale-125 duration-150 fab fa-orcid' />
             </a>
           )}
           {CONTACT_TWITTER && (
@@ -61,8 +74,9 @@ const SocialButton = () => {
               target='_blank'
               rel='noreferrer'
               title={'twitter'}
-              href={CONTACT_TWITTER}>
-              <i className='transform hover:scale-125 duration-150 fab fa-twitter ' />
+              href={CONTACT_TWITTER}
+              className={iconWrapperCls}>
+              <i className='transform hover:scale-125 duration-150 fab fa-twitter' />
             </a>
           )}
           {CONTACT_TELEGRAM && (
@@ -70,8 +84,9 @@ const SocialButton = () => {
               target='_blank'
               rel='noreferrer'
               href={CONTACT_TELEGRAM}
-              title={'telegram'}>
-              <i className='transform hover:scale-125 duration-150 fab fa-telegram ' />
+              title={'telegram'}
+              className={iconWrapperCls}>
+              <i className='transform hover:scale-125 duration-150 fab fa-telegram' />
             </a>
           )}
           {CONTACT_LINKEDIN && (
@@ -79,8 +94,9 @@ const SocialButton = () => {
               target='_blank'
               rel='noreferrer'
               href={CONTACT_LINKEDIN}
-              title={'linkIn'}>
-              <i className='transform hover:scale-125 duration-150 fab fa-linkedin ' />
+              title={'linkIn'}
+              className={iconWrapperCls}>
+              <i className='transform hover:scale-125 duration-150 fab fa-linkedin' />
             </a>
           )}
           {CONTACT_WEIBO && (
@@ -88,8 +104,9 @@ const SocialButton = () => {
               target='_blank'
               rel='noreferrer'
               title={'weibo'}
-              href={CONTACT_WEIBO}>
-              <i className='transform hover:scale-125 duration-150 fab fa-weibo ' />
+              href={CONTACT_WEIBO}
+              className={iconWrapperCls}>
+              <i className='transform hover:scale-125 duration-150 fab fa-weibo' />
             </a>
           )}
           {CONTACT_INSTAGRAM && (
@@ -97,17 +114,18 @@ const SocialButton = () => {
               target='_blank'
               rel='noreferrer'
               title={'instagram'}
-              href={CONTACT_INSTAGRAM}>
-              <i className='transform hover:scale-125 duration-150 fab fa-instagram ' />
+              href={CONTACT_INSTAGRAM}
+              className={iconWrapperCls}>
+              <i className='transform hover:scale-125 duration-150 fab fa-instagram' />
             </a>
           )}
           {CONTACT_EMAIL && (
             <a
               onClick={e => handleEmailClick(e, emailIcon, CONTACT_EMAIL)}
               title='email'
-              className='cursor-pointer'
+              className={`cursor-pointer ${iconWrapperCls}`}
               ref={emailIcon}>
-              <i className='transform hover:scale-125 duration-150 fas fa-envelope ' />
+              <i className='transform hover:scale-125 duration-150 fas fa-envelope' />
             </a>
           )}
           {ENABLE_RSS && (
@@ -115,8 +133,9 @@ const SocialButton = () => {
               target='_blank'
               rel='noreferrer'
               title={'RSS'}
-              href={'/rss/feed.xml'}>
-              <i className='transform hover:scale-125 duration-150 fas fa-rss ' />
+              href={'/rss/feed.xml'}
+              className={iconWrapperCls}>
+              <i className='transform hover:scale-125 duration-150 fas fa-rss' />
             </a>
           )}
           {CONTACT_BILIBILI && (
@@ -124,7 +143,8 @@ const SocialButton = () => {
               target='_blank'
               rel='noreferrer'
               title={'bilibili'}
-              href={CONTACT_BILIBILI}>
+              href={CONTACT_BILIBILI}
+              className={iconWrapperCls}>
               <i className='fab fa-bilibili transform hover:scale-125 duration-150' />
             </a>
           )}
@@ -133,13 +153,14 @@ const SocialButton = () => {
               target='_blank'
               rel='noreferrer'
               title={'youtube'}
-              href={CONTACT_YOUTUBE}>
+              href={CONTACT_YOUTUBE}
+              className={iconWrapperCls}>
               <i className='fab fa-youtube transform hover:scale-125 duration-150' />
             </a>
           )}
           <i
             onClick={toggleShow}
-            className='transform hover:scale-125 duration-150 fas fa-close '
+            className='transform hover:scale-125 duration-150 fas fa-close flex justify-center items-center w-10 h-10'
           />
         </>
       )}


### PR DESCRIPTION
## 修复内容

修复 matery 主题右下角悬浮按钮的图标居中偏移与点击光标闪烁问题。

### 问题
1. **SocialButton**（可展开的社交/RSS 按钮）：展开后 RSS 等所有图标横向偏移、未居中，收起态非正圆。根因：容器只有 `flex flex-col` 缺 `items-center`，且无固定宽度。
2. **FloatDarkModeButton / JumpToTopButton**：图标略有偏移。根因：外层 div 写了 `justify-center items-center` 但缺 `flex`（类失效）；`<i>` 用 `py-2.5` 撑居中不可靠。
3. **JumpToTopButton** 的 `<i>` id 为 `darkModeButton`，与 FloatDarkModeButton 重复（复制粘贴 bug，违反 HTML id 唯一性）。
4. 点击图标时出现文本光标(caret)闪烁。

### 修复
- **SocialButton**：容器补 `items-center w-10`，每个图标用 `flex justify-center items-center w-10 h-10` 成为 40px 居中单元。
- **FloatDarkModeButton / JumpToTopButton**：外层 div 补 `flex`，`<i>` 改 `flex justify-center items-center` 并去掉不可靠的 `py-2.5`。
- **JumpToTopButton**：修正重复 id（`darkModeButton` → `jumpToTopButton`）。
- 三个按钮加 `select-none`（user-select:none）消除点击光标闪烁。

### 效果
三个悬浮按钮统一为 40×40 flex 居中，视觉完全对齐，点击不再出现光标闪烁。不影响任何点击功能。

### 改动文件
- `themes/matery/components/SocialButton.js`
- `themes/matery/components/FloatDarkModeButton.js`
- `themes/matery/components/JumpToTopButton.js`

已在个人 fork 部署验证生效。