### PR TITLE
fix(matery): improve mobile post header and tags

### DIFF
--- a/themes/matery/components/ArticleInfo.js
+++ b/themes/matery/components/ArticleInfo.js
@@ -11,15 +11,15 @@ export const ArticleInfo = props => {
 
   return (
     <section className='mb-3 dark:text-gray-200'>
-      <div className='my-3'>
-        {post.tagItems && (
-          <div className='flex flex-nowrap overflow-x-auto'>
+      {post.tagItems?.length > 0 && (
+        <div className='my-4'>
+          <div className='flex flex-wrap items-center gap-2'>
             {post.tagItems.map(tag => (
               <TagItemMiddle key={tag.name} tag={tag} />
             ))}
           </div>
-        )}
-      </div>
+        </div>
+      )}
 
       <div className='flex flex-wrap gap-3 mt-5 text-sm'>
         {post?.type !== 'Page' && (
@@ -27,7 +27,8 @@ export const ArticleInfo = props => {
             <SmartLink
               href={`/archive#${formatDateFmt(post?.publishDate, 'yyyy-MM')}`}
               passHref
-              className='cursor-pointer whitespace-nowrap'>
+              className='cursor-pointer whitespace-nowrap'
+            >
               <i className='far fa-calendar-minus fa-fw' />{' '}
               {locale.COMMON.POST_TIME}: {post?.publishDay}
             </SmartLink>

--- a/themes/matery/components/PostHero.js
+++ b/themes/matery/components/PostHero.js
@@ -13,13 +13,15 @@ export default function PostHero({ post, siteInfo }) {
   return (
     <div
       id='header'
-      className='flex h-96 justify-center align-middle items-center w-full relative bg-black'>
-      <div
+      className='flex h-96 justify-center align-middle items-center w-full relative bg-black'
+    >
+      <h1
         data-wow-delay='.1s'
-        className='wow fadeInUp z-10 leading-snug font-bold xs:text-4xl sm:text-4xl md:text-5xl md:leading-snug text-4xl shadow-text-md flex justify-center text-center text-white'>
+        className='wow fadeInUp z-10 flex w-full max-w-5xl items-center justify-center break-words px-6 text-center text-3xl font-bold leading-tight text-white shadow-text-md sm:px-10 sm:text-4xl sm:leading-snug md:px-12 md:text-5xl'
+      >
         {siteConfig('POST_TITLE_ICON') && <NotionIcon icon={post?.pageIcon} />}
         {title}
-      </div>
+      </h1>
       <LazyImage
         alt={title}
         src={headerImage}

--- a/themes/matery/components/TagItemMiddle.js
+++ b/themes/matery/components/TagItemMiddle.js
@@ -2,18 +2,18 @@ import SmartLink from '@/components/SmartLink'
 
 const TagItemMiddle = ({ tag, selected = false }) => {
   return (
-      <SmartLink
-          key={tag}
-          href={selected ? '/' : `/tag/${encodeURIComponent(tag.name)}`}
-          passHref
-          className={`cursor-pointer inline-block rounded-xl  hover:text-white duration-200
-        mr-2 py-0.5 px-2 text-md whitespace-nowrap text-white  ${selected ? 'bg-black' : 'bg-indigo-700'}`}>
-
-          <div className='font-light'>
-              {selected && <i className='mr-1 fas fa-tag' />}
-              {tag.name + (tag.count ? `(${tag.count})` : '')} </div>
-
-      </SmartLink>
+    <SmartLink
+      href={selected ? '/' : `/tag/${encodeURIComponent(tag.name)}`}
+      passHref
+      className={`inline-block max-w-full cursor-pointer break-words rounded-full px-3 py-1 text-sm leading-5 text-white duration-200 hover:text-white ${
+        selected ? 'bg-black' : 'bg-indigo-700'
+      }`}
+    >
+      <span className='font-light'>
+        {selected && <i className='mr-1 fas fa-tag' />}
+        {tag.name + (tag.count ? ` (${tag.count})` : '')}
+      </span>
+    </SmartLink>
   )
 }
 

--- a/themes/matery/index.js
+++ b/themes/matery/index.js
@@ -263,7 +263,7 @@ const LayoutSlug = props => {
               {/* 文章信息 */}
               {post?.type && post?.type === 'Post' && (
                 <>
-                  <div data-wow-delay='.2s' className='wow fadeInUp px-10'>
+                  <div data-wow-delay='.2s' className='wow fadeInUp px-2 sm:px-6 lg:px-10'>
                     <ArticleInfo post={post} />
                   </div>
                   <hr />


### PR DESCRIPTION
## 已知问题

1. Matery 主题的文章详情页在移动端存在两处布局问题：
   - 标签列表使用 `flex-nowrap` 和横向滚动。标签较多时需要滑动查看，胶囊边缘还可能在文章卡片边界被裁切。
   - 文章封面标题在小屏幕仍使用较大字号，且没有水平安全间距。较长的中文标题会紧贴屏幕边缘，影响可读性。

## 解决方案

1. 将文章标签列表改为自动换行的弹性布局。
   - 使用 `flex-wrap` 和 `gap-2`，让标签随容器宽度自然换行。
   - 仅在存在标签时渲染标签区域。
2. 调整标签胶囊样式。
   - 使用完整圆角、统一内边距和移动端友好的字号。
   - 允许极长标签在胶囊内部换行，避免撑破容器。
3. 优化文章封面标题与信息区的响应式留白。
   - 使用语义化 `h1`，移动端采用较小字号，并随断点逐级放大。
   - 为标题设置最大宽度和 24px 起的水平安全间距。
   - 缩小文章信息区在移动端的水平内边距，保留桌面端原有间距。

## 改动收益

1. 标签无需横向滚动即可完整展示。
2. 长标题在手机端不再贴边，换行和行距更自然。
3. 改动仅限 Matery 主题文章详情页，不影响其他主题或配置接口。
4. 桌面端仍保留原有的大标题尺寸和文章信息间距。

## 具体改动

1. `themes/matery/components/ArticleInfo.js`
   - 标签容器由单行横向滚动改为多行流式布局。
2. `themes/matery/components/TagItemMiddle.js`
   - 调整标签胶囊的圆角、间距、字号和长文本换行。
3. `themes/matery/components/PostHero.js`
   - 使用 `h1` 并增加响应式字号、最大宽度和水平留白。
4. `themes/matery/index.js`
   - 调整文章信息区的移动端响应式内边距。

## 测试确认

- [ ] 本地开发环境测试通过
- [x] 生产环境构建测试通过（同一补丁已通过 fork 的 Vercel 部署）
- [x] Tailwind CSS 编译确认新增工具类可正常生成
- [x] GitHub CI 与 CodeQL 检查通过
- [x] 移动端页面人工确认通过
- [x] （不适用）版本号正确显示
- [x] （不适用）环境变量配置正常工作

## 用户文档（`docs/user-guide/` / `docs/developer/`）

- [x] 不适用（仅修复现有 Matery 移动端布局，未新增主题配置、部署步骤或站长操作方式）
- [x] 已按 [维护工作流](https://github.com/notionnext-org/NotionNext/blob/main/docs/user-guide/MAINTENANCE_WORKFLOW.md) 自检
- [ ] 路径符合 `docs/user-guide/` 目录约定
- [ ] 已更新 [user-guide/README.md](https://github.com/notionnext-org/NotionNext/blob/main/docs/user-guide/README.md)（新增/移动文章时）
- [ ] 已更新 [ARTICLE_INDEX.md](https://github.com/notionnext-org/NotionNext/blob/main/docs/user-guide/ARTICLE_INDEX.md)（新 slug 或路径变更时）
- [ ] 环境变量名与 `conf/*.config.js` 一致（若文档涉及配置）
- [x] 示例中无真实 Token、`.env`、私有 ID
- [ ] 保留或更新了「原文链接」（若源自 docs.tangly1024.com）

文档说明：本次未新增或修改用户文档、配置项、slug 或部署说明。
