### PR TITLE
feat: add automatic originality proof manifest

### DIFF
--- a/.github/workflows/originality-proofs.yml
+++ b/.github/workflows/originality-proofs.yml
@@ -1,0 +1,35 @@
+name: Originality proofs
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '20 2 * * *'
+
+permissions:
+  contents: write
+
+jobs:
+  update:
+    if: vars.ORIGINALITY_PROOF_AUTO_MANIFEST == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: yarn
+      - run: yarn install --frozen-lockfile
+      - run: yarn build
+        env:
+          ORIGINALITY_PROOF_AUTO_MANIFEST: 'true'
+      - name: Commit proof manifest
+        run: |
+          if git diff --quiet -- public/proofs/originality.json; then
+            echo "No originality proof changes."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add public/proofs/originality.json
+          git commit -m "chore: update originality proofs"
+          git push

--- a/__tests__/lib/utils/originalityProof.test.js
+++ b/__tests__/lib/utils/originalityProof.test.js
@@ -1,6 +1,7 @@
 /** @jest-environment node */
 
 import {
+  applyOriginalityProofRecord,
   createOriginalityProof,
   formatOriginalityProofText,
   isOriginalityProofEnabled
@@ -117,5 +118,27 @@ describe('originalityProof', () => {
         'Provider: local'
       ].join('\n')
     )
+  })
+
+  it('applies a public manifest record to a local proof', () => {
+    expect(
+      applyOriginalityProofRecord(
+        {
+          hash: 'local-hash',
+          proofTime: '2026-07-15',
+          provider: 'local'
+        },
+        {
+          hash: 'manifest-hash',
+          proofUrl: '/proofs/originality.json',
+          provider: 'manifest'
+        }
+      )
+    ).toMatchObject({
+      hash: 'manifest-hash',
+      proofTime: '2026-07-15',
+      proofUrl: '/proofs/originality.json',
+      provider: 'manifest'
+    })
   })
 })

--- a/__tests__/lib/utils/originalityProofManifest.test.js
+++ b/__tests__/lib/utils/originalityProofManifest.test.js
@@ -1,0 +1,80 @@
+/** @jest-environment node */
+
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import {
+  createOriginalityProofManifest,
+  findOriginalityProofManifestRecord,
+  isOriginalityProofAutoManifestEnabled,
+  recordOriginalityProofManifest
+} from '@/lib/utils/originalityProofManifest'
+
+describe('originalityProofManifest', () => {
+  it('creates a stable public manifest', () => {
+    expect(
+      createOriginalityProofManifest([
+        { pageId: 'b', url: 'https://example.com/b', hash: 'hash-b' },
+        { pageId: 'a', url: 'https://example.com/a', hash: 'hash-a' }
+      ])
+    ).toEqual({
+      version: 1,
+      proofs: [
+        {
+          pageId: 'a',
+          title: '',
+          url: 'https://example.com/a',
+          algorithm: 'SHA-256',
+          hash: 'hash-a',
+          proofTime: '',
+          proofUrl: '/proofs/originality.json',
+          provider: 'manifest'
+        },
+        {
+          pageId: 'b',
+          title: '',
+          url: 'https://example.com/b',
+          algorithm: 'SHA-256',
+          hash: 'hash-b',
+          proofTime: '',
+          proofUrl: '/proofs/originality.json',
+          provider: 'manifest'
+        }
+      ]
+    })
+  })
+
+  it('records and finds a manifest proof', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'notionnext-proof-'))
+    recordOriginalityProofManifest(
+      {
+        pageId: 'page-id',
+        title: 'Hello',
+        url: 'https://example.com/article/hello',
+        algorithm: 'SHA-256',
+        hash: 'hash',
+        proofTime: '2026-07-15'
+      },
+      true,
+      root
+    )
+
+    expect(
+      findOriginalityProofManifestRecord(
+        { id: 'page-id', href: '/article/hello' },
+        'https://example.com',
+        root
+      )
+    ).toMatchObject({
+      hash: 'hash',
+      proofUrl: '/proofs/originality.json',
+      provider: 'manifest'
+    })
+  })
+
+  it('parses manifest enable flags', () => {
+    expect(isOriginalityProofAutoManifestEnabled('true')).toBe(true)
+    expect(isOriginalityProofAutoManifestEnabled('是')).toBe(true)
+    expect(isOriginalityProofAutoManifestEnabled('false')).toBe(false)
+  })
+})

--- a/components/OriginalityProof.js
+++ b/components/OriginalityProof.js
@@ -13,6 +13,7 @@ const labels = {
   zh: {
     title: '原创存证',
     external: '外部凭证',
+    manifest: '公开清单',
     local: '本地哈希',
     algorithm: '算法',
     time: '时间',
@@ -26,6 +27,7 @@ const labels = {
   en: {
     title: 'Originality proof',
     external: 'External proof',
+    manifest: 'Public manifest',
     local: 'Local hash',
     algorithm: 'Algorithm',
     time: 'Time',
@@ -46,7 +48,12 @@ export default function OriginalityProof({ proof }) {
     ? labels.zh
     : labels.en
   const copyText = formatOriginalityProofText(proof)
-  const providerLabel = proof.provider === 'external' ? t.external : t.local
+  const providerLabel =
+    proof.provider === 'external'
+      ? t.external
+      : proof.provider === 'manifest'
+        ? t.manifest
+        : t.local
   const shortHash = `${String(proof.hash).slice(0, 12)}...`
   const copyProof = () => {
     if (!navigator.clipboard) {

--- a/conf/post.config.js
+++ b/conf/post.config.js
@@ -41,6 +41,8 @@ module.exports = {
 
   ORIGINALITY_PROOF_ENABLE:
     process.env.NEXT_PUBLIC_ORIGINALITY_PROOF_ENABLE || 'false', // 原创存证：生成并展示文章内容哈希，默认关闭
+  ORIGINALITY_PROOF_AUTO_MANIFEST:
+    process.env.ORIGINALITY_PROOF_AUTO_MANIFEST || 'false', // 原创存证：构建时自动生成 public/proofs/originality.json
 
   POST_WAITING_TIME_FOR_404:
     process.env.NEXT_PUBLIC_POST_WAITING_TIME_FOR_404 || '8', // 文章加载超时时间，单位秒；超时后跳转到404页面

--- a/docs/developer/rfc/2026-originality-proof-auto-manifest.md
+++ b/docs/developer/rfc/2026-originality-proof-auto-manifest.md
@@ -1,0 +1,40 @@
+# 原创存证自动公开清单任务
+
+状态：已实现，本地验收通过
+
+## 背景
+
+手动填写 `proof`、`proofHash` 或 `proofUrl` 已经足够低风险，但对全站原创长文用户仍然偏手动。NotionNext 更适合先提供开源友好的自动化方案，而不是直接绑定商业版权平台或区块链服务。
+
+## 目标
+
+- 构建期自动生成 `public/proofs/originality.json`。
+- 清单只保存哈希、URL、标题、页面 ID、算法和时间，不保存正文。
+- GitHub Actions 可选自动提交清单，借助公开 commit 时间线形成轻量证据。
+- 已有清单记录能自动触发文章页原创存证展示。
+
+## 非目标
+
+- 不上传正文到第三方服务。
+- 不接入 OpenTimestamps、RFC 3161、OriginStamp 或版权平台 API。
+- 不默认运行官方仓库 workflow；必须由仓库变量显式开启。
+
+## 实现
+
+- `ORIGINALITY_PROOF_AUTO_MANIFEST=true` 时，`processPostData` 会复用现有 SHA-256 生成逻辑并写入清单。
+- 如果仓库已有 `public/proofs/originality.json`，文章页会识别对应记录并显示为“公开清单”。
+- `.github/workflows/originality-proofs.yml` 默认跳过，只有设置 GitHub Actions 变量 `ORIGINALITY_PROOF_AUTO_MANIFEST=true` 才会运行。
+
+## 验收记录
+
+- [x] manifest helper 有单测覆盖。
+- [x] 原创存证 helper 能应用公开清单记录。
+- [x] VitePress 教程包含全自动开启步骤和限制。
+- [x] workflow 默认不会在未设置变量时运行。
+
+## 本地验证
+
+- `yarn test __tests__/lib/utils/originalityProof.test.js __tests__/lib/utils/originalityProofManifest.test.js --runInBand`：通过。
+- `yarn lint --file components/OriginalityProof.js --file lib/utils/originalityProof.js --file lib/utils/originalityProofManifest.js --file lib/utils/post.js --file __tests__/lib/utils/originalityProof.test.js --file __tests__/lib/utils/originalityProofManifest.test.js`：通过。
+- `yarn docs:site:build`：通过，仅有既有语法高亮和 chunk size 警告。
+- `git diff --check`：通过，仅有 Windows LF/CRLF 提示。

--- a/docs/developer/rfc/README.md
+++ b/docs/developer/rfc/README.md
@@ -20,4 +20,5 @@
 
 | RFC | 状态 | 说明 |
 | --- | --- | --- |
+| [2026-originality-proof-auto-manifest.md](./2026-originality-proof-auto-manifest.md) | 已实现，本地验收通过 | 原创存证自动生成 GitHub 公开清单 |
 | [2026-originality-proof-ux.md](./2026-originality-proof-ux.md) | 已落地，本地验收通过 | 原创存证从大块信息卡优化为徽章、展开详情和复制证据 |

--- a/docs/developer/rfc/index.md
+++ b/docs/developer/rfc/index.md
@@ -14,4 +14,5 @@
 
 ## 已有 RFC
 
+- [原创存证自动公开清单任务](./2026-originality-proof-auto-manifest.md)
 - [原创存证体验优化任务](./2026-originality-proof-ux.md)

--- a/docs/user-guide/changelog/latest.md
+++ b/docs/user-guide/changelog/latest.md
@@ -20,6 +20,7 @@
 - VitePress 部署目录新增「Notion 图片反代」入口。
 - 新增原创存证教程，说明 `NEXT_PUBLIC_ORIGINALITY_PROOF_ENABLE`、Notion `proof` / `proofTime` / `proofHash` / `proofUrl` 字段，以及本地内容哈希的证明边界。
 - 原创存证展示改为紧凑徽章，可展开查看详情并一键复制证据文本。
+- 原创存证新增可选 GitHub 自动公开清单模式，构建时可生成 `public/proofs/originality.json`，用于公开保存文章哈希证据。
 
 ### 升级说明
 

--- a/docs/user-guide/config/originality-proof.md
+++ b/docs/user-guide/config/originality-proof.md
@@ -20,6 +20,7 @@
 | 已经有外部存证平台 | 只填写 `proofUrl`，页面会自动展示外部凭证 |
 | 外部平台要求提交哈希 | 先用本地哈希或平台哈希填写 `proofHash` |
 | 全站都是原创长文 | 配置 `NEXT_PUBLIC_ORIGINALITY_PROOF_ENABLE=true` |
+| 想尽量全自动 | 开启 GitHub 自动公开清单模式 |
 | 某篇不想显示 | 在该文章填写 `proof=false` |
 
 ## 开启方式
@@ -53,6 +54,41 @@ NEXT_PUBLIC_ORIGINALITY_PROOF_ENABLE=true
 
 如果全站开启后有个别文章不想显示，在该文章的 `proof` 字段中填写 `false`。
 
+### 全自动：GitHub 公开清单
+
+如果希望文章发布后自动生成公开存证记录，可以开启 GitHub 自动公开清单模式。它会在构建时生成：
+
+```txt
+public/proofs/originality.json
+```
+
+这个文件只保存文章 URL、标题、页面 ID、算法、哈希和时间，不保存正文。提交到公开 GitHub 仓库后，GitHub commit 时间可以作为轻量公开时间线。
+
+开启步骤：
+
+1. 在 GitHub 仓库 `Settings -> Actions -> General` 中允许 workflow 写入仓库。
+2. 在 GitHub 仓库 `Settings -> Secrets and variables -> Actions -> Variables` 中新增变量：
+
+```txt
+ORIGINALITY_PROOF_AUTO_MANIFEST=true
+```
+
+3. 手动运行 `Originality proofs` workflow，或等待每日定时任务。
+4. workflow 会执行构建并自动提交 `public/proofs/originality.json`。
+5. 之后文章页会自动显示 `原创存证 · 公开清单 · 短哈希`，不需要在 Notion 里逐篇填写 `proof` 字段。
+
+本地也可以手动生成一次：
+
+```bash
+ORIGINALITY_PROOF_AUTO_MANIFEST=true yarn build
+```
+
+如果使用 Windows PowerShell：
+
+```powershell
+$env:ORIGINALITY_PROOF_AUTO_MANIFEST='true'; yarn build
+```
+
 ### 没有外部凭证时按单篇开启
 
 如果没有外部凭证，只想让某篇文章显示 NotionNext 自动生成的本地内容哈希，可以保持全站关闭，并在 Notion 文章数据库中新增 `proof` 字段。需要显示原创存证的文章填写：
@@ -71,6 +107,12 @@ NotionNext 会读取文章标题、页面 ID、作者、文章 URL 和正文纯�
 
 ```txt
 原创存证 · 外部凭证 · 5d41402abc4b...
+```
+
+如果来自自动公开清单，会显示：
+
+```txt
+原创存证 · 公开清单 · 5d41402abc4b...
 ```
 
 点击徽章后会展开：
@@ -92,6 +134,7 @@ NotionNext 会读取文章标题、页面 ID、作者、文章 URL 和正文纯�
 - 正文末尾只显示一行原创存证徽章，不会大面积打断阅读。
 - 点击徽章后能看到完整哈希。
 - 填写 `proofUrl` 时能打开外部凭证链接。
+- 开启自动公开清单时，仓库中能看到 `public/proofs/originality.json`。
 - 点击“复制证据”后按钮文案变为“已复制”；如果浏览器不支持剪贴板，按钮会提示“请手动复制”。
 
 ## 外部凭证字段
@@ -118,9 +161,10 @@ NotionNext 会读取文章标题、页面 ID、作者、文章 URL 和正文纯�
 
 - 本功能不会阻止复制、截图、OCR 或转载。
 - 本地哈希只能证明“当前页面内容可得到这个摘要”，不能替代第三方可信时间戳。
+- GitHub 公开清单依赖公开仓库 commit 时间线，适合轻量证据，不等同于第三方可信时间戳。
 - 如果需要更强证明力，建议把哈希提交到公开 GitHub 仓库、可信时间戳服务、版权存证平台或其他外部凭证来源。
 - 不要把未公开草稿正文上传到第三方平台；只提交哈希通常更安全。
 
 ## 后续扩展
 
-当前版本不内置 GitHub、OpenTimestamps、RFC 3161 或版权平台客户端。等社区确认具体 provider 和凭据流程后，再新增外部存证接入更稳。
+当前版本不内置 OpenTimestamps、RFC 3161 或版权平台客户端。等社区确认具体 provider 和凭据流程后，再新增外部存证接入更稳。

--- a/lib/utils/originalityProof.js
+++ b/lib/utils/originalityProof.js
@@ -89,6 +89,18 @@ export function createOriginalityProof({
   }
 }
 
+export function applyOriginalityProofRecord(proof, record) {
+  if (!proof || !record) return proof
+
+  return {
+    ...proof,
+    hash: record.hash || proof.hash,
+    proofTime: record.proofTime || proof.proofTime,
+    proofUrl: record.proofUrl || proof.proofUrl || '/proofs/originality.json',
+    provider: record.provider || 'manifest'
+  }
+}
+
 export function formatOriginalityProofText(proof = {}) {
   return [
     proof.title && `Title: ${proof.title}`,

--- a/lib/utils/originalityProofManifest.js
+++ b/lib/utils/originalityProofManifest.js
@@ -1,0 +1,99 @@
+import fs from 'fs'
+import path from 'path'
+
+const TRUE_VALUES = new Set(['1', 'true', 'yes', 'y', 'on', '是', '启用'])
+const PROOF_PATH = path.join('public', 'proofs', 'originality.json')
+
+export function isOriginalityProofAutoManifestEnabled(value) {
+  return value === true || TRUE_VALUES.has(String(value).trim().toLowerCase())
+}
+
+function getManifestPath(rootDir = process.cwd()) {
+  return path.join(rootDir, PROOF_PATH)
+}
+
+function readManifest(rootDir = process.cwd()) {
+  const file = getManifestPath(rootDir)
+  if (!fs.existsSync(file)) return { version: 1, proofs: [] }
+
+  try {
+    const manifest = JSON.parse(fs.readFileSync(file, 'utf8'))
+    return {
+      version: 1,
+      proofs: Array.isArray(manifest.proofs) ? manifest.proofs : []
+    }
+  } catch {
+    return { version: 1, proofs: [] }
+  }
+}
+
+function normalizeUrl(siteUrl, post = {}) {
+  const base = String(siteUrl || '').replace(/\/$/, '')
+  const slug = post.href || post.slug || post.id || ''
+
+  if (/^https?:\/\//.test(slug)) return slug
+  return `${base}/${String(slug).replace(/^\//, '')}`
+}
+
+function entryKey(entry = {}) {
+  return entry.pageId || entry.url
+}
+
+export function createOriginalityProofManifest(proofs = []) {
+  const proofMap = new Map()
+
+  proofs.forEach(proof => {
+    if (!proof?.hash) return
+    const entry = {
+      pageId: proof.pageId || '',
+      title: proof.title || '',
+      url: proof.url || '',
+      algorithm: proof.algorithm || 'SHA-256',
+      hash: proof.hash,
+      proofTime: proof.proofTime || '',
+      proofUrl: '/proofs/originality.json',
+      provider: 'manifest'
+    }
+    if (!entryKey(entry)) return
+    proofMap.set(entryKey(entry), entry)
+  })
+
+  return {
+    version: 1,
+    proofs: [...proofMap.values()].sort((a, b) =>
+      String(a.url || a.pageId).localeCompare(String(b.url || b.pageId))
+    )
+  }
+}
+
+export function findOriginalityProofManifestRecord(
+  post,
+  siteUrl,
+  rootDir = process.cwd()
+) {
+  const manifest = readManifest(rootDir)
+  const url = normalizeUrl(siteUrl, post)
+
+  return (
+    manifest.proofs.find(entry => entry.pageId && entry.pageId === post?.id) ||
+    manifest.proofs.find(entry => entry.url && entry.url === url) ||
+    null
+  )
+}
+
+export function recordOriginalityProofManifest(
+  proof,
+  enabled,
+  rootDir = process.cwd()
+) {
+  if (!enabled || !proof?.hash) return
+
+  const current = readManifest(rootDir)
+  const next = createOriginalityProofManifest([...current.proofs, proof])
+  const file = getManifestPath(rootDir)
+  const content = `${JSON.stringify(next, null, 2)}\n`
+  fs.mkdirSync(path.dirname(file), { recursive: true })
+
+  if (fs.existsSync(file) && fs.readFileSync(file, 'utf8') === content) return
+  fs.writeFileSync(file, content, 'utf8')
+}

--- a/lib/utils/post.js
+++ b/lib/utils/post.js
@@ -10,6 +10,7 @@ import { getPageContentText } from '@/lib/db/notion/getPageContentText'
 import { getPageTableOfContents } from '../db/notion/getPageTableOfContents'
 import { countWords } from '../plugins/wordCount'
 import {
+  applyOriginalityProofRecord,
   createOriginalityProof,
   isOriginalityProofEnabled
 } from './originalityProof'
@@ -151,16 +152,26 @@ export async function processPostData(props, from) {
     const { wordCount, readTime } = countWords(pageContentText)
     props.post.wordCount = wordCount
     props.post.readTime = readTime
+    const siteUrl = siteConfig('LINK', BLOG.LINK)
+    const autoManifest = await getOriginalityProofManifest(props.post, siteUrl)
     props.post.originalityProof = createOriginalityProof({
-      enabled: isOriginalityProofEnabled(
-        siteConfig('ORIGINALITY_PROOF_ENABLE', false),
-        props.post
-      ),
+      enabled:
+        autoManifest.enabled ||
+        !!autoManifest.record ||
+        isOriginalityProofEnabled(
+          siteConfig('ORIGINALITY_PROOF_ENABLE', false),
+          props.post
+        ),
       post: props.post,
       content: pageContentText,
       author: siteConfig('AUTHOR', BLOG.AUTHOR),
-      siteUrl: siteConfig('LINK', BLOG.LINK)
+      siteUrl
     })
+    props.post.originalityProof = applyOriginalityProofRecord(
+      props.post.originalityProof,
+      autoManifest.record
+    )
+    autoManifest.recordProof(props.post.originalityProof)
     await getPageAISummary(props, pageContentText)
   }
 
@@ -189,4 +200,22 @@ export async function processPostData(props, from) {
   }
 
   delete props.allPages
+}
+
+async function getOriginalityProofManifest(post, siteUrl) {
+  if (typeof window !== 'undefined') {
+    return { enabled: false, record: null, recordProof: async () => {} }
+  }
+
+  const manifest = await import('./originalityProofManifest')
+  const enabled = manifest.isOriginalityProofAutoManifestEnabled(
+    siteConfig('ORIGINALITY_PROOF_AUTO_MANIFEST', false)
+  )
+
+  return {
+    enabled,
+    record: manifest.findOriginalityProofManifestRecord(post, siteUrl),
+    recordProof: proof =>
+      manifest.recordOriginalityProofManifest(proof, enabled)
+  }
 }


### PR DESCRIPTION
## 背景

继续推进 issue #4278 的便捷化和专业度：在已有原创存证徽章、复制证据、外部凭证字段基础上，增加一个开源友好的全自动方案。

## 改动

- 新增可选 `ORIGINALITY_PROOF_AUTO_MANIFEST` 配置。
- 构建期可自动生成 `public/proofs/originality.json`，只保存文章 URL、标题、页面 ID、算法、哈希和时间，不保存正文。
- 已存在公开清单记录时，文章页会自动展示为 `原创存证 · 公开清单 · 短哈希`。
- 新增 `Originality proofs` GitHub Actions workflow；默认不会运行，只有设置仓库变量 `ORIGINALITY_PROOF_AUTO_MANIFEST=true` 才会定时/手动生成并提交清单。
- 更新原创存证教程，新增“全自动：GitHub 公开清单”步骤、PowerShell 示例、限制说明和验收项。
- 新增自动公开清单 RFC 和单测。

## 验证

- `yarn test __tests__/lib/utils/originalityProof.test.js __tests__/lib/utils/originalityProofManifest.test.js --runInBand`
- `yarn lint --file components/OriginalityProof.js --file lib/utils/originalityProof.js --file lib/utils/originalityProofManifest.js --file lib/utils/post.js --file __tests__/lib/utils/originalityProof.test.js --file __tests__/lib/utils/originalityProofManifest.test.js`
- `yarn docs:site:build`
- `yarn build`
- `git diff --check`

说明：`yarn docs:site:build` 仍有既有 syntax highlighting / chunk size 警告，但构建通过。