### PR TITLE
fix(notion): 从渲染上下文读取 Gallery 视图配置

### DIFF
--- a/__tests__/components/NotionCollectionGallery.test.js
+++ b/__tests__/components/NotionCollectionGallery.test.js
@@ -1,10 +1,95 @@
 /** @jest-environment node */
 
+import NotionCollection from '@/components/NotionCollection'
 import { galleryVisibilityClassName } from '@/lib/notion/galleryVisibilityClassName'
+import { execFileSync } from 'child_process'
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+
+jest.mock('react-notion-x/build/third-party/collection', () => {
+  const React = require('react')
+
+  return {
+    Collection: props =>
+      React.createElement('div', {
+        'data-collection-class-name': props.className || ''
+      })
+  }
+})
 
 const galleryView = format => ({ type: 'gallery', format })
 
+const galleryRecordMap = {
+  block: {
+    collection_view: {
+      value: {
+        id: 'collection_view',
+        type: 'collection_view',
+        collection_id: 'collection',
+        view_ids: ['gallery_view']
+      }
+    }
+  },
+  collection: {},
+  collection_view: {
+    gallery_view: {
+      value: galleryView({
+        gallery_properties: [{ property: 'title', visible: false }]
+      })
+    }
+  },
+  collection_query: {},
+  signed_urls: {}
+}
+
+const renderCollectionPropsScript = `
+  const React = (await import('react')).default
+  const { renderToStaticMarkup } = await import('react-dom/server')
+  const { NotionRenderer } = await import('react-notion-x')
+  const recordMap = ${JSON.stringify(galleryRecordMap)}
+  const ProbeCollection = props => {
+    const viewId = props.block?.view_ids?.[0]
+    const collectionView = props.ctx?.recordMap?.collection_view?.[viewId]?.value
+    return React.createElement('output', {
+      'data-prop-keys': Object.keys(props).sort().join(','),
+      'data-context-view-type': collectionView?.type || 'missing'
+    })
+  }
+  process.stdout.write(
+    renderToStaticMarkup(
+      React.createElement(NotionRenderer, {
+        recordMap,
+        components: { Collection: ProbeCollection }
+      })
+    )
+  )
+`
+
 describe('Notion Gallery visibility settings', () => {
+  it('receives block and renderer context instead of a collectionView prop', () => {
+    const markup = execFileSync(
+      process.execPath,
+      ['--input-type=module', '-e', renderCollectionPropsScript],
+      { encoding: 'utf8' }
+    )
+
+    expect(markup).toContain('data-prop-keys="block,ctx"')
+    expect(markup).toContain('data-context-view-type="gallery"')
+  })
+
+  it('reads the Gallery view from the Collection override renderer context', () => {
+    const markup = renderToStaticMarkup(
+      React.createElement(NotionCollection, {
+        block: galleryRecordMap.block.collection_view.value,
+        ctx: { recordMap: galleryRecordMap }
+      })
+    )
+
+    expect(markup).toContain(
+      'class="notion-gallery-hide-page-icons notion-gallery-hide-titles"'
+    )
+  })
+
   it('hides omitted page icons and an explicitly hidden title', () => {
     expect(
       galleryVisibilityClassName(

--- a/components/NotionCollection.js
+++ b/components/NotionCollection.js
@@ -2,7 +2,10 @@ import { galleryVisibilityClassName } from '@/lib/notion/galleryVisibilityClassN
 import { Collection } from 'react-notion-x/build/third-party/collection'
 
 export default function NotionCollection(props) {
-  const className = galleryVisibilityClassName(props.collectionView)
+  const viewId = props.block?.view_ids?.[0]
+  const collectionViewRecord = props.ctx?.recordMap?.collection_view?.[viewId]
+  const collectionView = collectionViewRecord?.value || collectionViewRecord
+  const className = galleryVisibilityClassName(collectionView)
 
   if (!className) return <Collection {...props} />
 


### PR DESCRIPTION
## 背景

#4338 已补齐 Gallery 页面图标和 Title 可见性规则，但报告者在合并后的最新 `main` 上复测仍无变化。

重新沿真实渲染路径检查后发现，#4343 将第三方补丁迁移为本地 `NotionCollection` 包装器时，包装器读取了 `props.collectionView`；而 `react-notion-x@7.10.0` 的 Collection override 实际只传入 `block` 和 `ctx`。因此可见性 helper 虽然测试通过，运行时却始终拿不到 Gallery 视图配置，也不会输出隐藏 class。

这是 #4334 / #4338 的后续修复。

## 解决方案

- 从 `block.view_ids[0]` 确定初始 Collection view；
- 从 `ctx.recordMap.collection_view` 读取并解包实际 Gallery view；
- 继续复用现有 `galleryVisibilityClassName` 和 Gallery 限定样式；
- 不恢复 `patch-package`，保留 #4343 避免修改第三方构建产物的目标。

## 回归测试

新增两层契约检查：

1. 使用真实 `NotionRenderer` 确认 Collection override 收到的是 `block` 与 `ctx`，并确认 Gallery view 位于 `ctx.recordMap`；
2. 使用该真实属性形态渲染本地包装器，确认同时输出隐藏页面图标和隐藏 Title 的 class。

原有当前数据与旧数据兼容用例继续保留。

## 风险与兼容性

- 风险等级：低。
- 仅修改 2 个文件，不升级依赖、不修改 CSS、配置、路由或数据结构。
- 非 Gallery Collection 仍返回空可见性 class，并沿用原渲染路径。

## 验证

- [x] `yarn jest __tests__/components/NotionCollectionGallery.test.js --runInBand`（6/6）
- [x] `yarn test --runInBand`（39 suites / 211 tests）
- [x] `yarn type-check`
- [x] `yarn lint`（退出码 0；仅仓库既有 warnings）
- [x] `yarn build`（61 个静态页面生成完成；仅仓库既有 warnings）
- [x] `yarn prettier --check components/NotionCollection.js __tests__/components/NotionCollectionGallery.test.js`
- [x] `git diff --check`

## 用户文档

- [x] 不适用：本次恢复现有 Gallery 配置语义，不新增配置项或部署步骤。
