### PR TITLE
fix(proxio): restore theme color semantics

### DIFF
--- a/conf/themeColorPalette.js
+++ b/conf/themeColorPalette.js
@@ -87,7 +87,20 @@ const THEME_COLOR_DEFAULTS = {
   },
   photo: { PRIMARY: '#2563eb', PRIMARY_DARK: '#ca8a04' },
   plog: { PRIMARY: '#1d4ed8' },
-  proxio: { PRIMARY: '#3758f9', BG: '#ffffff', BG_DARK: '#121212' },
+  proxio: {
+    PRIMARY: '#3758f9',
+    PRIMARY_DARK: '#3758f9',
+    BG: '#ffffff',
+    CARD: '#ffffff',
+    TEXT: '#111827',
+    TEXT_SECONDARY: '#637381',
+    BORDER: '#e5e7eb',
+    BG_DARK: '#121212',
+    CARD_DARK: '#181818',
+    TEXT_DARK: '#f3f4f6',
+    TEXT_SECONDARY_DARK: '#9ca3af',
+    BORDER_DARK: '#333333'
+  },
   simple: { PRIMARY: '#dd3333', TEXT: '#111827' },
   starter: { PRIMARY: '#3758f9', PRIMARY_DARK: '#3758f9', BG_DARK: '#111928' },
   thoughtlite: {

--- a/themes/proxio/components/Blog.js
+++ b/themes/proxio/components/Blog.js
@@ -33,7 +33,7 @@ export const Blog = ({ posts }) => {
   return (
     <>
       {/* <!-- ====== Blog Section Start --> */}
-      <section className='bg-white pt-20 dark:bg-dark lg:pt-[120px]'>
+      <section className='proxio-section pt-20 lg:pt-[120px]'>
         <div className='container mx-auto'>
           {/* 区块标题文字 */}
           <div
@@ -42,7 +42,7 @@ export const Blog = ({ posts }) => {
           >
             <div className='w-full px-4 py-4'>
               <div className='mx-auto max-w-[485px] text-center space-y-4'>
-                <span className='px-3 py-0.5 rounded-2xl mb-2 dark:bg-dark-1 border border-gray-200 dark:border-[#333333] dark:text-white'>
+                <span className='proxio-pill px-3 py-0.5 rounded-2xl mb-2 border'>
                   {siteConfig('PROXIO_BLOG_TITLE')}
                 </span>
 
@@ -73,7 +73,7 @@ export const Blog = ({ posts }) => {
                     className='wow fadeInUp group mb-10 relative overflow-hidden blog'
                     data-wow-delay='.1s'
                   >
-                    <div className='relative rounded-xl border overflow-hidden shadow-md dark:border-gray-700 dark:bg-gray-800'>
+                    <div className='proxio-card relative rounded-xl border overflow-hidden shadow-md'>
                       <SmartLink href={item?.href} className='block'>
                         {item.pageCoverThumbnail && (
                           // 图片半透明

--- a/themes/proxio/components/Brand.js
+++ b/themes/proxio/components/Brand.js
@@ -39,9 +39,9 @@ export const Brand = () => {
   return (
     <>
       {/* <!-- ====== Brands Section Start --> */}
-      <section id='brand' className='py-12 dark:bg-dark'>
+      <section id='brand' className='proxio-section py-12'>
         <div
-          className='overflow-hidden whitespace-nowrap container mx-auto p-3 border rounded-2xl border-gray-200 dark:border-[#333333]'
+          className='proxio-card overflow-hidden whitespace-nowrap container mx-auto p-3 border rounded-2xl'
           ref={scrollContainerRef}
         >
           <div className='inline-block'>

--- a/themes/proxio/components/CTA.js
+++ b/themes/proxio/components/CTA.js
@@ -14,14 +14,14 @@ export const CTA = () => {
   return (
     <>
       {/* <!-- ====== CTA Section Start --> */}
-      <section className='relative z-10 overflow-hidden bg-gray-1 dark:bg-black py-20 lg:py-[115px]'>
+      <section className='proxio-section-muted relative z-10 overflow-hidden py-20 lg:py-[115px]'>
         <div className='container mx-auto'>
           <div className='relative overflow-hidden'>
             <div className='-mx-4 flex flex-wrap items-stretch'>
               <div className='w-full px-4 mb-2'>
                 <div className='mx-auto max-w-[570px] text-center wow fadeInUp' data-wow-delay='.2s'>
                   <div>
-                    <span className='px-3 py-0.5 rounded-2xl dark:bg-dark-1 border border-gray-200 dark:border-[#333333] dark:text-white'>
+                    <span className='proxio-pill px-3 py-0.5 rounded-2xl border'>
                       {siteConfig('PROXIO_CTA_TITLE')}
                     </span>
                   </div>
@@ -38,7 +38,7 @@ export const CTA = () => {
                     <>
                       <SmartLink
                         href={siteConfig('PROXIO_CTA_BUTTON_URL', '')}
-                        className='inline-flex items-center justify-center rounded-2xl bg-white px-7 py-[14px] text-center text-base font-medium text-dark shadow-1 transition duration-300 ease-in-out hover:bg-gray-2'>
+                        className='proxio-card inline-flex items-center justify-center rounded-2xl border px-7 py-[14px] text-center text-base font-medium shadow-1 transition duration-300 ease-in-out hover:opacity-90'>
                         {siteConfig('PROXIO_CTA_BUTTON_TEXT')}
                       </SmartLink>
                     </>

--- a/themes/proxio/components/Career.js
+++ b/themes/proxio/components/Career.js
@@ -13,17 +13,17 @@ export const Career = () => {
       {/* <!-- ====== About Section Start --> */}
       <section
         id='about'
-        className='bg-gray-1 pb-8 pt-20 dark:bg-black lg:pb-[70px] lg:pt-[120px]'>
+        className='proxio-section-muted pb-8 pt-20 lg:pb-[70px] lg:pt-[120px]'>
         <div className='container'>
           <div className='wow fadeInUp' data-wow-delay='.2s'>
             {/* 左侧的文字说明板块 */}
             <div className='w-full px-4 lg:w-1/2'>
               <div className='mb-12 max-w-[540px] lg:mb-0'>
-                <span className='px-3 py-0.5 rounded-2xl dark:bg-dark-1 border border-gray-200 dark:border-[#333333] dark:text-white'>
+                <span className='proxio-pill px-3 py-0.5 rounded-2xl border'>
                   {siteConfig('PROXIO_CAREER_TITLE')}
                 </span>
                 <h2
-                  className='mb-10 text-3xl font-semibold leading-relaxed dark:text-dark-6'
+                  className='mb-10 text-3xl font-semibold leading-relaxed text-dark dark:text-white'
                 >{siteConfig('PROXIO_CAREER_TEXT')}</h2>
               </div>
             </div>

--- a/themes/proxio/components/FAQ.js
+++ b/themes/proxio/components/FAQ.js
@@ -18,13 +18,13 @@ export const FAQ = () => {
   return (
     <>
       {/* <!-- ====== FAQ Section Start --> */}
-      <section className="relative overflow-hidden bg-white pb-8 pt-20 dark:bg-dark lg:pb-[50px] lg:pt-[120px]">
+      <section className="proxio-section relative overflow-hidden pb-8 pt-20 lg:pb-[50px] lg:pt-[120px]">
         <div className='max-w-2xl mx-auto wow fadeInUp' data-wow-delay='.2s'>
           <div className="-mx-4 flex flex-wrap">
             <div className="w-full px-4">
               <div className="mx-auto mb-[60px] max-w-[520px] text-center flex flex-col space-y-4">
                 <div>
-                  <span className='px-3 py-0.5 rounded-2xl dark:bg-dark-1 border border-gray-200 dark:border-[#333333] dark:text-white'>
+                  <span className='proxio-pill px-3 py-0.5 rounded-2xl border'>
                     {siteConfig('PROXIO_FAQ_TITLE')}
                   </span>
                 </div>
@@ -46,7 +46,7 @@ export const FAQ = () => {
                 className="w-full px-4 cursor-pointer"
                 onClick={() => toggleFAQ(index)}
               >
-                <div className="p-4 border rounded-lg dark:bg-[#0E0E0E] bg-white dark:bg-dark-1 border-gray-200 dark:border-[#333333]">
+                <div className="proxio-card p-4 border rounded-lg">
                   {/* 问题部分 */}
                   <div className="flex justify-between items-center">
                     <h3 className="text-lg font-semibold text-dark dark:text-white">

--- a/themes/proxio/components/Features.js
+++ b/themes/proxio/components/Features.js
@@ -13,13 +13,13 @@ export const Features = () => {
   return (
     <>
       {/* <!-- ====== Features Section Start --> */}
-      <section className='pb-8 pt-20 dark:bg-dark lg:pb-[40px] lg:pt-[120px]'>
+      <section className='proxio-section pb-8 pt-20 lg:pb-[40px] lg:pt-[120px]'>
         <div className='container'>
 
           <div className='-mx-4 flex flex-wrap wow fadeInUp' data-wow-delay='.2s'>
             <div className='w-full px-4'>
               <div className='mx-auto mb-12 lg:mb-[40px]'>
-                <span className='px-3 py-0.5 rounded-2xl dark:bg-dark-1 border border-gray-200 dark:border-[#333333] dark:text-white'>
+                <span className='proxio-pill px-3 py-0.5 rounded-2xl border'>
                   {siteConfig('PROXIO_FEATURE_TITLE')}
                 </span>
                 <h2 className='my-5 text-3xl font-bold text-dark dark:text-white sm:text-4xl md:text-[40px] md:leading-[1.2]'>
@@ -34,10 +34,10 @@ export const Features = () => {
           {/* 支持三个特性 */}
           <div className='-mx-4 flex flex-col md:flex-row gap-4 px-4'>
 
-            <div className='w-full p-6 rounded-xl border border-gray-200 dark:border-[#333333]'>
+            <div className='proxio-card w-full p-6 rounded-xl border'>
               <div className='wow fadeInUp group flex-col space-y-2 flex' data-wow-delay='.1s'>
                 <div className='flex w-12 h-12'>
-                  <div className='overflow-hidden w-full flex justify-center items-center rounded-xl border border-gray-200 dark:border-[#333333] dark:text-white'>
+                  <div className='proxio-card overflow-hidden w-full flex justify-center items-center rounded-xl border dark:text-white'>
                     <i className={siteConfig('PROXIO_FEATURE_1_ICON_CLASS') + ' absolute'}></i>
                     <LazyImage src={siteConfig('PROXIO_FEATURE_1_ICON_IMG_URL')} className='z-10' />
                   </div>
@@ -51,11 +51,11 @@ export const Features = () => {
               </div>
             </div>
 
-            <div className='w-full p-6 rounded-xl border border-gray-200 dark:border-[#333333]'>
+            <div className='proxio-card w-full p-6 rounded-xl border'>
               <div className='wow fadeInUp group flex-col space-y-2 flex' data-wow-delay='.1s'>
                 <div className='flex w-12 h-12'>
-                  <div className='overflow-hidden w-full flex justify-center items-center rounded-xl border border-gray-200 dark:border-[#333333] dark:text-white'>
-                    <i class={siteConfig('PROXIO_FEATURE_2_ICON_CLASS')}></i>
+                  <div className='proxio-card overflow-hidden w-full flex justify-center items-center rounded-xl border dark:text-white'>
+                    <i className={siteConfig('PROXIO_FEATURE_2_ICON_CLASS')}></i>
                     <LazyImage src={siteConfig('PROXIO_FEATURE_2_ICON_IMG_URL')} className='z-10' />
                   </div>
                 </div>
@@ -68,11 +68,11 @@ export const Features = () => {
               </div>
             </div>
 
-            <div className='w-full p-6 rounded-xl border border-gray-200 dark:border-[#333333]'>
+            <div className='proxio-card w-full p-6 rounded-xl border'>
               <div className='wow fadeInUp group flex-col space-y-2 flex' data-wow-delay='.1s'>
                 <div className='flex w-12 h-12'>
-                  <div className='overflow-hidden w-full flex justify-center items-center rounded-xl border border-gray-200 dark:border-[#333333] dark:text-white'>
-                    <i class={siteConfig('PROXIO_FEATURE_3_ICON_CLASS')}></i>
+                  <div className='proxio-card overflow-hidden w-full flex justify-center items-center rounded-xl border dark:text-white'>
+                    <i className={siteConfig('PROXIO_FEATURE_3_ICON_CLASS')}></i>
                     <LazyImage src={siteConfig('PROXIO_FEATURE_3_ICON_IMG_URL')} className='z-10' />
                   </div>
                 </div>
@@ -90,7 +90,7 @@ export const Features = () => {
           <div className='mt-8 w-full flex justify-center items-center'>
             <SmartLink
               href={siteConfig('PROXIO_FEATURE_BUTTON_URL', '')}
-              className='px-4 py-2 rounded-3xl border dark:border-gray-200 border-[#333333] text-base font-medium text-dark hover:bg-gray-100 dark:text-white dark:hover:bg-white dark:hover:text-black duration-200'>
+              className='proxio-outline-button px-4 py-2 rounded-3xl border text-base font-medium duration-200'>
               {siteConfig('PROXIO_FEATURE_BUTTON_TEXT')}
               <i className="pl-4 fa-solid fa-arrow-right"></i>
             </SmartLink>

--- a/themes/proxio/components/Hero.js
+++ b/themes/proxio/components/Hero.js
@@ -31,7 +31,7 @@ export const Hero = props => {
   return (
     <>
       {/* <!-- ====== Hero Section Start --> */}
-      <div id='home' className='h-screen relative overflow-hidden bg-primary '>
+      <div id='home' className='proxio-hero h-screen relative overflow-hidden'>
         {/* 横幅图片 */}
         {!bannerIframe && bannerImage && (
           <LazyImage

--- a/themes/proxio/components/MenuItem.js
+++ b/themes/proxio/components/MenuItem.js
@@ -71,7 +71,7 @@ export const MenuItem = ({ link, isOpen, toggleOpen }) => {
 
           {/* 子菜单 */}
           <div
-            className={`submenu dark:border-gray-600 relative left-0 top-full w-[250px] rounded-sm bg-white p-4 transition-all duration-300 dark:bg-dark-2 lg:absolute lg:shadow-lg ${
+            className={`submenu proxio-card relative left-0 top-full w-[250px] rounded-sm border p-4 transition-all duration-300 lg:absolute lg:shadow-lg ${
               open
                 ? 'block opacity-100 visible'
                 : 'hidden opacity-0 invisible'

--- a/themes/proxio/components/MenuList.js
+++ b/themes/proxio/components/MenuList.js
@@ -97,7 +97,7 @@ export const MenuList = props => {
 
       <nav
         id='navbarCollapse'
-        className={`absolute right-4 top-full w-full max-w-[250px] rounded-lg bg-white py-5 shadow-lg dark:bg-dark-2 lg:static lg:block lg:w-full lg:max-w-full lg:bg-transparent lg:px-4 lg:py-0 lg:shadow-none dark:lg:bg-transparent xl:px-6 ${
+        className={`proxio-navbar-panel absolute right-4 top-full w-full max-w-[250px] rounded-lg py-5 lg:static lg:block lg:w-full lg:max-w-full lg:px-4 lg:py-0 xl:px-6 ${
           showMenu ? '' : 'hidden'
         }`}>
         <ul className='blcok lg:flex 2xl:ml-20'>

--- a/themes/proxio/components/Team.js
+++ b/themes/proxio/components/Team.js
@@ -15,17 +15,17 @@ export const Team = () => {
             {/* <!-- ====== Team Section Start --> */}
             <section
                 id='team'
-                className='overflow-hidden pb-12 pt-20 lg:pb-[90px] lg:pt-[120px]'>
+                className='proxio-section overflow-hidden pb-12 pt-20 lg:pb-[90px] lg:pt-[120px]'>
                 <div className='container mx-auto wow fadeInUp' data-wow-delay='.2s'>
-                    <div className='flex flex-col md:flex-row -mx-4 justify-between'>
+                    <div className='flex flex-col items-center gap-10 md:flex-row md:items-stretch md:justify-between'>
                         {/* 左边肖像图 */}
-                        <div className='mx-6 mb-6 max-w-96 border-gray-200 dark:border-[#333333] dark:bg-dark-1 border rounded-2xl overflow-hidden'>
-                            <LazyImage alt={AUTHOR} src={PROXIO_ABOUT_PHOTO_URL} className='object-cover h-full' />
+                        <div className='proxio-card w-full max-w-[420px] overflow-hidden rounded-2xl border md:w-[42%] md:min-h-[520px]'>
+                            <LazyImage alt={AUTHOR} src={PROXIO_ABOUT_PHOTO_URL} className='h-full w-full object-cover' />
                         </div>
                         {/* 右侧文字说明 */}
-                        <div className='flex flex-col px-4 space-y-4 mx-auto justify-between max-w-[485px]'>
+                        <div className='flex flex-col space-y-4 justify-between max-w-[485px]'>
                             <div>
-                                <span className='px-3 py-0.5 mb-2 dark:bg-dark-1 rounded-2xl border border-gray-200 dark:border-[#333333] dark:text-white'>
+                                <span className='proxio-pill px-3 py-0.5 mb-2 rounded-2xl border'>
                                     {siteConfig('PROXIO_ABOUT_TITLE')}
                                 </span>
                             </div>
@@ -48,7 +48,7 @@ export const Team = () => {
                             <div className='mt-8 w-full flex justify-end py-2'>
                                 <SmartLink
                                     href={siteConfig('PROXIO_ABOUT_BUTTON_URL', '')}
-                                    className='px-4 py-2 rounded-3xl border dark:border-gray-200 border-[#333333] text-base font-medium text-dark hover:bg-gray-100 dark:text-white dark:hover:bg-white dark:hover:text-black duration-200'>
+                                    className='proxio-outline-button px-4 py-2 rounded-3xl border text-base font-medium duration-200'>
                                     {siteConfig('PROXIO_ABOUT_BUTTON_TEXT')}
                                     <i className="pl-4 fa-solid fa-arrow-right"></i>
                                 </SmartLink>

--- a/themes/proxio/components/Testimonials.js
+++ b/themes/proxio/components/Testimonials.js
@@ -41,14 +41,14 @@ export const Testimonials = () => {
       {/* <!-- ====== Testimonial Section Start --> */}
       <section
         id="testimonials"
-        className="overflow-hidden bg-gray-1 py-20 dark:bg-black md:py-[60px]"
+        className="proxio-section-muted overflow-hidden py-20 md:py-[60px]"
       >
         <div className="container mx-auto flex flex-col md:flex-row items-start gap-10">
           {/* 左侧标题和描述 */}
           <div className="flex flex-col space-y-8 w-full md:w-1/2 text-center md:text-left">
 
             <div>
-              <span className='px-3 py-0.5 rounded-2xl dark:bg-dark-1 border border-gray-200 dark:border-[#333333] dark:text-white'>
+              <span className='proxio-pill px-3 py-0.5 rounded-2xl border'>
                 {siteConfig('PROXIO_TESTIMONIALS_TITLE')}
               </span>
             </div>
@@ -62,7 +62,7 @@ export const Testimonials = () => {
             <div className='mt-8 w-full flex justify-start items-center'>
               <SmartLink
                 href={siteConfig('PROXIO_TESTIMONIALS_BUTTON_URL', '')}
-                className='px-4 py-2 rounded-3xl border dark:border-gray-200 border-[#333333] text-base font-medium text-dark hover:bg-gray-100 dark:text-white dark:hover:bg-white dark:hover:text-black duration-200'>
+                className='proxio-outline-button px-4 py-2 rounded-3xl border text-base font-medium duration-200'>
                 {siteConfig('PROXIO_TESTIMONIALS_BUTTON_TEXT')}
                 <i className="pl-4 fa-solid fa-arrow-right"></i>
               </SmartLink>
@@ -79,7 +79,7 @@ export const Testimonials = () => {
               {PROXIO_TESTIMONIALS_ITEMS?.map((item, index) => (
                 <div
                   key={index}
-                  className="mb-6 rounded-xl bg-white px-4 py-[30px] shadow-testimonial border dark:bg-[#0E0E0E] sm:px-[30px] dark:border-[#333333] "
+                  className="proxio-card mb-6 rounded-xl px-4 py-[30px] shadow-testimonial border sm:px-[30px]"
                 >
                   <p className="mb-6 text-base text-body-color dark:text-dark-6">
                     “{item.PROXIO_TESTIMONIALS_ITEM_TEXT}”
@@ -110,7 +110,7 @@ export const Testimonials = () => {
               {PROXIO_TESTIMONIALS_ITEMS?.map((item, index) => (
                 <div
                   key={`clone-${index}`}
-                  className="mb-6 rounded-xl bg-white px-4 py-[30px] shadow-testimonial border dark:bg-[#0E0E0E] sm:px-[30px] dark:border-[#333333] "
+                  className="proxio-card mb-6 rounded-xl px-4 py-[30px] shadow-testimonial border sm:px-[30px]"
                 >
                   <p className="mb-6 text-base text-body-color dark:text-dark-6">
                     “{item.PROXIO_TESTIMONIALS_ITEM_TEXT}”

--- a/themes/proxio/style.js
+++ b/themes/proxio/style.js
@@ -18,11 +18,6 @@ const Style = () => {
         background-color: black;
     }
 
-    #theme-proxio .bg-primary {
-        --tw-bg-opacity: 1;
-        background-color: #121212;
-    }
-
     @media (min-width: 540px) {
         #theme-proxio .container {
             max-width: 540px;
@@ -72,7 +67,7 @@ const Style = () => {
   }
 
 
-  .dark\:bg-dark:is(.dark *) {
+  #theme-proxio .dark\:bg-dark:is(.dark *) {
     background-color: black!important;
  }
 
@@ -263,6 +258,91 @@ const Style = () => {
 }
 
       ${themeConsoleStyle('proxio', CONFIG)}
+
+  #theme-proxio {
+    --proxio-surface-muted: #f9fafb;
+    --proxio-surface-dark: var(--proxio-color-bg-dark, #121212);
+    --proxio-card-dark: var(--proxio-color-card-dark, #181818);
+    --proxio-border-dark: var(--proxio-color-border-dark, #333333);
+  }
+
+  #theme-proxio .proxio-hero {
+    background-color: var(--proxio-surface-dark) !important;
+  }
+
+  #theme-proxio .proxio-navbar-panel {
+    background-color: transparent !important;
+    box-shadow: none !important;
+  }
+
+  @media (max-width: 959.98px) {
+    #theme-proxio .proxio-navbar-panel {
+      background-color: var(--proxio-color-card, #ffffff) !important;
+      border: 1px solid var(--proxio-color-border, #e5e7eb);
+      box-shadow: 0 10px 30px rgba(15, 23, 42, 0.12) !important;
+    }
+
+    .dark #theme-proxio .proxio-navbar-panel {
+      background-color: var(--proxio-card-dark) !important;
+      border-color: var(--proxio-border-dark);
+    }
+  }
+
+  #theme-proxio .proxio-section {
+    background-color: var(--proxio-color-bg, #ffffff) !important;
+  }
+
+  #theme-proxio .proxio-section-muted {
+    background-color: var(--proxio-surface-muted) !important;
+  }
+
+  .dark #theme-proxio .proxio-section,
+  .dark #theme-proxio .proxio-section-muted {
+    background-color: var(--proxio-surface-dark) !important;
+  }
+
+  #theme-proxio .proxio-card {
+    background-color: var(--proxio-color-card, #ffffff) !important;
+    border-color: var(--proxio-color-border, #e5e7eb) !important;
+  }
+
+  .dark #theme-proxio .proxio-card {
+    background-color: var(--proxio-card-dark) !important;
+    border-color: var(--proxio-border-dark) !important;
+  }
+
+  #theme-proxio .proxio-pill {
+    background-color: transparent !important;
+    border-color: var(--proxio-color-border, #e5e7eb) !important;
+    color: var(--proxio-color-text, #111827) !important;
+  }
+
+  .dark #theme-proxio .proxio-pill {
+    background-color: var(--proxio-card-dark) !important;
+    border-color: var(--proxio-border-dark) !important;
+    color: var(--proxio-color-text-dark, #f3f4f6) !important;
+  }
+
+  #theme-proxio .proxio-outline-button {
+    background-color: transparent !important;
+    border-color: var(--proxio-color-border, #333333) !important;
+    color: var(--proxio-color-text, #111827) !important;
+  }
+
+  #theme-proxio .proxio-outline-button:hover {
+    background-color: var(--proxio-color-text, #111827) !important;
+    color: var(--proxio-color-bg, #ffffff) !important;
+  }
+
+  .dark #theme-proxio .proxio-outline-button {
+    border-color: var(--proxio-border-dark) !important;
+    color: var(--proxio-color-text-dark, #f3f4f6) !important;
+  }
+
+  .dark #theme-proxio .proxio-outline-button:hover {
+    background-color: var(--proxio-color-text-dark, #f3f4f6) !important;
+    color: var(--proxio-surface-dark) !important;
+  }
   `}</style>
 }
 


### PR DESCRIPTION
## Summary
- restore Proxio primary color semantics after global theme-token migration
- keep desktop navigation transparent while preserving a mobile dropdown panel
- normalize Proxio dark-mode section/card colors and enlarge the author photo card

## Validation
- git diff --check origin/main...HEAD