### PR TITLE
feat: add OpenAI compatible AI chat proxy

### DIFF
--- a/components/DocsChat.js
+++ b/components/DocsChat.js
@@ -8,12 +8,20 @@ const makeMessage = (role, text) => ({
 })
 
 export default function DocsChat() {
-  const api = siteConfig('DOCS_CHAT_API')
-  const title = siteConfig('DOCS_CHAT_TITLE', 'AI 助手')
-  const welcome = siteConfig(
-    'DOCS_CHAT_WELCOME',
-    '你好，我是这个站点的 AI 助手。你可以问我站点内容相关问题。'
-  )
+  const aiChatApi = siteConfig('AI_CHAT_API')
+  const api = aiChatApi || siteConfig('DOCS_CHAT_API')
+  const title = aiChatApi
+    ? siteConfig('AI_CHAT_TITLE', 'AI 助手')
+    : siteConfig('DOCS_CHAT_TITLE', 'AI 助手')
+  const welcome = aiChatApi
+    ? siteConfig(
+        'AI_CHAT_WELCOME',
+        '你好，我是这个站点的 AI 助手。你可以问我站点内容相关问题。'
+      )
+    : siteConfig(
+        'DOCS_CHAT_WELCOME',
+        '你好，我是这个站点的 AI 助手。你可以问我站点内容相关问题。'
+      )
   const [open, setOpen] = useState(false)
   const [input, setInput] = useState('')
   const [loading, setLoading] = useState(false)

--- a/components/ExternalPlugins.js
+++ b/components/ExternalPlugins.js
@@ -124,6 +124,7 @@ const ExternalPlugin = props => {
   // 默认关闭NProgress
   const ENABLE_NPROGRSS = siteConfig('ENABLE_NPROGRSS', false)
   const COZE_BOT_ID = siteConfig('COZE_BOT_ID')
+  const AI_CHAT_API = siteConfig('AI_CHAT_API')
   const DOCS_CHAT_API = siteConfig('DOCS_CHAT_API')
   const HILLTOP_ADS_META_ID = siteConfig(
     'HILLTOP_ADS_META_ID',
@@ -271,7 +272,7 @@ const ExternalPlugin = props => {
       {ENABLE_NPROGRSS && <LoadingProgress />}
       {pluginsIdle && <AosAnimation />}
       {ANALYTICS_51LA_ID && ANALYTICS_51LA_CK && <LA51 />}
-      {DOCS_CHAT_API ? <DocsChat /> : COZE_BOT_ID && <Coze />}
+      {AI_CHAT_API || DOCS_CHAT_API ? <DocsChat /> : COZE_BOT_ID && <Coze />}
 
       {ANALYTICS_51LA_ID && ANALYTICS_51LA_CK && (
         <>

--- a/conf/ai.config.js
+++ b/conf/ai.config.js
@@ -28,6 +28,13 @@ module.exports = {
   // Chatbase 机器人 @see https://www.chatbase.co/
   CHATBASE_ID: process.env.NEXT_PUBLIC_CHATBASE_ID || null,
 
+  // OpenAI compatible AI chat proxy. Keep API keys on the server only.
+  AI_CHAT_API: process.env.NEXT_PUBLIC_AI_CHAT_API || '',
+  AI_CHAT_TITLE: process.env.NEXT_PUBLIC_AI_CHAT_TITLE || 'AI 助手',
+  AI_CHAT_WELCOME:
+    process.env.NEXT_PUBLIC_AI_CHAT_WELCOME ||
+    '你好，我是这个站点的 AI 助手。你可以问我站点内容相关问题。',
+
   // 自建 AI 助手服务端代理；为空时不显示
   DOCS_CHAT_API: process.env.NEXT_PUBLIC_DOCS_CHAT_API || '',
   DOCS_CHAT_TITLE: process.env.NEXT_PUBLIC_DOCS_CHAT_TITLE || 'AI 助手',

--- a/docs/user-guide/ARTICLE_INDEX.md
+++ b/docs/user-guide/ARTICLE_INDEX.md
@@ -91,6 +91,7 @@
 | 🧷 外部扩展 | `notion-next-plugin-music-player` | [plugins/music-player.md](./plugins/music-player.md) |
 | 🧷 外部扩展 | `notion-next-plugin-live2d` | [plugins/notion-next-plugin-live2d.md](./plugins/notion-next-plugin-live2d.md) |
 | 🧷 外部扩展 | `notion-next-algolia` | [config/algolia.md](./config/algolia.md) |
+| 🧷 外部扩展 | `notion-next-ai-chat` | [plugins/notion-next-ai-chat.md](./plugins/notion-next-ai-chat.md) |
 | 🧷 外部扩展 | `notion-next-coze` | [plugins/notion-next-coze.md](./plugins/notion-next-coze.md) |
 | 🧷 外部扩展 | `notion-next-chat-base` | [plugins/notion-next-chat-base.md](./plugins/notion-next-chat-base.md) |
 | 🧷 外部扩展 | `notion-next-facebook-chat-plugn` | [plugins/notion-next-facebook-chat-plugn.md](./plugins/notion-next-facebook-chat-plugn.md) |

--- a/docs/user-guide/changelog/latest.md
+++ b/docs/user-guide/changelog/latest.md
@@ -6,6 +6,8 @@
 
 本版本集中合入 `v4.10.8` 之后的社区修复、Notion 渲染兼容、主题移动端体验、依赖安全更新和 Docker 发布增强。多数站点只需要同步最新 `main` 并重新部署，不需要新增环境变量。
 
+- 新增 OpenAI 兼容 AI 助手代理，可通过 `AI_CHAT_*` 配置接入 DeepSeek 等兼容 `chat/completions` 的模型服务。
+
 ### Notion 数据与内容渲染
 
 - Notion Config 读取兼容新版 Notion 数据库块：配置库既可以来自 `collection_view`，也可以来自 `collection_view_page`。

--- a/docs/user-guide/plugins/notion-next-ai-chat.md
+++ b/docs/user-guide/plugins/notion-next-ai-chat.md
@@ -1,0 +1,92 @@
+# OpenAI 兼容 AI 助手
+
+NotionNext 内置了一个轻量 AI 聊天入口，可以接入 DeepSeek 或其它兼容 OpenAI `chat/completions` 格式的模型服务。页面前端只负责显示聊天窗口，真正的模型请求必须走服务端代理。
+
+## 为什么这样设计
+
+DeepSeek 提供的是模型 API，不是 Chatbase、Coze 那种完整网页浮窗 SDK。API Key 不能写进 `NEXT_PUBLIC_*`、Notion 配置表或前端代码，否则访问者可以在浏览器里看到密钥。
+
+因此推荐架构是：
+
+1. 站点前端配置 `NEXT_PUBLIC_AI_CHAT_API`，显示右下角 AI 助手。
+2. 服务端代理 `/api/ai-chat` 读取 `AI_CHAT_API_KEY`。
+3. 代理转发到 DeepSeek 或其它 OpenAI 兼容接口。
+
+## 前端配置
+
+在 Vercel、Cloudflare Pages、Netlify 或服务器环境变量中添加：
+
+```bash
+NEXT_PUBLIC_AI_CHAT_API=https://你的域名/api/ai-chat
+NEXT_PUBLIC_AI_CHAT_TITLE=AI 助手
+NEXT_PUBLIC_AI_CHAT_WELCOME=你好，我是本站 AI 助手。你可以问我文章、主题和部署问题。
+```
+
+也可以在 Notion 配置表中添加同名配置：
+
+| 配置              | 说明                                                      |
+| ----------------- | --------------------------------------------------------- |
+| `AI_CHAT_API`     | 聊天代理地址，例如 `https://blog.example.com/api/ai-chat` |
+| `AI_CHAT_TITLE`   | 右下角按钮和窗口标题                                      |
+| `AI_CHAT_WELCOME` | 打开窗口后的第一句欢迎语                                  |
+
+## DeepSeek 代理配置
+
+如果你使用 Cloudflare Pages Functions，可以直接使用仓库内置的 `functions/api/ai-chat.ts`。在部署平台的服务端环境变量中添加：
+
+```bash
+AI_CHAT_API_KEY=你的 DeepSeek API Key
+AI_CHAT_BASE_URL=https://api.deepseek.com
+AI_CHAT_MODEL=deepseek-v4-flash
+AI_CHAT_CORS_ORIGINS=https://你的博客域名
+AI_CHAT_MAX_TOKENS=1200
+AI_CHAT_TEMPERATURE=0.3
+```
+
+`AI_CHAT_CORS_ORIGINS` 可以填写多个域名，用英文逗号分隔：
+
+```bash
+AI_CHAT_CORS_ORIGINS=https://blog.example.com,https://docs.example.com
+```
+
+本地或临时调试可以先写 `*`，正式站点建议改成自己的域名。
+
+## 使用其它 OpenAI 兼容服务
+
+只要服务支持 `POST /chat/completions`，通常只需要替换：
+
+```bash
+AI_CHAT_BASE_URL=https://你的服务商 base url
+AI_CHAT_MODEL=你的模型名
+AI_CHAT_API_KEY=你的服务端密钥
+```
+
+不要改前端组件，也不要把密钥写进 Notion。
+
+## 自定义回答范围
+
+可以用服务端变量设置系统提示词：
+
+```bash
+AI_CHAT_SYSTEM_PROMPT=你是本站 AI 助手，只回答本站文章、主题、配置和部署相关问题。回答要简洁，不确定时说明限制。
+```
+
+建议写入：
+
+- 站点定位和读者人群
+- 重点栏目或文章入口
+- 不希望 AI 回答的范围
+- 需要优先提示的部署、配置或联系信息
+
+不要写入后台地址、私密页面、未公开资料或任何密钥。
+
+## 和 Coze、Chatbase、Dify 怎么选
+
+| 方案                | 适合场景                                             |
+| ------------------- | ---------------------------------------------------- |
+| OpenAI 兼容 AI 助手 | 想自己控制模型、Key、系统提示词，或直接使用 DeepSeek |
+| Coze                | 想使用可视化工作流、插件和平台知识库                 |
+| Chatbase            | 想用第三方平台自动抓取网站内容并生成聊天机器人       |
+| Dify                | 已经自建 Dify 应用，希望直接嵌入 Dify 聊天窗口       |
+
+DeepSeek API 本身不会自动读取你的 Notion 数据库或站点文章。如果需要“基于全站文章回答”，后续还需要单独维护知识库或 RAG 流程。

--- a/docs/user-guide/plugins/overview.md
+++ b/docs/user-guide/plugins/overview.md
@@ -16,6 +16,7 @@ NotionNext 预支持了一些第三方功能脚本插件。除了评论插件，
 | 音乐播放器 | APlayer / Meting 音乐播放组件 | [音乐播放器](./music-player.md) |
 | Live2D 宠物 | 页面 Live2D 挂件模型 | [Live2D 宠物插件](./notion-next-plugin-live2d.md) |
 | Algolia | 全文搜索索引 | [Algolia 搜索](../config/algolia.md) |
+| OpenAI 兼容 AI 助手 | DeepSeek / OpenAI 兼容模型聊天代理 | [OpenAI 兼容 AI 助手](./notion-next-ai-chat.md) |
 | Google AdSense | 广告收益与文章内广告位 | [Google 广告营收插件](./notion-next-google-adsense.md) |
 | Coze | AI 聊天机器人 | [Coze AI 聊天机器人](./notion-next-coze.md) |
 | Chatbase | AI 聊天机器人 | [Chatbase AI 聊天机器人](./notion-next-chat-base.md) |

--- a/docs/user-guide/reference/features.md
+++ b/docs/user-guide/reference/features.md
@@ -90,6 +90,7 @@
 | `MUSIC_PLAYER_*` | APlayer / Meting，见 [plugins/music-player.md](../plugins/music-player.md) |
 | `WIDGET_PET` / `WIDGET_PET_LINK` | Live2D 宠物 |
 | `CHATBASE_ID` | Chatbase |
+| `AI_CHAT_*` | OpenAI 兼容 AI 助手，支持 DeepSeek 等模型服务 |
 | `WEB_WHIZ_*` | Webwhiz 机器人 |
 | `DIFY_CHATBOT_*` | Dify 嵌入 |
 | `FACEBOOK_PAGE_*` | Facebook Page / Messenger |

--- a/functions/api/ai-chat.ts
+++ b/functions/api/ai-chat.ts
@@ -1,0 +1,219 @@
+type Env = {
+  AI_CHAT_API_KEY?: string
+  AI_CHAT_BASE_URL?: string
+  AI_CHAT_MODEL?: string
+  AI_CHAT_SYSTEM_PROMPT?: string
+  AI_CHAT_CORS_ORIGINS?: string
+  AI_CHAT_MAX_TOKENS?: string
+  AI_CHAT_TEMPERATURE?: string
+}
+
+type PagesContext = {
+  request: Request
+  env: Env
+}
+
+type UIMessagePart = {
+  type?: string
+  text?: string
+}
+
+type UIMessage = {
+  role?: string
+  content?: string
+  parts?: UIMessagePart[]
+}
+
+type OpenAIMessage = {
+  role: 'system' | 'user' | 'assistant'
+  content: string
+}
+
+type ChatRequestBody = {
+  messages?: UIMessage[]
+}
+
+const DEFAULT_BASE_URL = 'https://api.deepseek.com'
+const DEFAULT_MODEL = 'deepseek-v4-flash'
+const DEFAULT_MAX_TOKENS = 1200
+const DEFAULT_TEMPERATURE = 0.3
+const MAX_REQUEST_BYTES = 20_000
+const MAX_MESSAGES = 8
+const MAX_USER_TEXT_CHARS = 1000
+const DEFAULT_SYSTEM_PROMPT =
+  '你是站点 AI 助手。请优先回答和本站内容、文章、主题、配置、部署、评论、插件相关的问题。回答要简洁、准确；不确定时说明限制，不要编造。'
+
+const json = (body: unknown, init: ResponseInit = {}) =>
+  new Response(JSON.stringify(body), {
+    ...init,
+    headers: {
+      'content-type': 'application/json; charset=utf-8',
+      ...init.headers
+    }
+  })
+
+const corsHeaders = (request: Request, env: Env) => {
+  const origin = request.headers.get('origin')
+  const allowed = env.AI_CHAT_CORS_ORIGINS?.split(',')
+    .map(item => item.trim())
+    .filter(Boolean)
+
+  if (!origin || !allowed?.length) {
+    return {}
+  }
+
+  if (!allowed.includes('*') && !allowed.includes(origin)) {
+    return {}
+  }
+
+  return {
+    'access-control-allow-origin': allowed.includes('*') ? '*' : origin,
+    'access-control-allow-methods': 'POST, OPTIONS',
+    'access-control-allow-headers': 'content-type'
+  }
+}
+
+const numberOrDefault = (
+  value: string | undefined,
+  fallback: number,
+  min = 0
+) => {
+  const parsed = Number(value)
+  return Number.isFinite(parsed) && parsed >= min ? parsed : fallback
+}
+
+const textFromMessage = (message?: UIMessage) => {
+  if (typeof message?.content === 'string') {
+    return message.content
+  }
+
+  return (
+    message?.parts
+      ?.map(part => (part.type === 'text' ? part.text || '' : ''))
+      .join('') || ''
+  )
+}
+
+const normalizeRole = (role: string | undefined): OpenAIMessage['role'] =>
+  role === 'assistant' ? 'assistant' : 'user'
+
+const toOpenAIMessages = (messages: UIMessage[], env: Env): OpenAIMessage[] => {
+  const chatMessages = messages
+    .slice(-MAX_MESSAGES)
+    .map(message => ({
+      role: normalizeRole(message.role),
+      content: textFromMessage(message).slice(0, MAX_USER_TEXT_CHARS)
+    }))
+    .filter(message => message.content.trim())
+
+  return [
+    {
+      role: 'system',
+      content: env.AI_CHAT_SYSTEM_PROMPT || DEFAULT_SYSTEM_PROMPT
+    },
+    ...chatMessages
+  ]
+}
+
+const lastUserText = (messages: UIMessage[]) =>
+  textFromMessage(
+    [...messages].reverse().find(message => message.role === 'user')
+  )
+
+const errorMessage = (error: unknown) => {
+  const message = error instanceof Error ? error.message : String(error)
+
+  if (/api key|permission|auth|credential|401|403/i.test(message)) {
+    return 'AI model authentication failed.'
+  }
+
+  if (/quota|rate limit|429/i.test(message)) {
+    return 'AI model quota or rate limit reached.'
+  }
+
+  if (/timeout|abort|network|fetch/i.test(message)) {
+    return 'AI model network request failed.'
+  }
+
+  return 'AI assistant request failed.'
+}
+
+const completionUrl = (baseUrl: string) =>
+  `${baseUrl.replace(/\/$/, '')}/chat/completions`
+
+export const onRequestOptions = ({ request, env }: PagesContext) =>
+  new Response(null, {
+    status: 204,
+    headers: corsHeaders(request, env)
+  })
+
+export const onRequestPost = async ({ request, env }: PagesContext) => {
+  const headers = corsHeaders(request, env)
+  const contentLength = Number(request.headers.get('content-length') || 0)
+
+  if (contentLength > MAX_REQUEST_BYTES) {
+    return json({ error: 'Request is too large.' }, { status: 413, headers })
+  }
+
+  if (!env.AI_CHAT_API_KEY) {
+    return json(
+      { error: 'Missing AI_CHAT_API_KEY in server settings.' },
+      { status: 500, headers }
+    )
+  }
+
+  const body = (await request.json()) as ChatRequestBody
+  const messages = Array.isArray(body.messages) ? body.messages : []
+
+  if (lastUserText(messages).length > MAX_USER_TEXT_CHARS) {
+    return json({ error: 'Question is too long.' }, { status: 413, headers })
+  }
+
+  try {
+    const response = await fetch(
+      completionUrl(env.AI_CHAT_BASE_URL || DEFAULT_BASE_URL),
+      {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${env.AI_CHAT_API_KEY}`,
+          'content-type': 'application/json'
+        },
+        body: JSON.stringify({
+          model: env.AI_CHAT_MODEL || DEFAULT_MODEL,
+          messages: toOpenAIMessages(messages, env),
+          max_tokens: numberOrDefault(
+            env.AI_CHAT_MAX_TOKENS,
+            DEFAULT_MAX_TOKENS,
+            1
+          ),
+          temperature: numberOrDefault(
+            env.AI_CHAT_TEMPERATURE,
+            DEFAULT_TEMPERATURE
+          ),
+          stream: false
+        })
+      }
+    )
+    const data = (await response.json()) as {
+      choices?: Array<{ message?: { content?: string } }>
+      error?: { message?: string }
+    }
+
+    if (!response.ok) {
+      throw new Error(
+        data.error?.message || `AI provider returned ${response.status}`
+      )
+    }
+
+    return json(
+      { text: data.choices?.[0]?.message?.content || '' },
+      { headers }
+    )
+  } catch (error) {
+    console.error(error)
+    return json({ error: errorMessage(error) }, { status: 502, headers })
+  }
+}
+
+export const onRequest = () =>
+  json({ error: 'Method not allowed.' }, { status: 405 })


### PR DESCRIPTION
## Summary

Closes #3197.

This implements the DeepSeek request as an OpenAI-compatible AI chat proxy instead of a DeepSeek-only browser plugin. DeepSeek provides a model API rather than a stable web widget SDK, so the safe integration path is:

- keep API keys on the server
- expose only a public chat proxy URL to the frontend
- support DeepSeek by default while allowing other OpenAI-compatible providers

## Changes

- add `functions/api/ai-chat.ts` for OpenAI-compatible `/chat/completions` providers
- add `AI_CHAT_*` frontend config keys while preserving the existing `DOCS_CHAT_*` path
- update `DocsChat` and `ExternalPlugins` so `AI_CHAT_API` enables the existing chat widget
- add a user guide for DeepSeek / OpenAI-compatible setup
- update plugin overview, feature reference, article index, and changelog

## Verification

- `yarn install --frozen-lockfile`
- `node --check components/DocsChat.js`
- `node --check components/ExternalPlugins.js`
- `./node_modules/.bin/tsc.cmd --noEmit --pretty false`
- `yarn lint --file components/DocsChat.js --file components/ExternalPlugins.js`
  - passes with an existing `react-hooks/exhaustive-deps` warning in `ExternalPlugins.js`
- `git diff --check`
- `yarn docs:site:build`
  - passes with existing VitePress highlighter/chunk-size warnings