### PR TITLE
fix: support callouts without icons

### DIFF
--- a/__tests__/lib/db/notion/getPostBlocks.test.js
+++ b/__tests__/lib/db/notion/getPostBlocks.test.js
@@ -198,6 +198,57 @@ describe('formatNotionBlock', () => {
     expect(formatted['hosted-video'].value.type).toBe('video')
   })
 
+  it('marks newer Notion callouts with removed icons', () => {
+    const formatted = formatNotionBlock({
+      callout: {
+        value: {
+          id: 'callout',
+          type: 'callout',
+          format: {
+            page_icon: '💡'
+          },
+          callout: {
+            icon: null,
+            color: 'gray_background',
+            rich_text: [
+              {
+                plain_text: 'No icon',
+                annotations: { bold: true }
+              }
+            ]
+          }
+        }
+      }
+    })
+
+    expect(formatted.callout.value.format.page_icon).toBeUndefined()
+    expect(formatted.callout.value.format.callout_no_icon).toBe(true)
+    expect(formatted.callout.value.format.block_color).toBe('gray_background')
+    expect(formatted.callout.value.properties.title).toEqual([
+      ['No icon', [['b']]]
+    ])
+  })
+
+  it('maps newer Notion callout emoji icons to legacy renderer fields', () => {
+    const formatted = formatNotionBlock({
+      callout: {
+        value: {
+          id: 'callout',
+          type: 'callout',
+          callout: {
+            icon: {
+              type: 'emoji',
+              emoji: '✅'
+            }
+          }
+        }
+      }
+    })
+
+    expect(formatted.callout.value.format.page_icon).toBe('✅')
+    expect(formatted.callout.value.format.callout_no_icon).toBeUndefined()
+  })
+
   it('rewrites newer Notion pdf file URLs to signed URLs', () => {
     const formatted = formatNotionBlock({
       pdf: {

--- a/components/NotionPage.js
+++ b/components/NotionPage.js
@@ -7,7 +7,11 @@ import mediumZoom from '@fisch0920/medium-zoom'
 import 'katex/dist/katex.min.css'
 import dynamic from 'next/dynamic'
 import { useEffect, useRef } from 'react'
-import { NotionRenderer } from 'react-notion-x'
+import {
+  NotionRenderer,
+  PageIcon,
+  Text as NotionRendererText
+} from 'react-notion-x'
 import OriginalityProof from './OriginalityProof'
 
 /**
@@ -128,6 +132,7 @@ const NotionPage = ({ post, className }) => {
           Modal,
           Pdf,
           Quote: NotionQuote,
+          Callout: NotionCallout,
           Tweet
         }}
       />
@@ -308,6 +313,29 @@ const NotionQuote = ({ block, children }) => {
       {title && <NotionText value={title} />}
       {children}
     </blockquote>
+  )
+}
+
+const NotionCallout = ({ block, className, children }) => {
+  const blockColor = block?.format?.block_color
+  const hasIcon = Boolean(block?.format?.page_icon)
+  const classNames = [
+    'notion-callout',
+    blockColor ? `notion-${blockColor}_co` : '',
+    hasIcon ? '' : 'notion-callout-no-icon',
+    className || ''
+  ].filter(Boolean).join(' ')
+
+  return (
+    <div className={classNames}>
+      {hasIcon && <PageIcon block={block} hideDefaultIcon />}
+      <div
+        className='notion-callout-text'
+        style={hasIcon ? undefined : { marginLeft: 0 }}>
+        <NotionRendererText value={block?.properties?.title} block={block} />
+        {children}
+      </div>
+    </div>
   )
 }
 

--- a/lib/db/notion/getPostBlocks.js
+++ b/lib/db/notion/getPostBlocks.js
@@ -342,6 +342,7 @@ export function formatNotionBlock(block) {
 
     sanitizeBlockUrls(b?.value)
     normalizeExternalMediaBlock(b?.value)
+    normalizeCalloutBlock(b?.value)
 
     if (b?.value?.type === 'sync_block') {
       const childBlockIds = []
@@ -411,6 +412,65 @@ export function formatNotionBlock(block) {
   }
 
   return clonedBlock
+}
+
+function normalizeCalloutBlock(blockValue) {
+  if (blockValue?.type !== 'callout') return
+
+  const callout = blockValue.callout
+  if (!callout || typeof callout !== 'object') return
+
+  blockValue.format = blockValue.format || {}
+
+  if (callout.color && !blockValue.format.block_color) {
+    blockValue.format.block_color = callout.color
+  }
+
+  if (!blockValue.properties?.title && Array.isArray(callout.rich_text)) {
+    blockValue.properties = blockValue.properties || {}
+    blockValue.properties.title = normalizeRichText(callout.rich_text)
+  }
+
+  const icon = normalizeCalloutIcon(callout.icon)
+  if (icon === null) {
+    delete blockValue.format.page_icon
+    blockValue.format.callout_no_icon = true
+  } else if (icon) {
+    blockValue.format.page_icon = icon
+    delete blockValue.format.callout_no_icon
+  }
+}
+
+function normalizeCalloutIcon(icon) {
+  if (icon === null) return null
+  if (!icon || typeof icon !== 'object') return undefined
+
+  if (icon.type === 'emoji') return icon.emoji || null
+  if (icon.type === 'external') return icon.external?.url || null
+  if (icon.type === 'file') return icon.file?.url || null
+  if (icon.type === 'custom_emoji') return icon.custom_emoji?.url || null
+  if (icon.type === 'native_icon') return icon.native_icon?.name || null
+
+  return undefined
+}
+
+function normalizeRichText(richText) {
+  return richText
+    .map(item => {
+      const text = item?.plain_text ?? item?.text?.content ?? ''
+      if (!text) return null
+
+      const formats = []
+      const annotations = item.annotations || {}
+      if (annotations.bold) formats.push(['b'])
+      if (annotations.italic) formats.push(['i'])
+      if (annotations.strikethrough) formats.push(['s'])
+      if (annotations.code) formats.push(['c'])
+      if (item.href) formats.push(['a', item.href])
+
+      return formats.length ? [text, formats] : [text]
+    })
+    .filter(Boolean)
 }
 
 function replaceContentReference(blockMap, oldId, newIds) {


### PR DESCRIPTION
## Summary
- Normalize newer Notion callout payloads for react-notion-x, including `icon: null`, color, and rich text.
- Override callout rendering so blocks without icons do not keep the left icon gap.
- Add regression coverage for removed callout icons and emoji callout icons.

Fixes #3022

## Test
- `yarn test --runTestsByPath __tests__/lib/db/notion/getPostBlocks.test.js --runInBand --env=node`