### PR TITLE
fix: 修复含有数据库视图和HTML块的页面构建崩溃问题

### DIFF
--- a/lib/db/notion/getPageContentText.js
+++ b/lib/db/notion/getPageContentText.js
@@ -84,7 +84,7 @@ export function getPageContentText(post, pageBlockMap) {
     }
     const textArray = getPropertyValue(properties, customKeys)
     result.push(getTextArray(textArray))
-    if (block.type !== 'page' && block['content']?.length > 0) {
+    if (block.type !== 'page' && Array.isArray(block.content) && block.content.length > 0) {
       for (const blockContent of block.content) {
         result.push(getBlockContentText(blockContent))
       }
@@ -106,8 +106,10 @@ export function getPageContentText(post, pageBlockMap) {
     const blockPointerId = blockPointer.id
     if (blockPointer && pageBlockMap.block[blockPointerId].value) {
       const blockContentList = pageBlockMap.block[blockPointerId].value.content
-      for (const blockContent of blockContentList) {
-        result.push(getBlockContentText(blockContent))
+      if (Array.isArray(blockContentList)) {
+        for (const blockContent of blockContentList) {
+          result.push(getBlockContentText(blockContent))
+        }
       }
     }
     return result.join(' ')
@@ -125,6 +127,10 @@ export function getPageContentText(post, pageBlockMap) {
         return getTransclusionReference(block)
       case 'table':
         return getTableText(block.content)
+      case 'collection_view':
+      case 'collection_view_page':
+      case 'html':
+        return ''
       case 'page':
         if (id !== postId) {
           return getText(block)
@@ -151,6 +157,7 @@ export function getPageContentText(post, pageBlockMap) {
   }
 
   function getTableText(tableRowIds) {
+    if (!Array.isArray(tableRowIds)) return ''
     const result = []
     for (const blockRowId of tableRowIds) {
       if (pageBlockMap.block[blockRowId]) {

--- a/lib/db/notion/getPageContentText.js
+++ b/lib/db/notion/getPageContentText.js
@@ -102,9 +102,9 @@ export function getPageContentText(post, pageBlockMap) {
 
   function getTransclusionReference(block) {
     const result = []
-    const blockPointer = block.format.transclusion_reference_pointer
-    const blockPointerId = blockPointer.id
-    if (blockPointer && pageBlockMap.block[blockPointerId].value) {
+    const blockPointer = block.format?.transclusion_reference_pointer
+    if (blockPointer && pageBlockMap.block[blockPointer.id]?.value) {
+      const blockPointerId = blockPointer.id
       const blockContentList = pageBlockMap.block[blockPointerId].value.content
       if (Array.isArray(blockContentList)) {
         for (const blockContent of blockContentList) {

--- a/lib/db/notion/getPageTableOfContents.js
+++ b/lib/db/notion/getPageTableOfContents.js
@@ -89,6 +89,10 @@ function getBlockHeader(contents, recordMap, toc, pageId) {
     return toc
   }
 
+  if (!Array.isArray(contents)) {
+    return toc
+  }
+
   for (const blockId of contents) {
     const block = recordMap.block[blockId]?.value
     if (!block) {
@@ -99,7 +103,7 @@ function getBlockHeader(contents, recordMap, toc, pageId) {
       typeof type === 'string' &&
       (type.indexOf('header') >= 0 || /^heading_[1234]$/.test(type))
 
-    if (block.content?.length > 0) {
+    if (Array.isArray(block.content) && block.content.length > 0) {
       getBlockHeader(block.content, recordMap, toc, pageId)
     } else {
       if (isHeading) {
@@ -142,7 +146,7 @@ function getBlockHeader(contents, recordMap, toc, pageId) {
           toc,
           pageId
         )
-      } else if (type === 'transclusion_container') {
+      } else if (type === 'transclusion_container' && Array.isArray(block.content) && block.content.length > 0) {
         getBlockHeader(block.content, recordMap, toc, pageId)
       }
     }


### PR DESCRIPTION
## 问题

当页面中包含内嵌数据库视图（collection_view/collection_view_page）或 HTML 代码块（html）时，Vercel 构建会崩溃：

  TypeError: b.block[j].value.content is not iterable

进而导致：

  Error serializing `.prev` returned from getStaticProps
  Reason: `undefined` cannot be serialized as JSON

## 原因

这两种 block 类型的 content 字段不是数组，但 getPageTableOfContents.js 和
getPageContentText.js 中直接用 for...of 遍历 content，缺少 Array.isArray 防护。

## 修改内容

- getPageTableOfContents.js：遍历 contents、递归 block.content、transclusion_container
  之前增加 Array.isArray 检查
- getPageContentText.js：遍历 block.content、blockContentList、tableRowIds 之前
  增加 Array.isArray 检查；switch 中新增 collection_view、collection_view_page、
  html 类型 case，返回空字符串

## 验证

已在 Vercel 成功构建，Notion 数据库中包含内嵌数据库视图和 HTML 块的页面不再报错。