### PR TITLE
fix(config): prefer env config before defaults

### DIFF
--- a/__tests__/lib/config.test.js
+++ b/__tests__/lib/config.test.js
@@ -1,0 +1,27 @@
+/**
+ * @jest-environment node
+ */
+import BLOG from '@/blog.config'
+import { siteConfig } from '@/lib/config'
+
+describe('siteConfig', () => {
+  const originalPostListStyle = BLOG.POST_LIST_STYLE
+
+  afterEach(() => {
+    BLOG.POST_LIST_STYLE = originalPostListStyle
+  })
+
+  it('uses BLOG/env config before caller default for server-only keys', () => {
+    BLOG.POST_LIST_STYLE = 'scroll'
+
+    expect(siteConfig('POST_LIST_STYLE', 'page', {})).toBe('scroll')
+  })
+
+  it('keeps extend config higher priority than BLOG/env config', () => {
+    BLOG.POST_LIST_STYLE = 'scroll'
+
+    expect(siteConfig('POST_LIST_STYLE', 'page', { POST_LIST_STYLE: 'page' })).toBe(
+      'page'
+    )
+  })
+})

--- a/lib/config.js
+++ b/lib/config.js
@@ -58,7 +58,7 @@ export const siteConfig = (key, defaultVal = null, extendConfig = {}) => {
         }
       }
       return convertVal(
-        getValue(extendConfig[key], getValue(defaultVal, BLOG[key]))
+        getValue(extendConfig[key], getValue(BLOG[key], defaultVal))
       )
     default:
   }


### PR DESCRIPTION
## Summary
- fix siteConfig fallback order so env-backed BLOG values are not overridden by caller defaults
- add a focused regression test for POST_LIST_STYLE priority

## Tests
- yarn test __tests__/lib/config.test.js --runInBand
- git diff --check -- lib/config.js __tests__/lib/config.test.js