### PR TITLE
fix: support modern Notion config databases

### DIFF
--- a/__tests__/lib/db/notion/getNotionConfig.test.js
+++ b/__tests__/lib/db/notion/getNotionConfig.test.js
@@ -30,7 +30,7 @@ describe('parseConfigFromPage', () => {
               id: 'row',
               properties: {
                 key: [['AUTHOR']],
-                value: [['科技小王哥']],
+                value: [['Example Author']],
                 enable: [['Yes']]
               }
             }
@@ -58,7 +58,7 @@ describe('parseConfigFromPage', () => {
       }
 
       expect(parseConfigFromPage(recordMap, ['table'])).toEqual({
-        AUTHOR: '科技小王哥'
+        AUTHOR: 'Example Author'
       })
     }
   )

--- a/__tests__/lib/db/notion/getNotionConfig.test.js
+++ b/__tests__/lib/db/notion/getNotionConfig.test.js
@@ -1,0 +1,65 @@
+jest.mock('@/lib/db/notion/getPostBlocks', () => ({
+  fetchNotionPageBlocks: jest.fn()
+}))
+jest.mock('@/lib/plugins/mailEncrypt', () => ({
+  encryptEmail: jest.fn(value => value)
+}))
+jest.mock('notion-utils', () => ({
+  getDateValue: jest.fn(),
+  getTextContent: jest.fn(value => value?.[0]?.[0] || '')
+}))
+
+import { parseConfigFromPage } from '@/lib/db/notion/getNotionConfig'
+
+describe('parseConfigFromPage', () => {
+  it.each(['collection_view', 'collection_view_page'])(
+    'reads config from a %s database block',
+    type => {
+      const recordMap = {
+        block: {
+          table: {
+            value: {
+              id: 'table',
+              type,
+              collection_id: 'collection',
+              view_ids: ['view']
+            }
+          },
+          row: {
+            value: {
+              id: 'row',
+              properties: {
+                key: [['AUTHOR']],
+                value: [['科技小王哥']],
+                enable: [['Yes']]
+              }
+            }
+          }
+        },
+        collection: {
+          collection: {
+            value: {
+              schema: {
+                key: { name: '配置名', type: 'title' },
+                value: { name: '配置值', type: 'text' },
+                enable: { name: '启用', type: 'text' }
+              }
+            }
+          }
+        },
+        collection_query: {
+          collection: {
+            view: {
+              blockIds: ['row']
+            }
+          }
+        },
+        collection_view: {}
+      }
+
+      expect(parseConfigFromPage(recordMap, ['table'])).toEqual({
+        AUTHOR: '科技小王哥'
+      })
+    }
+  )
+})

--- a/lib/db/notion/getNotionConfig.js
+++ b/lib/db/notion/getNotionConfig.js
@@ -89,7 +89,9 @@ export function parseConfigFromPage(pageRecordMap, content) {
 
   const configTableId = content.find(contentId => {
     const blockItem = pageRecordMap.block?.[contentId]?.value
-    return normalizePageBlock(blockItem)?.type === 'collection_view'
+    return ['collection_view', 'collection_view_page'].includes(
+      normalizePageBlock(blockItem)?.type
+    )
   })
 
   if (!configTableId) return null


### PR DESCRIPTION
## 已知问题

新创建的 Notion 内联数据库可能以 `collection_view_page` block 返回。`getNotionConfig.js` 后续解析流程已经兼容该类型，但最初查找配置表时只接受 `collection_view`，导致配置表被跳过，Notion Config 无法生效。

## 解决方案

- 查找配置表时同时接受 `collection_view` 和 `collection_view_page`。
- 保留原有 `collection_view` 行为，确保向后兼容。
- 增加参数化回归测试，覆盖两种 block 类型。

## 改动收益

- 新创建的 Notion Config 数据库可以被正常读取。
- 旧版 Notion 数据库继续按原方式工作。
- 通过测试防止配置表识别逻辑再次退化。

## 具体改动

- `lib/db/notion/getNotionConfig.js`
  - 配置表类型判断增加 `collection_view_page`。
- `__tests__/lib/db/notion/getNotionConfig.test.js`
  - 验证两种数据库 block 类型均能解析出启用的配置项。

## 测试确认

- [x] 定向单元测试通过：2 tests passed
- [x] `git diff --check` 通过
- [x] Fork CI 的 unit tests、lint/type-check、lockfile、VitePress、CodeQL、Docker 和 Vercel 检查通过

## 用户文档（`docs/user-guide/` / `docs/developer/`）

- [x] 不适用（内部兼容性修复，没有新增配置、环境变量、部署步骤或 UI 行为）
